### PR TITLE
Added env var for cairo-run command in hyperfine script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
   test_macos:
-      name: Test (macOS, Apple sillicon)
+      name: Test (macOS, Apple silicon)
       runs-on: [self-hosted, macOS]
       env:
         CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ $MLIR_SYS_160_PREFIX=/path/to/llvm16  # Required for non-standard LLVM install l
 make bench
 ```
 
+The `bench` target will run the `./scripts/bench-hyperfine.sh` script.
+This script runs hyperfine comands to compare the execution time of programs in the `./programs/benches/` folder.
+Each program is compiled and executed via the execution engine with the `sierrajit` command and via the cairo-vm with the `cairo-run` command provided by the `cairo` codebase.
+The `cairo-run` command should be available in the `$PATH` and ideally compiled with `cargo build --release`.
+If you want the benchmarks to run using a specific build, or the `cairo-run` commands conflicts with something (e.g. the cairo-svg package binaries in macos) then the command to run `cairo-run` with a full path can be specified with the `$CAIRO_RUN` environment variable.
+
 ## MLIR Resources
 - https://mlir.llvm.org/docs/Tutorials/
 

--- a/scripts/bench-hyperfine.sh
+++ b/scripts/bench-hyperfine.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 # Configuration.
 ROOT_DIR="$(dirname $(dirname ${0%/*}))"
 MLIR_DIR="$MLIR_SYS_160_PREFIX"
@@ -10,10 +9,10 @@ CAIRO_SRCS=$(find \
     -type f -name "*.cairo")
 IFS=$'\n' read -rd '' -a CAIRO_SRCS <<<"$CAIRO_SRCS"
 
+CAIRO_RUN="${CAIRO_RUN:=cairo-run}"
 COMPILER_CLI="$ROOT_DIR/target/release/sierra2mlir"
 JIT_CLI="$ROOT_DIR/target/release/sierrajit"
 OUTPUT_DIR="$ROOT_DIR/target/bench-outputs"
-
 
 # Initial setup.
 if [[ ! -e "$COMPILER_CLI" ]]
@@ -29,7 +28,6 @@ fi
 
 set -e
 mkdir -p "$OUTPUT_DIR"
-
 
 # Benchmarking code.
 run_bench() {
@@ -89,9 +87,9 @@ run_bench() {
 
     hyperfine \
         --shell=none \
-        --export-markdown "$OUTPUT_DIR/$base_name.md" \
         --warmup 3 \
-        "cairo-run --available-gas 18446744073709551615 $base_path.cairo" \
+        --export-markdown "$OUTPUT_DIR/$base_name.md" \
+        "$CAIRO_RUN --available-gas 18446744073709551615 --single-file $base_path.cairo" \
         "echo '[null, 18446744073709551615]' | $JIT_CLI $base_path.cairo $base_name::$base_name::main --inputs -" \
         "$OUTPUT_DIR/$base_name" \
         "$OUTPUT_DIR/$base_name-march-native" \


### PR DESCRIPTION
# Add env var for cairo-run command in hyperfine script

## Description

The benchmarking script that runs hyperfine uses the cairo-run command to run programs through the cairo-vm, and defaults to running whatever cairo-run command is present in $PATH.
An environment variable allowing specifying a location for the command was added to the script and its use documented in the README.md

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
