### PR TITLE
move missed libfuncs on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Done:
 1. `array_new`
 1. `array_pop_front_consume`
 1. `array_pop_front`
+1. `array_slice`
 1. `array_snapshot_pop_back`
 1. `array_snapshot_pop_front`
 1. `bitwise`
@@ -81,7 +82,9 @@ Done:
 1. `u128_byte_reverse`
 1. `u128_const`
 1. `u128_eq`
+1. `u128_guarantee_mul`
 1. `u128_is_zero`
+1. `u128_mul_guarantee_verify`
 1. `u128_overflowing_add`
 1. `u128_overflowing_sub`
 1. `u128_safe_divmod`
@@ -138,7 +141,6 @@ Done:
 1. `withdraw_gas` (5)
 
 TODO:
-1. `array_slice`
 1. `call_contract_syscall` (StarkNet)
 1. `class_hash_const` (StarkNet)
 1. `class_hash_to_felt252` (StarkNet)
@@ -183,8 +185,6 @@ TODO:
 1. `storage_read_syscall` (StarkNet)
 1. `storage_write_syscall` (StarkNet)
 1. `struct_snapshot_deconstruct`
-1. `u128_guarantee_mul`
-1. `u128_mul_guarantee_verify`
 1. `u512_safe_divmod_by_u256`
 
 


### PR DESCRIPTION
Some libfuncs where already done but still placed on todo on the readme, this moves them to the done section.