### PR TITLE
Fix future merge conflicts in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,184 +8,184 @@ A compiler to convert Cairo's intermediate representation "Sierra" code to machi
 
 Done:
 1. `alloc_local`
-2. `array_append`
-3. `array_get`
-4. `array_len`
-5. `array_new`
-6. `array_pop_front_consume`
-7. `array_pop_front`
-8. `array_snapshot_pop_back`
-9. `array_snapshot_pop_front`
-10. `bitwise`
-11. `bool_and_impl`
-12. `bool_not_impl`
-13. `bool_or_impl`
-14. `bool_to_felt252`
-15. `bool_xor_impl`
-16. `branch_align`
-17. `disable_ap_tracking`
-18. `downcast`
-19. `drop` (3)
-20. `dup` (3)
-21. `ec_neg`
-22. `ec_point_from_x_nz`
-23. `ec_point_is_zero`
-24. `ec_point_try_new_nz`
-25. `ec_point_unwrap`
-26. `ec_point_zero`
-27. `ec_state_add_mul`
-28. `ec_state_add`
-29. `ec_state_init`
-30. `ec_state_try_finalize_nz`
-31. `enable_ap_tracking`
-32. `enum_init`
-33. `enum_match`
-34. `felt252_add_const` (4)
-35. `felt252_add`
-36. `felt252_const`
-37. `felt252_dict_entry_finalize`
-38. `felt252_dict_entry_get`
-39. `felt252_dict_new`
-40. `felt252_dict_squash`
-41. `felt252_div_const` (4)
-42. `felt252_div` (4)
-43. `felt252_is_zero`
-44. `felt252_mul_const` (4)
-45. `felt252_mul`
-46. `felt252_sub_const` (4)
-47. `felt252_sub`
-48. `finalize_locals`
-49. `function_call`
-50. `get_block_hash_syscall` (StarkNet)
-51. `get_builtin_costs` (5)
-52. `into_box` (2)
-53. `jump`
-54. `match_nullable`
-55. `null`
-56. `nullable_from_box`
-57. `pedersen`
-58. `print`
-59. `rename`
-60. `revoke_ap_tracking` (1)
-61. `snapshot_take` (6)
-62. `storage_address_from_base_and_offset` (StarkNet)
-63. `storage_address_from_base` (StarkNet)
-64. `storage_address_to_felt252` (StarkNet)
-65. `storage_address_try_from_felt252` (StarkNet)
-66. `storage_base_address_const` (StarkNet)
-67. `storage_base_address_from_felt252` (StarkNet)
-68. `store_local`
-69. `store_temp`
-70. `struct_construct`
-71. `struct_deconstruct`
-72. `u128_byte_reverse`
-73. `u128_const`
-74. `u128_eq`
-75. `u128_is_zero`
-76. `u128_overflowing_add`
-77. `u128_overflowing_sub`
-78. `u128_safe_divmod`
-79. `u128_sqrt`
-80. `u128_to_felt252`
-81. `u128s_from_felt252`
-82. `u16_const`
-83. `u16_eq`
-84. `u16_is_zero`
-85. `u16_overflowing_add`
-86. `u16_overflowing_sub`
-87. `u16_safe_divmod`
-88. `u16_sqrt`
-89. `u16_to_felt252`
-90. `u16_try_from_felt252`
-91. `u32_const`
-92. `u32_eq`
-93. `u32_is_zero`
-94. `u32_overflowing_add`
-95. `u32_overflowing_sub`
-96. `u32_safe_divmod`
-97. `u32_sqrt`
-98. `u32_to_felt252`
-99. `u32_try_from_felt252`
-100. `u64_const`
-101. `u64_eq`
-102. `u64_is_zero`
-103. `u64_overflowing_add`
-104. `u64_overflowing_sub`
-105. `u64_safe_divmod`
-106. `u64_sqrt`
-107. `u64_to_felt252`
-108. `u64_try_from_felt252`
-109. `u8_const`
-110. `u8_eq`
-111. `u8_is_zero`
-112. `u8_overflowing_add`
-113. `u8_overflowing_sub`
-114. `u8_safe_divmod`
-115. `u8_sqrt`
-116. `u8_to_felt252`
-117. `u8_try_from_felt252`
-118. `unbox` (2)
-119. `unwrap_non_zero`
-120. `upcast`
-121. `withdraw_gas_all` (5)
-122. `withdraw_gas` (5)
+1. `array_append`
+1. `array_get`
+1. `array_len`
+1. `array_new`
+1. `array_pop_front_consume`
+1. `array_pop_front`
+1. `array_snapshot_pop_back`
+1. `array_snapshot_pop_front`
+1. `bitwise`
+1. `bool_and_impl`
+1. `bool_not_impl`
+1. `bool_or_impl`
+1. `bool_to_felt252`
+1. `bool_xor_impl`
+1. `branch_align`
+1. `disable_ap_tracking`
+1. `downcast`
+1. `drop` (3)
+1. `dup` (3)
+1. `ec_neg`
+1. `ec_point_from_x_nz`
+1. `ec_point_is_zero`
+1. `ec_point_try_new_nz`
+1. `ec_point_unwrap`
+1. `ec_point_zero`
+1. `ec_state_add_mul`
+1. `ec_state_add`
+1. `ec_state_init`
+1. `ec_state_try_finalize_nz`
+1. `enable_ap_tracking`
+1. `enum_init`
+1. `enum_match`
+1. `felt252_add_const` (4)
+1. `felt252_add`
+1. `felt252_const`
+1. `felt252_dict_entry_finalize`
+1. `felt252_dict_entry_get`
+1. `felt252_dict_new`
+1. `felt252_dict_squash`
+1. `felt252_div_const` (4)
+1. `felt252_div` (4)
+1. `felt252_is_zero`
+1. `felt252_mul_const` (4)
+1. `felt252_mul`
+1. `felt252_sub_const` (4)
+1. `felt252_sub`
+1. `finalize_locals`
+1. `function_call`
+1. `get_block_hash_syscall` (StarkNet)
+1. `get_builtin_costs` (5)
+1. `into_box` (2)
+1. `jump`
+1. `match_nullable`
+1. `null`
+1. `nullable_from_box`
+1. `pedersen`
+1. `print`
+1. `rename`
+1. `revoke_ap_tracking` (1)
+1. `snapshot_take` (6)
+1. `storage_address_from_base_and_offset` (StarkNet)
+1. `storage_address_from_base` (StarkNet)
+1. `storage_address_to_felt252` (StarkNet)
+1. `storage_address_try_from_felt252` (StarkNet)
+1. `storage_base_address_const` (StarkNet)
+1. `storage_base_address_from_felt252` (StarkNet)
+1. `store_local`
+1. `store_temp`
+1. `struct_construct`
+1. `struct_deconstruct`
+1. `u128_byte_reverse`
+1. `u128_const`
+1. `u128_eq`
+1. `u128_is_zero`
+1. `u128_overflowing_add`
+1. `u128_overflowing_sub`
+1. `u128_safe_divmod`
+1. `u128_sqrt`
+1. `u128_to_felt252`
+1. `u128s_from_felt252`
+1. `u16_const`
+1. `u16_eq`
+1. `u16_is_zero`
+1. `u16_overflowing_add`
+1. `u16_overflowing_sub`
+1. `u16_safe_divmod`
+1. `u16_sqrt`
+1. `u16_to_felt252`
+1. `u16_try_from_felt252`
+1. `u32_const`
+1. `u32_eq`
+1. `u32_is_zero`
+1. `u32_overflowing_add`
+1. `u32_overflowing_sub`
+1. `u32_safe_divmod`
+1. `u32_sqrt`
+1. `u32_to_felt252`
+1. `u32_try_from_felt252`
+1. `u64_const`
+1. `u64_eq`
+1. `u64_is_zero`
+1. `u64_overflowing_add`
+1. `u64_overflowing_sub`
+1. `u64_safe_divmod`
+1. `u64_sqrt`
+1. `u64_to_felt252`
+1. `u64_try_from_felt252`
+1. `u8_const`
+1. `u8_eq`
+1. `u8_is_zero`
+1. `u8_overflowing_add`
+1. `u8_overflowing_sub`
+1. `u8_safe_divmod`
+1. `u8_sqrt`
+1. `u8_to_felt252`
+1. `u8_try_from_felt252`
+1. `unbox` (2)
+1. `unwrap_non_zero`
+1. `upcast`
+1. `withdraw_gas_all` (5)
+1. `withdraw_gas` (5)
 
 TODO:
 1. `array_slice`
-2. `call_contract_syscall` (StarkNet)
-3. `class_hash_const` (StarkNet)
-4. `class_hash_to_felt252` (StarkNet)
-5. `class_hash_try_from_felt252` (StarkNet)
-6. `contract_address_const` (StarkNet)
-7. `contract_address_to_felt252` (StarkNet)
-8. `contract_address_try_from_felt252` (StarkNet)
-9. `deploy_syscall` (StarkNet)
-10. `emit_event_syscall` (StarkNet)
-11. `enum_snapshot_match`
-12. `get_available_gas`
-13. `get_execution_info_syscall` (StarkNet)
-14. `keccak_syscall` (StarkNet)
-15. `library_call_syscall` (StarkNet)
-16. `pop_log` (StarkNet, testing)
-17. `poseidon`
-18. `redeposit_gas`
-19. `replace_class_syscall` (StarkNet)
-20. `secp256k1_add_syscall` (StarkNet)
-21. `secp256k1_get_point_from_x_syscall` (StarkNet)
-22. `secp256k1_get_xy_syscall` (StarkNet)
-23. `secp256k1_mul_syscall` (StarkNet)
-24. `secp256k1_new_syscall` (StarkNet)
-25. `secp256r1_add_syscall` (StarkNet)
-26. `secp256r1_get_point_from_x_syscall` (StarkNet)
-27. `secp256r1_get_xy_syscall` (StarkNet)
-28. `secp256r1_mul_syscall` (StarkNet)
-29. `secp256r1_new_syscall` (StarkNet)
-30. `send_message_to_l1_syscall` (StarkNet)
-31. `set_account_contract_address` (StarkNet, testing)
-32. `set_block_number` (StarkNet, testing)
-33. `set_block_timestamp` (StarkNet, testing)
-34. `set_caller_address` (StarkNet, testing)
-35. `set_chain_id` (StarkNet, testing)
-36. `set_contract_address` (StarkNet, testing)
-37. `set_max_fee` (StarkNet, testing)
-38. `set_nonce` (StarkNet, testing)
-39. `set_sequencer_address` (StarkNet, testing)
-40. `set_signature` (StarkNet, testing)
-41. `set_transaction_hash` (StarkNet, testing)
-42. `set_version` (StarkNet, testing)
-43. `storage_read_syscall` (StarkNet)
-44. `storage_write_syscall` (StarkNet)
-45. `struct_snapshot_deconstruct`
-46. `u128_guarantee_mul`
-47. `u128_mul_guarantee_verify`
-48. `u16_wide_mul`
-59. `u256_is_zero`
-50. `u256_safe_divmod`
-51. `u256_sqrt`
-52. `u32_wide_mul`
-53. `u512_safe_divmod_by_u256`
-54. `u64_wide_mul`
-55. `u8_wide_mul`
+1. `call_contract_syscall` (StarkNet)
+1. `class_hash_const` (StarkNet)
+1. `class_hash_to_felt252` (StarkNet)
+1. `class_hash_try_from_felt252` (StarkNet)
+1. `contract_address_const` (StarkNet)
+1. `contract_address_to_felt252` (StarkNet)
+1. `contract_address_try_from_felt252` (StarkNet)
+1. `deploy_syscall` (StarkNet)
+1. `emit_event_syscall` (StarkNet)
+1. `enum_snapshot_match`
+1. `get_available_gas`
+1. `get_execution_info_syscall` (StarkNet)
+1. `keccak_syscall` (StarkNet)
+1. `library_call_syscall` (StarkNet)
+1. `pop_log` (StarkNet, testing)
+1. `poseidon`
+1. `redeposit_gas`
+1. `replace_class_syscall` (StarkNet)
+1. `secp256k1_add_syscall` (StarkNet)
+1. `secp256k1_get_point_from_x_syscall` (StarkNet)
+1. `secp256k1_get_xy_syscall` (StarkNet)
+1. `secp256k1_mul_syscall` (StarkNet)
+1. `secp256k1_new_syscall` (StarkNet)
+1. `secp256r1_add_syscall` (StarkNet)
+1. `secp256r1_get_point_from_x_syscall` (StarkNet)
+1. `secp256r1_get_xy_syscall` (StarkNet)
+1. `secp256r1_mul_syscall` (StarkNet)
+1. `secp256r1_new_syscall` (StarkNet)
+1. `send_message_to_l1_syscall` (StarkNet)
+1. `set_account_contract_address` (StarkNet, testing)
+1. `set_block_number` (StarkNet, testing)
+1. `set_block_timestamp` (StarkNet, testing)
+1. `set_caller_address` (StarkNet, testing)
+1. `set_chain_id` (StarkNet, testing)
+1. `set_contract_address` (StarkNet, testing)
+1. `set_max_fee` (StarkNet, testing)
+1. `set_nonce` (StarkNet, testing)
+1. `set_sequencer_address` (StarkNet, testing)
+1. `set_signature` (StarkNet, testing)
+1. `set_transaction_hash` (StarkNet, testing)
+1. `set_version` (StarkNet, testing)
+1. `storage_read_syscall` (StarkNet)
+1. `storage_write_syscall` (StarkNet)
+1. `struct_snapshot_deconstruct`
+1. `u128_guarantee_mul`
+1. `u128_mul_guarantee_verify`
+1. `u16_wide_mul`
+1. `u256_is_zero`
+1. `u256_safe_divmod`
+1. `u256_sqrt`
+1. `u32_wide_mul`
+1. `u512_safe_divmod_by_u256`
+1. `u64_wide_mul`
+1. `u8_wide_mul`
 
 
 Footnotes


### PR DESCRIPTION
# Fix future merge conflicts in `README.md`

## Description

Changing the enumeration of libfuncs to have all the same index will fix merge conflicts while not affecting the compiled markdown because it'll be fixed automatically.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
