### PR TITLE
Fix native benchmark wrappers.

### DIFF
--- a/programs/benches/factorial.c
+++ b/programs/benches/factorial.c
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -20,16 +19,15 @@ typedef struct factorial_return_values
 } factorial_return_values_t;
 
 
+static void run_bench(factorial_return_values_t *, void *, uint64_t)
+    __attribute__((weakref("_mlir_ciface_factorial::factorial::main")));
+
+
 int main()
 {
     factorial_return_values_t return_values;
-    void (*ptr)(factorial_return_values_t *, void *, uint64_t);
-    void *handle;
 
-    handle = dlopen(NULL, RTLD_LAZY);
-
-    *(void **) (&ptr) = dlsym(handle, "_mlir_ciface_factorial::factorial::main");
-    ptr(&return_values, NULL, 0);
+    run_bench(&return_values, NULL, 0);
 
     return 0;
 }

--- a/programs/benches/factorial_100.c
+++ b/programs/benches/factorial_100.c
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -20,16 +19,15 @@ typedef struct factorial_return_values
 } factorial_return_values_t;
 
 
+static void run_bench(factorial_return_values_t *, void *, uint64_t)
+    __attribute__((weakref("_mlir_ciface_factorial_100::factorial_100::main")));
+
+
 int main()
 {
     factorial_return_values_t return_values;
-    void (*ptr)(factorial_return_values_t *, void *, uint64_t);
-    void *handle;
 
-    handle = dlopen(NULL, RTLD_LAZY);
-
-    *(void **) (&ptr) = dlsym(handle, "_mlir_ciface_factorial_100c::factorial_100c::main");
-    ptr(&return_values, NULL, 0);
+    run_bench(&return_values, NULL, 0);
 
     return 0;
 }

--- a/programs/benches/fib.c
+++ b/programs/benches/fib.c
@@ -20,16 +20,15 @@ typedef struct fib_return_values
 } fib_return_values_t;
 
 
+static void run_bench(fib_return_values_t *, void *, uint64_t)
+    __attribute__((weakref("_mlir_ciface_fib::fib::main")));
+
+
 int main()
 {
     fib_return_values_t return_values;
-    void (*ptr)(fib_return_values_t *, void *, uint64_t);
-    void *handle;
 
-    handle = dlopen(NULL, RTLD_LAZY);
-
-    *(void **) (&ptr) = dlsym(handle, "_mlir_ciface_fib::fib::main");
-    ptr(&return_values, NULL, 0);
+    run_bench(&return_values, NULL, 0);
 
     return 0;
 }

--- a/programs/benches/fib_1k.c
+++ b/programs/benches/fib_1k.c
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -20,16 +19,15 @@ typedef struct fib_return_values
 } fib_return_values_t;
 
 
+static void run_bench(fib_return_values_t *, void *, uint64_t)
+    __attribute__((weakref("_mlir_ciface_fib_1k::fib_1k::main")));
+
+
 int main()
 {
     fib_return_values_t return_values;
-    void (*ptr)(fib_return_values_t *, void *, uint64_t);
-    void *handle;
 
-    handle = dlopen(NULL, RTLD_LAZY);
-
-    *(void **) (&ptr) = dlsym(handle, "_mlir_ciface_fib_1k::fib_1k::main");
-    ptr(&return_values, NULL, 0);
+    run_bench(&return_values, NULL, 0);
 
     return 0;
 }

--- a/programs/benches/map.c
+++ b/programs/benches/map.c
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -20,16 +19,15 @@ typedef struct map_return_values
 } map_return_values_t;
 
 
+static void run_bench(map_return_values_t *, void *, uint64_t)
+    __attribute__((weakref("_mlir_ciface_map::map::main")));
+
+
 int main()
 {
     map_return_values_t return_values;
-    void (*ptr)(map_return_values_t *, void *, uint64_t);
-    void *handle;
 
-    handle = dlopen(NULL, RTLD_LAZY);
-
-    *(void **) (&ptr) = dlsym(handle, "_mlir_ciface_map::map::main");
-    ptr(&return_values, NULL, 0);
+    run_bench(&return_values, NULL, 0);
 
     return 0;
 }


### PR DESCRIPTION
# Fix native benchmark wrappers

## Description

Some configurations seemed to remove the actual benchmark code since it wasn't directly called. This PR fixes this, although requires a C compiler that supports `__attribute__(())`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
