### PR TITLE
fix array examples

### DIFF
--- a/examples/compare_arrays_200000.cairo
+++ b/examples/compare_arrays_200000.cairo
@@ -64,8 +64,8 @@ fn fill_array(
 fn main() {
     let array_length = 200000;
 
-    let mut array_a = ArrayTrait::<felt252>::new();
-    let mut array_b = ArrayTrait::<felt252>::new();
+    let mut array_a = Default::default();
+    let mut array_b = Default::default();
 
     fill_array(ref array_a, 7, 3, array_length, 0);
     fill_array(ref array_b, 7, 3, array_length, 0);

--- a/examples/example_array.cairo
+++ b/examples/example_array.cairo
@@ -2,7 +2,7 @@ use array::Array;
 use array::ArrayTrait;
 
 fn main() -> (u32, u32, u32, u32, u32) {
-    let mut data: Array<u32> = ArrayTrait::new();
+    let mut data: Array<u32> = Default::default();
     data.append(1_u32);
     data.append(2_u32);
     data.append(3_u32);

--- a/examples/felt_div.cairo
+++ b/examples/felt_div.cairo
@@ -13,7 +13,7 @@ fn main() {
 
 fn felt_to_nonzero(value: felt252) -> NonZero<felt252> {
     match felt252_is_zero(value) {
-        IsZeroResult::Zero(()) => panic(ArrayTrait::new()),
+        IsZeroResult::Zero(()) => panic(Default::default()),
         IsZeroResult::NonZero(x) => x,
     }
 }

--- a/examples/index_array.cairo
+++ b/examples/index_array.cairo
@@ -2,7 +2,7 @@ use array::Array;
 use array::ArrayTrait;
 
 fn main() -> u8 {
-    let mut data: Array<u8> = ArrayTrait::new();
+    let mut data: Array<u8> = Default::default();
     data.append(4_u8);
     data.append(5_u8);
     data.append(4_u8);


### PR DESCRIPTION
# Fix array examples

## Description

ArrayTrait::new() was removed from the cairo 1 compiler and we should use Default::default() instead.
This PR updates the examples.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
