### PR TITLE
Fix nightly-2023-06-19 in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-06-19"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Otherwise compilation of the project fails with:

```
   Compiling melior-asm-proc v0.1.0 (/Users/klaus/lambda/kraken_zk_stack/sequencer/cairo_native/melior-asm-proc)
error[E0635]: unknown feature `proc_macro_span_shrink`
 --> melior-asm-proc/src/lib.rs:1:35
  |
1 | #![feature(proc_macro_diagnostic, proc_macro_span_shrink)]
  |                                   ^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `before` found for struct `proc_macro::Span` in the current scope
  --> melior-asm-proc/src/verify.rs:30:32
   |
30 |         location_span.unwrap().before().error(diagnostic.to_string()).emit();
   |                                ^^^^^^ method not found in `Span`
```