### PR TITLE
Implement de/serialization for values.

### DIFF
--- a/src/jit_runner.rs
+++ b/src/jit_runner.rs
@@ -99,6 +99,8 @@ where
                 ty,
             ))
             .unwrap();
+
+        // TODO: Drop if necessary (ex. arrays).
     }
 
     Ok(return_seq.end().unwrap())

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -276,7 +276,11 @@ mod test {
     use serde_json::json;
 
     fn error_value(n: u128) -> serde_json::Value {
-        json!([(), [1, [[], [n]]]])
+        let mut bytes = [0u8; 32];
+        bytes[..16].copy_from_slice(&n.to_le_bytes());
+
+        let data = unsafe { std::mem::transmute_copy::<_, [u32; 8]>(&bytes) };
+        json!([(), [1, [[], [data]]]])
     }
 
     #[test]

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -279,6 +279,11 @@ mod test {
         let mut bytes = [0u8; 32];
         bytes[..16].copy_from_slice(&n.to_le_bytes());
 
+        // The following transmute is safe because:
+        //   - It transmutes between a slice of `Copy`.
+        //   - Each element is a primitive which is valid no matter its underlying data.
+        //   - The slices have the same size.
+        //   - Their alignment is respected by using `transmute_copy()`.
         let data = unsafe { std::mem::transmute_copy::<_, [u32; 8]>(&bytes) };
         json!([(), [1, [[], [data]]]])
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -209,10 +209,6 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
     where
         D: serde::Deserializer<'de>,
     {
-        // let ptr = self
-        //     .arena
-        //     .alloc_layout(self.info.layout(self.registry))
-        //     .cast::<()>();
         unsafe {
             match self.info {
                 CoreTypeConcrete::Array(info) => {

--- a/src/values.rs
+++ b/src/values.rs
@@ -213,54 +213,60 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
         //     .arena
         //     .alloc_layout(self.info.layout(self.registry))
         //     .cast::<()>();
-        Ok(match self.info {
-            CoreTypeConcrete::Array(info) => unsafe {
-                self::array::deserialize(deserializer, self.arena, self.registry, info)?
-            },
-            CoreTypeConcrete::Bitwise(_) => todo!(),
-            CoreTypeConcrete::Box(_) => todo!(),
-            CoreTypeConcrete::EcOp(_) => todo!(),
-            CoreTypeConcrete::EcPoint(_) => todo!(),
-            CoreTypeConcrete::EcState(_) => todo!(),
-            CoreTypeConcrete::Felt252(info) => unsafe {
-                self::felt252::deserialize(deserializer, self.arena, self.registry, info)?
-            },
-            CoreTypeConcrete::GasBuiltin(info) => unsafe {
-                self::gas_builtin::deserialize(deserializer, self.arena, self.registry, info)?
-            },
-            CoreTypeConcrete::BuiltinCosts(_) => todo!(),
-            CoreTypeConcrete::Uint8(info) => {
-                unsafe { self::uint8::deserialize(deserializer, self.arena, self.registry, info) }?
+        unsafe {
+            match self.info {
+                CoreTypeConcrete::Array(info) => {
+                    self::array::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Bitwise(_) => todo!(),
+                CoreTypeConcrete::Box(_) => todo!(),
+                CoreTypeConcrete::EcOp(_) => todo!(),
+                CoreTypeConcrete::EcPoint(_) => todo!(),
+                CoreTypeConcrete::EcState(_) => todo!(),
+                CoreTypeConcrete::Felt252(info) => {
+                    self::felt252::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::GasBuiltin(info) => {
+                    self::gas_builtin::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::BuiltinCosts(_) => todo!(),
+                CoreTypeConcrete::Uint8(info) => {
+                    self::uint8::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Uint16(info) => {
+                    self::uint16::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Uint32(info) => {
+                    self::uint32::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Uint64(info) => {
+                    self::uint64::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Uint128(_) => todo!(),
+                CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
+                CoreTypeConcrete::NonZero(_) => todo!(),
+                CoreTypeConcrete::Nullable(_) => todo!(),
+                CoreTypeConcrete::RangeCheck(info) => {
+                    self::range_check::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Uninitialized(_) => todo!(),
+                CoreTypeConcrete::Enum(info) => {
+                    self::r#enum::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Struct(info) => {
+                    self::r#struct::deserialize(deserializer, self.arena, self.registry, info)
+                }
+                CoreTypeConcrete::Felt252Dict(_) => todo!(),
+                CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
+                CoreTypeConcrete::SquashedFelt252Dict(_) => todo!(),
+                CoreTypeConcrete::Pedersen(_) => todo!(),
+                CoreTypeConcrete::Poseidon(_) => todo!(),
+                CoreTypeConcrete::Span(_) => todo!(),
+                CoreTypeConcrete::StarkNet(_) => todo!(),
+                CoreTypeConcrete::SegmentArena(_) => todo!(),
+                CoreTypeConcrete::Snapshot(_) => todo!(),
             }
-            CoreTypeConcrete::Uint16(info) => {
-                unsafe { self::uint16::deserialize(deserializer, self.arena, self.registry, info) }?
-            }
-            CoreTypeConcrete::Uint32(info) => {
-                unsafe { self::uint32::deserialize(deserializer, self.arena, self.registry, info) }?
-            }
-            CoreTypeConcrete::Uint64(info) => {
-                unsafe { self::uint64::deserialize(deserializer, self.arena, self.registry, info) }?
-            }
-            CoreTypeConcrete::Uint128(_) => todo!(),
-            CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
-            CoreTypeConcrete::NonZero(_) => todo!(),
-            CoreTypeConcrete::Nullable(_) => todo!(),
-            CoreTypeConcrete::RangeCheck(info) => unsafe {
-                self::range_check::deserialize(deserializer, self.arena, self.registry, info)?
-            },
-            CoreTypeConcrete::Uninitialized(_) => todo!(),
-            CoreTypeConcrete::Enum(_) => todo!(),
-            CoreTypeConcrete::Struct(_) => todo!(),
-            CoreTypeConcrete::Felt252Dict(_) => todo!(),
-            CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
-            CoreTypeConcrete::SquashedFelt252Dict(_) => todo!(),
-            CoreTypeConcrete::Pedersen(_) => todo!(),
-            CoreTypeConcrete::Poseidon(_) => todo!(),
-            CoreTypeConcrete::Span(_) => todo!(),
-            CoreTypeConcrete::StarkNet(_) => todo!(),
-            CoreTypeConcrete::SegmentArena(_) => todo!(),
-            CoreTypeConcrete::Snapshot(_) => todo!(),
-        })
+        }
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -209,13 +209,13 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
     where
         D: serde::Deserializer<'de>,
     {
-        let ptr = self
-            .arena
-            .alloc_layout(self.info.layout(self.registry))
-            .cast::<()>();
-        match self.info {
+        // let ptr = self
+        //     .arena
+        //     .alloc_layout(self.info.layout(self.registry))
+        //     .cast::<()>();
+        Ok(match self.info {
             CoreTypeConcrete::Array(info) => unsafe {
-                self::array::deserialize(deserializer, self.registry, ptr, info)?
+                self::array::deserialize(deserializer, self.arena, self.registry, info)?
             },
             CoreTypeConcrete::Bitwise(_) => todo!(),
             CoreTypeConcrete::Box(_) => todo!(),
@@ -223,30 +223,37 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
             CoreTypeConcrete::EcPoint(_) => todo!(),
             CoreTypeConcrete::EcState(_) => todo!(),
             CoreTypeConcrete::Felt252(info) => unsafe {
-                self::felt252::deserialize(deserializer, self.registry, ptr, info)?
+                // self::felt252::deserialize(deserializer, self.registry, ptr, info)?
+                todo!()
             },
             CoreTypeConcrete::GasBuiltin(info) => unsafe {
-                self::gas_builtin::deserialize(deserializer, self.registry, ptr, info)?
+                // self::gas_builtin::deserialize(deserializer, self.registry, ptr, info)?
+                todo!()
             },
             CoreTypeConcrete::BuiltinCosts(_) => todo!(),
             CoreTypeConcrete::Uint8(info) => {
-                unsafe { self::uint8::deserialize(deserializer, self.registry, ptr, info) }?
+                // unsafe { self::uint8::deserialize(deserializer, self.registry, ptr, info) }?
+                todo!()
             }
             CoreTypeConcrete::Uint16(info) => {
-                unsafe { self::uint16::deserialize(deserializer, self.registry, ptr, info) }?
+                // unsafe { self::uint16::deserialize(deserializer, self.registry, ptr, info) }?
+                todo!()
             }
             CoreTypeConcrete::Uint32(info) => {
-                unsafe { self::uint32::deserialize(deserializer, self.registry, ptr, info) }?
+                // unsafe { self::uint32::deserialize(deserializer, self.registry, ptr, info) }?
+                todo!()
             }
             CoreTypeConcrete::Uint64(info) => {
-                unsafe { self::uint64::deserialize(deserializer, self.registry, ptr, info) }?
+                // unsafe { self::uint64::deserialize(deserializer, self.registry, ptr, info) }?
+                todo!()
             }
             CoreTypeConcrete::Uint128(_) => todo!(),
             CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
             CoreTypeConcrete::NonZero(_) => todo!(),
             CoreTypeConcrete::Nullable(_) => todo!(),
             CoreTypeConcrete::RangeCheck(info) => unsafe {
-                self::range_check::deserialize(deserializer, self.registry, ptr, info)?
+                // self::range_check::deserialize(deserializer, self.registry, ptr, info)?
+                todo!()
             },
             CoreTypeConcrete::Uninitialized(_) => todo!(),
             CoreTypeConcrete::Enum(_) => todo!(),
@@ -260,9 +267,7 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
             CoreTypeConcrete::StarkNet(_) => todo!(),
             CoreTypeConcrete::SegmentArena(_) => todo!(),
             CoreTypeConcrete::Snapshot(_) => todo!(),
-        }
-
-        Ok(ptr)
+        })
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -223,37 +223,30 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
             CoreTypeConcrete::EcPoint(_) => todo!(),
             CoreTypeConcrete::EcState(_) => todo!(),
             CoreTypeConcrete::Felt252(info) => unsafe {
-                // self::felt252::deserialize(deserializer, self.registry, ptr, info)?
-                todo!()
+                self::felt252::deserialize(deserializer, self.arena, self.registry, info)?
             },
             CoreTypeConcrete::GasBuiltin(info) => unsafe {
-                // self::gas_builtin::deserialize(deserializer, self.registry, ptr, info)?
-                todo!()
+                self::gas_builtin::deserialize(deserializer, self.arena, self.registry, info)?
             },
             CoreTypeConcrete::BuiltinCosts(_) => todo!(),
             CoreTypeConcrete::Uint8(info) => {
-                // unsafe { self::uint8::deserialize(deserializer, self.registry, ptr, info) }?
-                todo!()
+                unsafe { self::uint8::deserialize(deserializer, self.arena, self.registry, info) }?
             }
             CoreTypeConcrete::Uint16(info) => {
-                // unsafe { self::uint16::deserialize(deserializer, self.registry, ptr, info) }?
-                todo!()
+                unsafe { self::uint16::deserialize(deserializer, self.arena, self.registry, info) }?
             }
             CoreTypeConcrete::Uint32(info) => {
-                // unsafe { self::uint32::deserialize(deserializer, self.registry, ptr, info) }?
-                todo!()
+                unsafe { self::uint32::deserialize(deserializer, self.arena, self.registry, info) }?
             }
             CoreTypeConcrete::Uint64(info) => {
-                // unsafe { self::uint64::deserialize(deserializer, self.registry, ptr, info) }?
-                todo!()
+                unsafe { self::uint64::deserialize(deserializer, self.arena, self.registry, info) }?
             }
             CoreTypeConcrete::Uint128(_) => todo!(),
             CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
             CoreTypeConcrete::NonZero(_) => todo!(),
             CoreTypeConcrete::Nullable(_) => todo!(),
             CoreTypeConcrete::RangeCheck(info) => unsafe {
-                // self::range_check::deserialize(deserializer, self.registry, ptr, info)?
-                todo!()
+                self::range_check::deserialize(deserializer, self.arena, self.registry, info)?
             },
             CoreTypeConcrete::Uninitialized(_) => todo!(),
             CoreTypeConcrete::Enum(_) => todo!(),

--- a/src/values/array.rs
+++ b/src/values/array.rs
@@ -160,7 +160,7 @@ where
                 ptr = unsafe {
                     libc::realloc(ptr.cast(), elem_layout.size() * new_cap as usize).cast()
                 };
-                cap = len.try_into().unwrap();
+                cap = new_cap;
             }
 
             unsafe {

--- a/src/values/enum.rs
+++ b/src/values/enum.rs
@@ -1,5 +1,6 @@
 use super::{ValueBuilder, ValueSerializer};
 use crate::types::TypeBuilder;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{enm::EnumConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -10,10 +11,10 @@ use std::{fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     _deserializer: D,
+    _arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    _ptr: NonNull<()>,
     _info: &EnumConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,

--- a/src/values/enum.rs
+++ b/src/values/enum.rs
@@ -1,4 +1,4 @@
-use super::{ValueBuilder, ValueSerializer};
+use super::{ValueBuilder, ValueDeserializer, ValueSerializer};
 use crate::types::TypeBuilder;
 use bumpalo::Bump;
 use cairo_lang_sierra::{
@@ -6,14 +6,14 @@ use cairo_lang_sierra::{
     ids::ConcreteTypeId,
     program_registry::ProgramRegistry,
 };
-use serde::{ser::SerializeSeq, Deserializer, Serializer};
+use serde::{de, ser::SerializeSeq, Deserializer, Serializer};
 use std::{fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
-    _deserializer: D,
-    _arena: &Bump,
-    _registry: &ProgramRegistry<TType, TLibfunc>,
-    _info: &EnumConcreteType,
+    deserializer: D,
+    arena: &Bump,
+    registry: &ProgramRegistry<TType, TLibfunc>,
+    info: &EnumConcreteType,
 ) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
@@ -21,7 +21,7 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
-    todo!()
+    deserializer.deserialize_seq(Visitor::new(arena, registry, info))
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(
@@ -78,4 +78,96 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
 {
     todo!()
+}
+
+struct Visitor<'a, TType, TLibfunc>
+where
+    TType: GenericType,
+    TLibfunc: GenericLibfunc,
+    <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
+{
+    arena: &'a Bump,
+    registry: &'a ProgramRegistry<TType, TLibfunc>,
+    info: &'a EnumConcreteType,
+}
+
+impl<'a, TType, TLibfunc> Visitor<'a, TType, TLibfunc>
+where
+    TType: GenericType,
+    TLibfunc: GenericLibfunc,
+    <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
+{
+    fn new(
+        arena: &'a Bump,
+        registry: &'a ProgramRegistry<TType, TLibfunc>,
+        info: &'a EnumConcreteType,
+    ) -> Self {
+        Self {
+            arena,
+            registry,
+            info,
+        }
+    }
+}
+
+impl<'a, 'de, TType, TLibfunc> de::Visitor<'de> for Visitor<'a, TType, TLibfunc>
+where
+    TType: GenericType,
+    TLibfunc: GenericLibfunc,
+    <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
+{
+    type Value = NonNull<()>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "A sequence of the discriminant followed by the payload")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let tag_value = seq.next_element::<usize>()?.unwrap();
+        assert!(tag_value <= self.info.variants.len());
+
+        type ParamDeserializer<'a, TType, TLibfunc> =
+            <<TType as GenericType>::Concrete as ValueBuilder<TType, TLibfunc>>::Deserializer<'a>;
+
+        let payload_ty = self
+            .registry
+            .get_type(&self.info.variants[tag_value])
+            .unwrap();
+        let payload = seq
+            .next_element_seed(ParamDeserializer::<TType, TLibfunc>::new(
+                self.arena,
+                self.registry,
+                payload_ty,
+            ))?
+            .unwrap();
+
+        let (layout, tag_layout, variant_layouts) =
+            crate::types::r#enum::get_layout_for_variants(self.registry, &self.info.variants)
+                .unwrap();
+        let ptr = self.arena.alloc_layout(layout).cast();
+
+        match tag_layout.size() {
+            1 => *unsafe { ptr.cast::<u8>().as_mut() } = tag_value as u8,
+            2 => *unsafe { ptr.cast::<u16>().as_mut() } = tag_value as u16,
+            4 => *unsafe { ptr.cast::<u32>().as_mut() } = tag_value as u32,
+            8 => *unsafe { ptr.cast::<u64>().as_mut() } = tag_value as u64,
+            _ => unreachable!(),
+        }
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                payload.as_ptr(),
+                ptr.map_addr(|addr| {
+                    addr.unchecked_add(tag_layout.extend(variant_layouts[tag_value]).unwrap().1)
+                })
+                .as_ptr(),
+                variant_layouts[tag_value].size(),
+            );
+        };
+
+        Ok(ptr)
+    }
 }

--- a/src/values/felt252.rs
+++ b/src/values/felt252.rs
@@ -1,5 +1,6 @@
 use super::ValueBuilder;
 use crate::types::felt252::PRIME;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{types::InfoOnlyConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -8,20 +9,24 @@ use cairo_lang_sierra::{
 use num_bigint::BigUint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Number;
-use std::{fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
+    arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    ptr: NonNull<()>,
     _info: &InfoOnlyConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
+    let ptr = arena
+        .alloc_layout(Layout::from_size_align(32, 8).unwrap())
+        .cast();
+
     let value = <Number as Deserialize>::deserialize(deserializer)?;
     let value: BigUint = value.to_string().parse().unwrap();
     assert!(value < *PRIME);
@@ -30,7 +35,7 @@ where
     bytes.resize(32, 0);
     ptr.cast::<[u8; 32]>().as_mut().copy_from_slice(&bytes);
 
-    Ok(())
+    Ok(ptr)
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(

--- a/src/values/struct.rs
+++ b/src/values/struct.rs
@@ -7,13 +7,14 @@ use cairo_lang_sierra::{
 };
 use serde::{ser::SerializeTuple, Deserializer, Serializer};
 use std::{alloc::Layout, fmt, ptr::NonNull};
+use bumpalo::Bump;
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     _deserializer: D,
+    _arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    _ptr: NonNull<()>,
     _info: &StructConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,

--- a/src/values/uint16.rs
+++ b/src/values/uint16.rs
@@ -1,4 +1,5 @@
 use super::ValueBuilder;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{types::InfoOnlyConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -6,24 +7,27 @@ use cairo_lang_sierra::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Number;
-use std::{fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
+    arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    ptr: NonNull<()>,
     _info: &InfoOnlyConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
+    let ptr = arena.alloc_layout(Layout::new::<u16>()).cast();
+
     let value = <Number as Deserialize>::deserialize(deserializer)?;
     let value: u16 = value.to_string().parse().unwrap();
-    std::ptr::write(ptr.cast::<u16>().as_mut(), value);
-    Ok(())
+    *ptr.cast::<u16>().as_mut() = value;
+
+    Ok(ptr)
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(

--- a/src/values/uint16.rs
+++ b/src/values/uint16.rs
@@ -6,8 +6,7 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Number;
-use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
@@ -23,8 +22,7 @@ where
 {
     let ptr = arena.alloc_layout(Layout::new::<u16>()).cast();
 
-    let value = <Number as Deserialize>::deserialize(deserializer)?;
-    let value: u16 = value.to_string().parse().unwrap();
+    let value = u16::deserialize(deserializer)?;
     *ptr.cast::<u16>().as_mut() = value;
 
     Ok(ptr)
@@ -42,8 +40,7 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     S: Serializer,
 {
-    let value = ptr.cast::<u16>().as_ref();
-    <Number as Serialize>::serialize(&Number::from_str(&value.to_string()).unwrap(), serializer)
+    ptr.cast::<u16>().as_ref().serialize(serializer)
 }
 
 pub unsafe fn debug_fmt<TType, TLibfunc>(

--- a/src/values/uint32.rs
+++ b/src/values/uint32.rs
@@ -1,4 +1,5 @@
 use super::ValueBuilder;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{types::InfoOnlyConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -6,24 +7,27 @@ use cairo_lang_sierra::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Number;
-use std::{fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
+    arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    ptr: NonNull<()>,
     _info: &InfoOnlyConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
+    let ptr = arena.alloc_layout(Layout::new::<u32>()).cast();
+
     let value = <Number as Deserialize>::deserialize(deserializer)?;
     let value: u32 = value.to_string().parse().unwrap();
-    std::ptr::write(ptr.cast::<u32>().as_mut(), value);
-    Ok(())
+    *ptr.cast::<u32>().as_mut() = value;
+
+    Ok(ptr)
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(

--- a/src/values/uint32.rs
+++ b/src/values/uint32.rs
@@ -6,8 +6,7 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Number;
-use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
@@ -23,8 +22,7 @@ where
 {
     let ptr = arena.alloc_layout(Layout::new::<u32>()).cast();
 
-    let value = <Number as Deserialize>::deserialize(deserializer)?;
-    let value: u32 = value.to_string().parse().unwrap();
+    let value = u32::deserialize(deserializer)?;
     *ptr.cast::<u32>().as_mut() = value;
 
     Ok(ptr)
@@ -42,8 +40,7 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     S: Serializer,
 {
-    let value = ptr.cast::<u32>().as_ref();
-    <Number as Serialize>::serialize(&Number::from_str(&value.to_string()).unwrap(), serializer)
+    ptr.cast::<u32>().as_ref().serialize(serializer)
 }
 
 pub unsafe fn debug_fmt<TType, TLibfunc>(

--- a/src/values/uint64.rs
+++ b/src/values/uint64.rs
@@ -1,4 +1,5 @@
 use super::ValueBuilder;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{types::InfoOnlyConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -6,24 +7,27 @@ use cairo_lang_sierra::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Number;
-use std::{fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
+    arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    ptr: NonNull<()>,
     _info: &InfoOnlyConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
+    let ptr = arena.alloc_layout(Layout::new::<u64>()).cast();
+
     let value = <Number as Deserialize>::deserialize(deserializer)?;
     let value: u64 = value.to_string().parse().unwrap();
-    std::ptr::write(ptr.cast::<u64>().as_mut(), value);
-    Ok(())
+    *ptr.cast::<u64>().as_mut() = value;
+
+    Ok(ptr)
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(

--- a/src/values/uint64.rs
+++ b/src/values/uint64.rs
@@ -6,8 +6,7 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Number;
-use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
@@ -23,8 +22,7 @@ where
 {
     let ptr = arena.alloc_layout(Layout::new::<u64>()).cast();
 
-    let value = <Number as Deserialize>::deserialize(deserializer)?;
-    let value: u64 = value.to_string().parse().unwrap();
+    let value = u64::deserialize(deserializer)?;
     *ptr.cast::<u64>().as_mut() = value;
 
     Ok(ptr)
@@ -42,8 +40,7 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     S: Serializer,
 {
-    let value = ptr.cast::<u64>().as_ref();
-    <Number as Serialize>::serialize(&Number::from_str(&value.to_string()).unwrap(), serializer)
+    ptr.cast::<u64>().as_ref().serialize(serializer)
 }
 
 pub unsafe fn debug_fmt<TType, TLibfunc>(

--- a/src/values/uint8.rs
+++ b/src/values/uint8.rs
@@ -1,4 +1,5 @@
 use super::ValueBuilder;
+use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{types::InfoOnlyConcreteType, GenericLibfunc, GenericType},
     ids::ConcreteTypeId,
@@ -6,24 +7,27 @@ use cairo_lang_sierra::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Number;
-use std::{fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
+    arena: &Bump,
     _registry: &ProgramRegistry<TType, TLibfunc>,
-    ptr: NonNull<()>,
     _info: &InfoOnlyConcreteType,
-) -> Result<(), D::Error>
+) -> Result<NonNull<()>, D::Error>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     D: Deserializer<'de>,
 {
+    let ptr = arena.alloc_layout(Layout::new::<u8>()).cast();
+
     let value = <Number as Deserialize>::deserialize(deserializer)?;
     let value: u8 = value.to_string().parse().unwrap();
-    std::ptr::write(ptr.cast::<u8>().as_mut(), value);
-    Ok(())
+    *ptr.cast::<u8>().as_mut() = value;
+
+    Ok(ptr)
 }
 
 pub unsafe fn serialize<TType, TLibfunc, S>(

--- a/src/values/uint8.rs
+++ b/src/values/uint8.rs
@@ -6,8 +6,7 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Number;
-use std::{alloc::Layout, fmt, ptr::NonNull, str::FromStr};
+use std::{alloc::Layout, fmt, ptr::NonNull};
 
 pub unsafe fn deserialize<'de, TType, TLibfunc, D>(
     deserializer: D,
@@ -23,8 +22,7 @@ where
 {
     let ptr = arena.alloc_layout(Layout::new::<u8>()).cast();
 
-    let value = <Number as Deserialize>::deserialize(deserializer)?;
-    let value: u8 = value.to_string().parse().unwrap();
+    let value = u8::deserialize(deserializer)?;
     *ptr.cast::<u8>().as_mut() = value;
 
     Ok(ptr)
@@ -42,8 +40,7 @@ where
     <TType as GenericType>::Concrete: ValueBuilder<TType, TLibfunc>,
     S: Serializer,
 {
-    let value = ptr.cast::<u8>().as_ref();
-    <Number as Serialize>::serialize(&Number::from_str(&value.to_string()).unwrap(), serializer)
+    ptr.cast::<u8>().as_ref().serialize(serializer)
 }
 
 pub unsafe fn debug_fmt<TType, TLibfunc>(


### PR DESCRIPTION
# Implement de/serialization for values

## Description

  - Implement missing de/serialization for the `array` type.
  - Implement missing de/serialization for the `enum` type.
  - Implement missing de/serialization for the `arrays` type.
  - Fix de/serialization of `felt252` and `uintN` types (avoid `serde_json` dependency).

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
