### PR TITLE
Fix `enum` type.

### DIFF
--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -445,6 +445,13 @@ where
             Layout::from_size_align(0, 1).unwrap(),
         ));
 
+    let filling_ty = llvm::r#type::array(
+        IntegerType::new(context, 8).into(),
+        (tag_layout.extend(variant_layout).unwrap().1 - tag_layout.size())
+            .try_into()
+            .unwrap(),
+    );
+
     let total_len = variant_tys
         .iter()
         .map(|(_, layout)| tag_layout.extend(*layout).unwrap().0.size())
@@ -459,7 +466,7 @@ where
 
     Ok(llvm::r#type::r#struct(
         context,
-        &[tag_ty, variant_ty, padding_ty],
+        &[tag_ty, filling_ty, variant_ty, padding_ty],
         false,
     ))
 }


### PR DESCRIPTION
# Fix `enum` type

## Description

A cairo enum like the one below will generate the following MLIR layouts for each variant:

```cairo
enum MyEnum {
    A: u8,
    B: u64,
}
```

| Variant | Align | Size | Aligned payload offset |
| ------- | ----- | ---- | ---------------------- |
| `MyEnum::A` | 1 | 1 | 1 |
| `MyEnum::B` | 8 | 8 | 8 |

This is as expected. Now, to force MLIR to respect alignments, the `enum` will use the variant with the largest align as its default payload; that is, `MyEnum::B`. This leaves the following layout (including padding):

| Offset | Type | Description |
| ------ | ---- | ----------- |
| 0 | `u8` | Enum discriminant. |
| 1 | `[u8; 7]` | Padding. |
| 8 | `u64` | Payload. |

For reference, `MyEnum::A` would have the following layout:

| Offset | Type | Description |
| ------ | ---- | ----------- |
| 0 | `u8` | Enum discriminant. |
| 1 | `u8` | Payload. |
| 1 | `[u8; 14]` | Padding. |

Note how `MyEnum::A`'s payload is within the default variant's (`MyEnum::B`) padding.

Now, since the padding between the discriminant and the payload wasn't explicitly declared, the compiler (LLVM) assumed there was no data where the padding is and caused a value of `MyEnum::A` to read an uninitialized/garbage value.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
