### PR TITLE
Fix tail recursion.

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -190,6 +190,7 @@ where
     'this: 'ctx,
 {
     pub(crate) module: &'this Module<'ctx>,
+    pub(crate) init_block: &'this BlockRef<'ctx, 'this>,
 
     pub(crate) region: &'this Region<'ctx>,
     pub(crate) blocks_arena: &'this Bump,
@@ -207,6 +208,15 @@ where
         self.results
             .into_iter()
             .map(|x| x.into_iter().map(|x| x.into_inner().unwrap()).collect())
+    }
+
+    /// Return the initialization block.
+    ///
+    /// The init block is used for `llvm.alloca` instructions. It is guaranteed to not be executed
+    /// multiple times on tail-recursive functions. This property allows generating tail-recursive
+    /// functions that do not grow the stack.
+    pub fn init_block(&self) -> &Block<'ctx> {
+        self.init_block
     }
 
     /// Inserts a new block after all the current libfunc's blocks.

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -133,7 +133,7 @@ where
         IntegerAttribute::new(1, IntegerType::new(context, 64).into()).into(),
         location,
     ));
-    let op5 = entry.append_operation(
+    let op5 = helper.init_block().append_operation(
         OperationBuilder::new("llvm.alloca", location)
             .add_attributes(&[(
                 Identifier::new(context, "alignment"),
@@ -220,7 +220,7 @@ where
         IntegerAttribute::new(1, IntegerType::new(context, 64).into()).into(),
         location,
     ));
-    let op1 = entry.append_operation(
+    let op1 = helper.init_block().append_operation(
         OperationBuilder::new("llvm.alloca", location)
             .add_attributes(&[(
                 Identifier::new(context, "alignment"),


### PR DESCRIPTION
# Fix tail recursion

## Description

Currently, tail recursion avoids calling the function and therefore the frame that would reside on the stack. However, there are some operations, such as `llvm.alloca` that allocate space on the stack. The compiler is not smart enough to understand when those go out of scope and reuse the space and instead allocates more space, which defeats the whole purpose of tail recursive functions.

This PR fixes this by adding making a block accessible to the libfunc builders which is guaranteed to be executed only once for tail recursive functions. All `llvm.alloca` instructions have been moved there.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
