### PR TITLE
Attempt to fix the enums.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! # Cairo Sierra to MLIR compiler and JIT engine
 
+#![feature(alloc_layout_extra)]
 #![feature(arc_unwrap_or_clone)]
 #![feature(box_into_inner)]
 #![feature(error_generic_member_access)]

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -466,7 +466,7 @@ where
     Ok(llvm::r#type::r#struct(
         context,
         &[tag_ty, filling_ty, variant_ty, padding_ty],
-        false,
+        true,
     ))
 }
 

--- a/src/values/enum.rs
+++ b/src/values/enum.rs
@@ -38,11 +38,12 @@ where
         TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError> + ValueBuilder<TType, TLibfunc>,
     S: Serializer,
 {
-    let tag_layout = crate::utils::get_integer_layout(
-        (info.variants.len().next_power_of_two().next_multiple_of(8) >> 3)
+    let tag_layout = crate::utils::get_integer_layout(match info.variants.len() {
+        0 | 1 => 0,
+        num_variants => (num_variants.next_power_of_two().next_multiple_of(8) >> 3)
             .try_into()
             .unwrap(),
-    );
+    });
     let tag_value = match info.variants.len() {
         0 => {
             // An enum without variants is basically the `!` (never) type in Rust.

--- a/src/values/enum.rs
+++ b/src/values/enum.rs
@@ -43,12 +43,19 @@ where
             .try_into()
             .unwrap(),
     );
-    let tag_value = match tag_layout.size() {
-        1 => *ptr.cast::<u8>().as_ref() as usize,
-        2 => *ptr.cast::<u16>().as_ref() as usize,
-        4 => *ptr.cast::<u32>().as_ref() as usize,
-        8 => *ptr.cast::<u64>().as_ref() as usize,
-        _ => unreachable!(),
+    let tag_value = match info.variants.len() {
+        0 => {
+            // An enum without variants is basically the `!` (never) type in Rust.
+            panic!("An enum without variants is not a valid type.")
+        }
+        1 => 0,
+        _ => match tag_layout.size() {
+            1 => *ptr.cast::<u8>().as_ref() as usize,
+            2 => *ptr.cast::<u16>().as_ref() as usize,
+            4 => *ptr.cast::<u32>().as_ref() as usize,
+            8 => *ptr.cast::<u64>().as_ref() as usize,
+            _ => unreachable!(),
+        },
     };
 
     let payload_ty = registry.get_type(&info.variants[tag_value]).unwrap();


### PR DESCRIPTION
# Attempt to fix the enums

## Description

Enums are failing on Mac OS due to the way LLVM handles padding. Our solution is to make all paddings explicit and mark the intermediate structs as packed. This way, LLVM will not generate padding, but the fields will still be properly aligned.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
