### PR TITLE
erc20 example / segfault llvm bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 docs/*.js linguist-generated
+Cargo.lock linguist-generated

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,4 +2,6 @@ coverage:
   status:
     project:
       default: # This can be anything, but it needs to exist as the name
-        threshold: 5%
+        threshold: 65%
+        paths:
+          - "src"

--- a/.github/workflows/bench-hyperfine.yml
+++ b/.github/workflows/bench-hyperfine.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Fetch corelibs.
         run: ./scripts/fetch-corelibs.sh
       - name: Fetch and build cairo.
-        run: wget https://github.com/starkware-libs/cairo/releases/download/v1.1.0/release-x86_64-unknown-linux-musl.tar.gz && tar xvf release-x86_64-unknown-linux-musl.tar.gz
+        run: wget https://github.com/starkware-libs/cairo/releases/download/v2.1.0-rc4/release-x86_64-unknown-linux-musl.tar.gz && tar xvf release-x86_64-unknown-linux-musl.tar.gz
       - name: Build project
         run: make build
       - name: Run benchmarks

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustdoc
       - uses: Swatinem/rust-cache@v2
       - name: add llvm deb repository
         uses: myci-actions/add-deb-repo@10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e4847267117f1c79697e1523968422600bd2b4ab36b58404b9d7def254ef9"
+checksum = "1bfb23212923a656f06d49ff2a953d83a40c916dc01802bf43a6a8b230cc1ae5"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a73bb1aab3b02df4199e46f709959eab56ccc810d00d4d23c46bac66ae1c84"
+checksum = "6cb8e62e8ea8ec8953900c591e8ec8afadeacb5414c66c391e2374cd33e75265"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -419,18 +419,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b6f842315f8a69978556f7d05ffba208f0ae7bdec3d88f821d5c9b75217bd4"
+checksum = "688919661be70385834619abb6e91b822c2e36ee0d5490efa6a3c708741cb1a9"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab196c3f5a7b09cc5fbf74770e5740b64bab9975233c6abdc329bdf4019946a"
+checksum = "17ae52e506409795292e5fa5a06cda8cc705a1b714d31071841827b74453dad3"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826c7e4282d6447c909486e365f1bc4cecc79285d710456c5cd801508cc2c5f6"
+checksum = "f3f53df12acc714e2fc505fba706c754c0d19d092710b4527dbec489b59589b1"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f568be682ded01d7ef471fa26c5beb72960b7f6052d5d3bfce30a88c38b5ed8"
+checksum = "be26fab051abb2ff8e53cd3bd728db6e85d5b044c6779c0ac202c68613844bbb"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff25a29eae5b5502f3c8be11ecdea9e2c815ed348477f5cd796f3d1d03259dfc"
+checksum = "22faaa72b212e6dd21a9d1547e86cea65a3cb7c7f4d43be1f7b051e4a1613a46"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404eb42841fe77aba941ba329d737a6ea749e809632f096d18590b52f3211234"
+checksum = "f2160203c5556d680f155e1a24432c77ada4bf04c1701e08cfb8e35d33a717b6"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0cb8b895da0e7b092a0d772e2c985287ddb73e1d77bdbbf91ca4e61f4980ca"
+checksum = "b25cb9b8be9bf706739030a282d088cb0a2de42e2ec0a21e720ec5bb34a41218"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418ba1fdc6fd03fa87c27faff28dd705c0f2945adaa2dfcd58638fd952b9119b"
+checksum = "b685065afc3305b780e9713132a4a747de5f0d71bcf101201474ad0ebfe3f06e"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e27ea16f824e01d28aa45ab8c1830838134247a43f57fc64fc62c60f6a4afa"
+checksum = "8b1a49e58ad1eeefe0b1efc667a6ee544b5f906c6123d6d1e77e0321b4d1db92"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226e9876e268d91571e93d6872603258470c488da3b744edf65512c83557f41e"
+checksum = "d29d3e28ff80fb8fd94f4e6db12c42bacbe6e3ab7a991aa997861b99d0cb2fa2"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801cabe3186da140d4f423c0384950c5939b82917ed1f571b48ce8cf05051137"
+checksum = "abcc2ff6ebb5fbdd9578f3506a6ffab3944da5383e38546ed30eebaa992df01b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e223f688d25bf616e65b24132defb61bbe21ee526eb081eb29e3242958e8f40"
+checksum = "5fc0538b422abaff683425ceb945d29d956172e2748f28924904226303d07486"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27bfcaa8e23086adc6287e07c15e0697e20f03adf761d021d6bc3f23538606"
+checksum = "2b84a986fa30c459447cbe7175243d50ba55e5659d8efc3a867b051ca7a629b0"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc3b21046e99c9ef8f7f181dabf117c6987f63efeb6e13e9305738cc70a357"
+checksum = "224dad404d483b4c3ea9cb08d94285c2b4755539eaf78dcd5e280bf1a2ca96cb"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2a5dcec285df1f59b3f0166251fd1103b3927fd229ea2ff981fdd451c917bd"
+checksum = "e1246a3fc5249d5fc7e7d1b0611dd41e6b13e88c4fd4ce5d77708581975baa6a"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd078441c13fbc26c8f792085f29790041169ccc85213cdcd437b09c3f2580e"
+checksum = "91b4e0a3a883348e262ca84ca085ff402b52dc206278352c0d74db476d76e960"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdaf6efb30b9b18eefffc4299e94a1716563155e3361ca0b0f1a12b8c6d20e5"
+checksum = "4ba03115b3cf4d3fe691f5574ff1a95565f1abc430fba717d6605db11d7e2cd4"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70518ff6735aab928968d2dc60d47df15916714cc7ab9a92376735a63b4664aa"
+checksum = "ff65da8fd75ab9020159b072817c8a516d859b0b0bc60ab3693681b635339729"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79046b134371524cb939ca28d1dbd7edec718dd276388511a3c8e726f61f2dd7"
+checksum = "326f47941e94a8cdbb420a041411df44a4328a5b8190bb5647092499ed4d3fa9"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8af4bdabb3172bada1fb539ae3e0b99c7ba6a4d41712247a768f39c3e70a95"
+checksum = "84885246b2b8626034fe8fe2fc7360f8618b695769413bd8f8b31063c8964d8d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10dec5db88b32a5d2916dfd900e925f52b8c16bf3fe9c7340f8b4d8cdc329861"
+checksum = "a87271440bc2624da4b5411db90403302224c39f2cdac4293f52967439238e6c"
 dependencies = [
  "genco",
  "xshell",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.1.0-rc3"
+version = "2.1.0-rc4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25468f2dfe544d7581ec3880724c29ff9e0459e1f16561fbc47cf0c8376976cd"
+checksum = "22628c2fcd2d249ed6655a0fb7ba29a668a6b65741016b8ed562bd5ef906778a"
 dependencies = [
  "indexmap 2.0.0",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +359,12 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cairo-felt"
@@ -812,19 +827,25 @@ dependencies = [
  "cairo-lang-lowering",
  "cairo-lang-runner",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-ap-change",
+ "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-starknet",
+ "cairo-lang-utils",
  "cairo-native-runtime",
  "cc",
  "clap",
  "id-arena",
  "itertools 0.11.0",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "melior",
  "mlir-sys",
  "num-bigint",
+ "num-traits 0.2.16",
  "pretty_assertions",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",
@@ -1069,6 +1090,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1342,6 +1369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1401,19 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1540,12 +1589,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambdaworks-math"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66ebb7299e567bbc393b50eef9de8db7728605567b7e5cc31634e34b4c8875ba"
+dependencies = [
+ "heapless",
+ "rand",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -1571,6 +1632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1820,6 +1887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2046,6 +2114,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits 0.2.16",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2242,6 +2345,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,9 +2439,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.179"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
@@ -2342,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.179"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2437,6 +2552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sprs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2570,12 @@ dependencies = [
  "num-complex",
  "num-traits 0.1.43",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"
@@ -2769,6 +2899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unescaper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,6 +2948,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +109,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -120,7 +126,7 @@ dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "digest",
  "itertools 0.10.5",
@@ -162,7 +168,7 @@ checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
  "ark-ff",
  "ark-serialize",
- "ark-std 0.4.0",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
 ]
@@ -175,7 +181,7 @@ checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
 dependencies = [
  "ark-ec",
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -186,7 +192,7 @@ checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
 dependencies = [
  "ark-ec",
  "ark-ff",
- "ark-std 0.4.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -196,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.4.0",
+ "ark-std",
  "digest",
  "num-bigint",
 ]
@@ -210,16 +216,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits 0.2.16",
- "rand",
 ]
 
 [[package]]
@@ -368,9 +364,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cairo-felt"
-version = "0.6.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec837cac4e5e5a7f7abd6fb26c1d91cf0a588cf394367a7111a9549cabaa0b9"
+checksum = "ed22664386f178bf9ca7b9ae7235727d92fa37b731a9063b5122488a1f699834"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -381,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65519f6686244c4ba6be09c6ef3d8146d1d4d5c87cbb6693671117c0ae2a5b01"
+checksum = "b47e4847267117f1c79697e1523968422600bd2b4ab36b58404b9d7def254ef9"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -398,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5a8463717f788a132f1573fb1ad6368edd1f41bfdef6f4d143368b3816a1f9"
+checksum = "f4a73bb1aab3b02df4199e46f709959eab56ccc810d00d4d23c46bac66ae1c84"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -423,18 +419,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec1fd38b6ae840897d86788a6c81332b903e37f438470c2c2558f79a6ceb9d9"
+checksum = "37b6f842315f8a69978556f7d05ffba208f0ae7bdec3d88f821d5c9b75217bd4"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e91660f00c69d9d322032a82f8d426463d5eeb84cf614fb6ae3cb9eeb87a50"
+checksum = "dab196c3f5a7b09cc5fbf74770e5740b64bab9975233c6abdc329bdf4019946a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -442,41 +438,42 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2c525de1fe9c3e877a75826414246f5d9502712a11cb7bd02a27f916573b2b"
+checksum = "826c7e4282d6447c909486e365f1bc4cecc79285d710456c5cd801508cc2c5f6"
 dependencies = [
+ "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "salsa",
 ]
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8794b6c3c8b76bd04a59a73c490260fb6877ed1780b53d632a5fa6576335d33c"
+checksum = "7f568be682ded01d7ef471fa26c5beb72960b7f6052d5d3bfce30a88c38b5ed8"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
 ]
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a690a34a6b8ead64ee489e1ee0c0922bc11636259b2dffd64eb17921c1e8ee5"
+checksum = "ff25a29eae5b5502f3c8be11ecdea9e2c815ed348477f5cd796f3d1d03259dfc"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -488,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35834c45f88863183fe575b4de20935389cdfba2178b4c6b677bd4a022f841d6"
+checksum = "404eb42841fe77aba941ba329d737a6ea749e809632f096d18590b52f3211234"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -502,8 +499,8 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -513,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334b94f038c8c583002523b4b17adcedcac355f50f6a5b13373c2da58dcabc4c"
+checksum = "8c0cb8b895da0e7b092a0d772e2c985287ddb73e1d77bdbbf91ca4e61f4980ca"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -523,7 +520,7 @@ dependencies = [
  "cairo-lang-syntax-codegen",
  "cairo-lang-utils",
  "colored",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -534,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fa6b03b252d501c11e9ecfa5cee009191fce232aafd2b19da521de770a41bf"
+checksum = "418ba1fdc6fd03fa87c27faff28dd705c0f2945adaa2dfcd58638fd952b9119b"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -546,27 +543,28 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "indoc",
- "itertools 0.10.5",
+ "itertools 0.11.0",
+ "num-bigint",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f927a0a2a84d4fc0400fb6fcb8b7948863a497b194cef0952cef03107af3b087"
+checksum = "00e27ea16f824e01d28aa45ab8c1830838134247a43f57fc64fc62c60f6a4afa"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe69dc1e2f225964fc2b10637a8238bfa3b256fbe4b30cfcec31ad0270728e"
+checksum = "226e9876e268d91571e93d6872603258470c488da3b744edf65512c83557f41e"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -578,15 +576,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c119cc75a8ebaaffa07ca273915f6f002cdfe4899fb9f9678d4c95f281fe1c7"
+checksum = "801cabe3186da140d4f423c0384950c5939b82917ed1f571b48ce8cf05051137"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-std 0.3.0",
+ "ark-std",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-compiler",
@@ -600,10 +598,11 @@ dependencies = [
  "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "cairo-vm",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "keccak",
  "num-bigint",
  "num-integer",
@@ -614,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852484f7908ba89d1423b95dd465f1e66560793f2c6505a4a52fabffa2d82fa4"
+checksum = "6e223f688d25bf616e65b24132defb61bbe21ee526eb081eb29e3242958e8f40"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -627,7 +626,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -637,15 +636,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d80a2fbb25c54d71135e5603e8c3f2882e06b072ea1ebd6a3163e18a03e958f"
+checksum = "ee27bfcaa8e23086adc6287e07c15e0697e20f03adf761d021d6bc3f23538606"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
@@ -660,35 +659,37 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2b7a53b741b8f4a72aef86ed54a15974d6e5389fa91740225f33ef7bbaafcc"
+checksum = "f6cc3b21046e99c9ef8f7f181dabf117c6987f63efeb6e13e9305738cc70a357"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b101112c0e2a2101b3d1f66a300f06be1c183245e4a7de9739a9c8c564c60936"
+checksum = "9a2a5dcec285df1f59b3f0166251fd1103b3927fd229ea2ff981fdd451c917bd"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e34636a12e1fd393e9600aec5eac0c1b2ba3ddf4c5e47559bed3d14b81ac289"
+checksum = "7dd078441c13fbc26c8f792085f29790041169ccc85213cdcd437b09c3f2580e"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -703,8 +704,8 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "num-bigint",
  "salsa",
  "smol_str",
@@ -712,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7127b5b2f6c08e745f4332aac4bfefd007e2b94d7fc4581447ff1df48f63cf00"
+checksum = "abdaf6efb30b9b18eefffc4299e94a1716563155e3361ca0b0f1a12b8c6d20e5"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -722,9 +723,10 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
  "indoc",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.16",
@@ -732,10 +734,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "cairo-lang-starknet"
-version = "2.0.2"
+name = "cairo-lang-sierra-type-size"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2603ecb84110869254287c1c440f14ddc5dafa8b913ce0a66cda201564cad62"
+checksum = "70518ff6735aab928968d2dc60d47df15916714cc7ab9a92376735a63b4664aa"
+dependencies = [
+ "cairo-lang-sierra",
+ "cairo-lang-utils",
+]
+
+[[package]]
+name = "cairo-lang-starknet"
+version = "2.1.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79046b134371524cb939ca28d1dbd7edec718dd276388511a3c8e726f61f2dd7"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -757,8 +769,9 @@ dependencies = [
  "cairo-lang-utils",
  "convert_case",
  "genco",
+ "indent",
  "indoc",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-integer",
@@ -773,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02676702b628792b3437b391b87cb915480a111037d253a5e995d6a952f59515"
+checksum = "fa8af4bdabb3172bada1fb539ae3e0b99c7ba6a4d41712247a768f39c3e70a95"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -790,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955668038c14f09e16d708feb4416ab37b657e8d345c09f3c9d48c02a1dcb616"
+checksum = "10dec5db88b32a5d2916dfd900e925f52b8c16bf3fe9c7340f8b4d8cdc329861"
 dependencies = [
  "genco",
  "xshell",
@@ -800,12 +813,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.0.2"
+version = "2.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d38012d7e208df96a5cccb87122dfe8ae02eba2690d29a3d735979c9fb8dde7"
+checksum = "25468f2dfe544d7581ec3880724c29ff9e0459e1f16561fbc47cf0c8376976cd"
 dependencies = [
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.16",
@@ -866,27 +879,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "cairo-take_until_unbalanced"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c366b2a52b63db19fcc20a761ea37aa9f5fdce1723016c458e3990ef4fdf2c"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cairo-vm"
-version = "0.6.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f62944d2694a457cad49099504efbc6b91fa583cfc690e626d9db05bd925b1"
+checksum = "74af2798567c670dc274245ca135c4501100fc5639e91c83b8527d9e46a97249"
 dependencies = [
  "anyhow",
  "bincode",
  "bitvec",
  "cairo-felt",
- "cairo-take_until_unbalanced",
  "generic-array",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "hex",
  "keccak",
  "lazy_static",
@@ -897,14 +900,11 @@ dependencies = [
  "num-prime",
  "num-traits 0.2.16",
  "rand",
- "rand_core",
  "serde",
- "serde_bytes",
  "serde_json",
  "sha2",
  "sha3",
  "starknet-crypto 0.5.1",
- "thiserror",
  "thiserror-no-std",
 ]
 
@@ -1393,7 +1393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
- "serde",
 ]
 
 [[package]]
@@ -1401,6 +1400,11 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -1469,6 +1473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1497,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1559,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -1571,8 +1582,9 @@ dependencies = [
  "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1581,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -1999,9 +2011,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-clean"
-version = "0.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "peeking_take_while"
@@ -2027,6 +2039,12 @@ checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -2447,15 +2465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2494,15 @@ checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
  "serde",
 ]
 
@@ -2806,11 +2824,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2818,6 +2839,9 @@ name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2826,6 +2850,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ with-runtime = ["cairo-native-runtime"]
 
 [dependencies]
 bumpalo = "3.13"
-cairo-felt = "0.8"
-cairo-lang-compiler = "2.1.0-rc3"
-cairo-lang-defs = "2.1.0-rc3"
-cairo-lang-diagnostics = "2.1.0-rc3"
-cairo-lang-filesystem = "2.1.0-rc3"
-cairo-lang-lowering = "2.1.0-rc3"
-cairo-lang-sierra = "2.1.0-rc3"
-cairo-lang-sierra-generator = "2.1.0-rc3"
+cairo-felt = "0.8.5"
+cairo-lang-compiler = "2.1.0-rc4"
+cairo-lang-defs = "2.1.0-rc4"
+cairo-lang-diagnostics = "2.1.0-rc4"
+cairo-lang-filesystem = "2.1.0-rc4"
+cairo-lang-lowering = "2.1.0-rc4"
+cairo-lang-sierra = "2.1.0-rc4"
+cairo-lang-sierra-generator = "2.1.0-rc4"
 id-arena = "2.2"
 itertools = "0.11"
 lazy_static = "1.4"
@@ -51,13 +51,13 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"], optional = t
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
-cairo-lang-sierra-gas = "2.1.0-rc3"
-cairo-lang-sierra-ap-change = "2.1.0-rc3"
-cairo-lang-utils = "2.1.0-rc3"
+cairo-lang-sierra-gas = "2.1.0-rc4"
+cairo-lang-sierra-ap-change = "2.1.0-rc4"
+cairo-lang-utils = "2.1.0-rc4"
 
 [dev-dependencies]
-cairo-lang-runner = "2.1.0-rc3"
-cairo-lang-starknet = "2.1.0-rc3"
+cairo-lang-runner = "2.1.0-rc4"
+cairo-lang-starknet = "2.1.0-rc4"
 lambdaworks-math = "0.1"
 num-traits = "0.2"
 pretty_assertions = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ with-runtime = ["cairo-native-runtime"]
 
 [dependencies]
 bumpalo = "3.13.0"
-cairo-felt = "0.6.1"
-cairo-lang-compiler = "2.0.2"
-cairo-lang-defs = "2.0.2"
-cairo-lang-diagnostics = "2.0.2"
-cairo-lang-filesystem = "2.0.2"
-cairo-lang-lowering = "2.0.2"
-cairo-lang-sierra = "2.0.2"
-cairo-lang-sierra-generator = "2.0.2"
+cairo-felt = "0.8.2"
+cairo-lang-compiler = "2.1.0-rc3"
+cairo-lang-defs = "2.1.0-rc3"
+cairo-lang-diagnostics = "2.1.0-rc3"
+cairo-lang-filesystem = "2.1.0-rc3"
+cairo-lang-lowering = "2.1.0-rc3"
+cairo-lang-sierra = "2.1.0-rc3"
+cairo-lang-sierra-generator = "2.1.0-rc3"
 id-arena = "2.2.1"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
@@ -51,13 +51,13 @@ serde_json = { version = "1.0.103", features = ["arbitrary_precision"], optional
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
 ], optional = true }
-cairo-lang-sierra-gas = "2.0.2"
-cairo-lang-sierra-ap-change = "2.0.2"
-cairo-lang-utils = "2.0.2"
+cairo-lang-sierra-gas = "2.1.0-rc3"
+cairo-lang-sierra-ap-change = "2.1.0-rc3"
+cairo-lang-utils = "2.1.0-rc3"
 
 [dev-dependencies]
-cairo-lang-runner = "2.0.2"
-cairo-lang-starknet = "2.0.2"
+cairo-lang-runner = "2.1.0-rc3"
+cairo-lang-starknet = "2.1.0-rc3"
 lambdaworks-math = "0.1.3"
 num-traits = "0.2.16"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ serde_json = { version = "1.0.103", features = ["arbitrary_precision"], optional
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
 ], optional = true }
+cairo-lang-sierra-gas = "2.0.2"
+cairo-lang-sierra-ap-change = "2.0.2"
+cairo-lang-utils = "2.0.2"
 
 [dev-dependencies]
 cairo-lang-runner = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ build-cli = ["clap", "serde_json", "tracing-subscriber"]
 with-runtime = ["cairo-native-runtime"]
 
 [dependencies]
-bumpalo = "3.13.0"
-cairo-felt = "0.8.2"
+bumpalo = "3.13"
+cairo-felt = "0.8"
 cairo-lang-compiler = "2.1.0-rc3"
 cairo-lang-defs = "2.1.0-rc3"
 cairo-lang-diagnostics = "2.1.0-rc3"
@@ -33,22 +33,22 @@ cairo-lang-filesystem = "2.1.0-rc3"
 cairo-lang-lowering = "2.1.0-rc3"
 cairo-lang-sierra = "2.1.0-rc3"
 cairo-lang-sierra-generator = "2.1.0-rc3"
-id-arena = "2.2.1"
-itertools = "0.11.0"
-lazy_static = "1.4.0"
+id-arena = "2.2"
+itertools = "0.11"
+lazy_static = "1.4"
 libc = "0.2.147"
-melior = "0.9.6"
+melior = "0.9.9"
 mlir-sys = "0.2.0"
 num-bigint = "0.4.3"
-serde = { version = "1.0.171", features = ["derive"] }
-thiserror = "1.0.43"
-tracing = "0.1.37"
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+tracing = "0.1"
 
 # CLI dependencies
 cairo-native-runtime = { path = "runtime", optional = true }
-clap = { version = "4.3.12", features = ["derive"], optional = true }
-serde_json = { version = "1.0.103", features = ["arbitrary_precision"], optional = true }
-tracing-subscriber = { version = "0.3.17", features = [
+clap = { version = "4.3", features = ["derive"], optional = true }
+serde_json = { version = "1.0", features = ["arbitrary_precision"], optional = true }
+tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 cairo-lang-sierra-gas = "2.1.0-rc3"
@@ -58,15 +58,15 @@ cairo-lang-utils = "2.1.0-rc3"
 [dev-dependencies]
 cairo-lang-runner = "2.1.0-rc3"
 cairo-lang-starknet = "2.1.0-rc3"
-lambdaworks-math = "0.1.3"
-num-traits = "0.2.16"
-pretty_assertions = "1.4.0"
-proptest = "1.2.0"
-serde_json = { version = "1.0.103", features = ["arbitrary_precision"] }
-tempfile = "3.6.0"
+lambdaworks-math = "0.1"
+num-traits = "0.2"
+pretty_assertions = "1.4"
+proptest = "1.2"
+serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+tempfile = "3.6"
 
 [build-dependencies]
-cc = "1.0.79"
+cc = "1.0"
 
 [profile.optimized-dev]
 inherits = "dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . /cairo_native/
 
 # Fetch cairo corelibs
 RUN git clone --depth 1 \
-    --branch v2.1.0-rc3 \
+    --branch v2.1.0-rc4 \
     https://github.com/starkware-libs/cairo.git \
     starkware-cairo
 RUN cp -r starkware-cairo/corelib /cairo_native

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . /cairo_native/
 
 # Fetch cairo corelibs
 RUN git clone --depth 1 \
-    --branch v2.0.2 \
+    --branch v2.1.0-rc3 \
     https://github.com/starkware-libs/cairo.git \
     starkware-cairo
 RUN cp -r starkware-cairo/corelib /cairo_native

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -1,0 +1,429 @@
+#![feature(strict_provenance)]
+
+use cairo_felt::Felt252;
+use cairo_lang_compiler::CompilerConfig;
+use cairo_lang_sierra::{
+    extensions::core::{CoreLibfunc, CoreType},
+    program::Program,
+    program_registry::ProgramRegistry,
+};
+use cairo_native::{
+    metadata::{
+        gas::{GasMetadata, MetadataComputationConfig},
+        runtime_bindings::RuntimeBindingsMeta,
+        syscall_handler::SyscallHandlerMeta,
+        MetadataStorage,
+    },
+    starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
+    utils::register_runtime_symbols,
+};
+use melior::{
+    dialect::DialectRegistry,
+    ir::{Location, Module},
+    pass::{self, PassManager},
+    utility::{register_all_dialects, register_all_passes},
+    Context, ExecutionEngine,
+};
+use serde_json::json;
+use std::{io, path::Path};
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+#[derive(Debug)]
+struct SyscallHandler;
+
+impl StarkNetSyscallHandler for SyscallHandler {
+    fn get_block_hash(&self, block_number: u64) -> SyscallResult<cairo_felt::Felt252> {
+        println!("Called `get_block_hash({block_number})` from MLIR.");
+        Ok(Felt252::from_bytes_be(b"get_block_hash ok"))
+    }
+
+    fn get_execution_info(&self) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
+        println!("Called `get_execution_info()` from MLIR.");
+        Ok(ExecutionInfo {
+            block_info: BlockInfo {
+                block_number: 1234,
+                block_timestamp: 2345,
+                sequencer_address: 3456.into(),
+            },
+            tx_info: TxInfo {
+                version: 4567.into(),
+                account_contract_address: 5678.into(),
+                max_fee: 6789,
+                signature: vec![1248.into(), 2486.into()],
+                transaction_hash: 9876.into(),
+                chain_id: 8765.into(),
+                nonce: 7654.into(),
+            },
+            caller_address: 6543.into(),
+            contract_address: 5432.into(),
+            entry_point_selector: 4321.into(),
+        })
+    }
+
+    fn deploy(
+        &self,
+        class_hash: cairo_felt::Felt252,
+        contract_address_salt: cairo_felt::Felt252,
+        calldata: &[cairo_felt::Felt252],
+        deploy_from_zero: bool,
+    ) -> SyscallResult<(cairo_felt::Felt252, Vec<cairo_felt::Felt252>)> {
+        println!("Called `deploy({class_hash}, {contract_address_salt}, {calldata:?}, {deploy_from_zero})` from MLIR.");
+        Ok((
+            class_hash + contract_address_salt,
+            calldata.iter().map(|x| x + &Felt252::new(1)).collect(),
+        ))
+    }
+
+    fn replace_class(&self, class_hash: cairo_felt::Felt252) -> SyscallResult<()> {
+        println!("Called `replace_class({class_hash})` from MLIR.");
+        Ok(())
+    }
+
+    fn library_call(
+        &self,
+        class_hash: cairo_felt::Felt252,
+        function_selector: cairo_felt::Felt252,
+        calldata: &[cairo_felt::Felt252],
+    ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
+        println!(
+            "Called `library_call({class_hash}, {function_selector}, {calldata:?})` from MLIR."
+        );
+        Ok(calldata.iter().map(|x| x * &Felt252::new(3)).collect())
+    }
+
+    fn call_contract(
+        &self,
+        address: cairo_felt::Felt252,
+        entry_point_selector: cairo_felt::Felt252,
+        calldata: &[cairo_felt::Felt252],
+    ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
+        println!(
+            "Called `call_contract({address}, {entry_point_selector}, {calldata:?})` from MLIR."
+        );
+        Ok(calldata.iter().map(|x| x * &Felt252::new(3)).collect())
+    }
+
+    fn storage_read(
+        &self,
+        address_domain: u32,
+        address: cairo_felt::Felt252,
+    ) -> SyscallResult<cairo_felt::Felt252> {
+        println!("Called `storage_read({address_domain}, {address})` from MLIR.");
+        Ok(address * &Felt252::new(3))
+    }
+
+    fn storage_write(
+        &self,
+        address_domain: u32,
+        address: cairo_felt::Felt252,
+        value: cairo_felt::Felt252,
+    ) -> SyscallResult<()> {
+        println!("Called `storage_write({address_domain}, {address}, {value})` from MLIR.");
+        Ok(())
+    }
+
+    fn emit_event(
+        &self,
+        keys: &[cairo_felt::Felt252],
+        data: &[cairo_felt::Felt252],
+    ) -> SyscallResult<()> {
+        println!("Called `emit_event({keys:?}, {data:?})` from MLIR.");
+        Ok(())
+    }
+
+    fn send_message_to_l1(
+        &self,
+        to_address: cairo_felt::Felt252,
+        payload: &[cairo_felt::Felt252],
+    ) -> SyscallResult<()> {
+        println!("Called `send_message_to_l1({to_address}, {payload:?})` from MLIR.");
+        Ok(())
+    }
+
+    fn keccak(&self, input: &[u64]) -> SyscallResult<cairo_native::starknet::U256> {
+        println!("Called `keccak({input:?})` from MLIR.");
+        Ok(U256(Felt252::from(1234567890).to_le_bytes()))
+    }
+
+    fn secp256k1_add(
+        &self,
+        _p0: cairo_native::starknet::Secp256k1Point,
+        _p1: cairo_native::starknet::Secp256k1Point,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256k1_get_point_from_x(
+        &self,
+        _x: cairo_native::starknet::U256,
+        _y_parity: bool,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256k1_get_xy(
+        &self,
+        _p: cairo_native::starknet::Secp256k1Point,
+    ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
+        todo!()
+    }
+
+    fn secp256k1_mul(
+        &self,
+        _p: cairo_native::starknet::Secp256k1Point,
+        _m: cairo_native::starknet::U256,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256k1_new(
+        &self,
+        _x: cairo_native::starknet::U256,
+        _y: cairo_native::starknet::U256,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256r1_add(
+        &self,
+        _p0: cairo_native::starknet::Secp256k1Point,
+        _p1: cairo_native::starknet::Secp256k1Point,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256r1_get_point_from_x(
+        &self,
+        _x: cairo_native::starknet::U256,
+        _y_parity: bool,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256r1_get_xy(
+        &self,
+        _p: cairo_native::starknet::Secp256k1Point,
+    ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
+        todo!()
+    }
+
+    fn secp256r1_mul(
+        &self,
+        _p: cairo_native::starknet::Secp256k1Point,
+        _m: cairo_native::starknet::U256,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn secp256r1_new(
+        &self,
+        _x: cairo_native::starknet::U256,
+        _y: cairo_native::starknet::U256,
+    ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
+        todo!()
+    }
+
+    fn pop_log(&self) {
+        todo!()
+    }
+
+    fn set_account_contract_address(&self, _contract_address: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_block_number(&self, _block_number: u64) {
+        todo!()
+    }
+
+    fn set_block_timestamp(&self, _block_timestamp: u64) {
+        todo!()
+    }
+
+    fn set_caller_address(&self, _address: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_chain_id(&self, _chain_id: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_contract_address(&self, _address: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_max_fee(&self, _max_fee: u128) {
+        todo!()
+    }
+
+    fn set_nonce(&self, _nonce: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_sequencer_address(&self, _address: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_signature(&self, _signature: &[cairo_felt::Felt252]) {
+        todo!()
+    }
+
+    fn set_transaction_hash(&self, _transaction_hash: cairo_felt::Felt252) {
+        todo!()
+    }
+
+    fn set_version(&self, _version: cairo_felt::Felt252) {
+        todo!()
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Configure logging and error handling.
+    tracing::subscriber::set_global_default(
+        FmtSubscriber::builder()
+            .with_env_filter(EnvFilter::from_default_env())
+            .finish(),
+    )?;
+
+    // FIXME: Remove when cairo adds an easy to use API for setting the corelibs path.
+    std::env::set_var(
+        "CARGO_MANIFEST_DIR",
+        format!("{}/a", std::env::var("CARGO_MANIFEST_DIR").unwrap()),
+    );
+
+    let program = cairo_lang_sierra::ProgramParser::new()
+        .parse(include_str!("../programs/erc20.sierra"))
+        .unwrap();
+
+    let entry_point = match program.funcs.iter().find(|x| {
+        x.id.debug_name.as_deref() == Some("erc20::erc20::erc_20::__constructor::constructor")
+    }) {
+        Some(x) => x,
+        None => {
+            // TODO: Use a proper error.
+            eprintln!("Entry point `erc20::erc20::erc_20::__constructor::constructor` not found in program.");
+            return Ok(());
+        }
+    };
+
+    // Initialize MLIR.
+    let context = Context::new();
+    context.append_dialect_registry(&{
+        let registry = DialectRegistry::new();
+        register_all_dialects(&registry);
+        registry
+    });
+    context.load_all_available_dialects();
+
+    register_all_passes();
+
+    // Compile the program.
+    let mut module = Module::new(Location::unknown(&context));
+    let mut metadata = MetadataStorage::new();
+    let registry = ProgramRegistry::<CoreType, CoreLibfunc>::new(&program)?;
+
+    // Make the runtime library available.
+    metadata.insert(RuntimeBindingsMeta::default()).unwrap();
+
+    // Make the Starknet syscall handler available.
+    metadata
+        .insert(SyscallHandlerMeta::new(&SyscallHandler))
+        .unwrap();
+
+    // Gas
+    let required_initial_gas = if program
+        .type_declarations
+        .iter()
+        .any(|decl| decl.long_id.generic_id.0.as_str() == "GasBuiltin")
+    {
+        let gas_metadata = GasMetadata::new(&program, MetadataComputationConfig::default());
+
+        let required_initial_gas = { gas_metadata.get_initial_required_gas(&entry_point.id) };
+        metadata.insert(gas_metadata).unwrap();
+        required_initial_gas
+    } else {
+        None
+    };
+
+    cairo_native::compile::<CoreType, CoreLibfunc>(
+        &context,
+        &module,
+        &program,
+        &registry,
+        &mut metadata,
+        None,
+    )?;
+
+    // Lower to LLVM.
+    let pass_manager = PassManager::new(&context);
+    pass_manager.enable_verifier(true);
+    pass_manager.add_pass(pass::transform::create_canonicalizer());
+
+    pass_manager.add_pass(pass::conversion::create_scf_to_control_flow());
+
+    pass_manager.add_pass(pass::conversion::create_arith_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_control_flow_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_func_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_index_to_llvm_pass());
+    pass_manager.add_pass(pass::conversion::create_mem_ref_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_reconcile_unrealized_casts());
+
+    pass_manager.run(&mut module)?;
+
+    // Create the JIT engine.
+    let engine = ExecutionEngine::new(&module, 3, &[], false);
+
+    #[cfg(feature = "with-runtime")]
+    register_runtime_symbols(&engine);
+
+    /*
+    erc20::erc20::erc_20::__external::get_name@0([0]: RangeCheck, [1]: GasBuiltin, [2]: System, [3]: core::array::Span::<core::felt252>) -> (RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::get_symbol@122([0]: RangeCheck, [1]: GasBuiltin, [2]: System, [3]: core::array::Span::<core::felt252>) -> (RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::get_decimals@244([0]: RangeCheck, [1]: GasBuiltin, [2]: System, [3]: core::array::Span::<core::felt252>) -> (RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::get_total_supply@366([0]: RangeCheck, [1]: GasBuiltin, [2]: System, [3]: core::array::Span::<core::felt252>) -> (RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::balance_of@488([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::allowance@641([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::transfer@820([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::transfer_from@991([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::approve@1189([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::increase_allowance@1360([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__external::decrease_allowance@1531([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+    erc20::erc20::erc_20::__constructor::constructor@1702([0]: Pedersen, [1]: RangeCheck, [2]: GasBuiltin, [3]: System, [4]: core::array::Span::<core::felt252>) -> (Pedersen, RangeCheck, GasBuiltin, System, core::panics::PanicResult::<(core::array::Span::<core::felt252>,)>);
+
+     */
+
+    let params_input = json!([
+        null,     // pedersen
+        null,     // range check
+        u64::MAX, // gas
+        metadata
+            .get::<SyscallHandlerMeta>()
+            .unwrap()
+            .as_ptr()
+            .addr(), // system
+        [
+            // contract state
+            [1, 0, 0, 0, 0, 0, 0, 0],
+            [2, 0, 0, 0, 0, 0, 0, 0],
+            [3, 0, 0, 0, 0, 0, 0, 0],
+            [4, 0, 0, 0, 0, 0, 0, 0],
+            [5, 0, 0, 0, 0, 0, 0, 0],
+            [6, 0, 0, 0, 0, 0, 0, 0],
+            [7, 0, 0, 0, 0, 0, 0, 0],
+            [8, 0, 0, 0, 0, 0, 0, 0],
+            [9, 0, 0, 0, 0, 0, 0, 0],
+        ]
+    ]);
+
+    cairo_native::execute(
+        &engine,
+        &registry,
+        &entry_point.id,
+        params_input,
+        &mut serde_json::Serializer::pretty(io::stdout()),
+        required_initial_gas,
+    )
+    .unwrap();
+    println!();
+
+    Ok(())
+}

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -379,6 +379,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &entry_point.id,
         params_input,
         &mut serde_json::Serializer::pretty(io::stdout()),
+        None, // TODO: Add gas
     )
     .unwrap();
     println!();

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -8,7 +8,10 @@ use cairo_lang_sierra::{
 };
 use cairo_native::{
     metadata::{
-        runtime_bindings::RuntimeBindingsMeta, syscall_handler::SyscallHandlerMeta, MetadataStorage,
+        gas::{GasMetadata, MetadataComputationConfig},
+        runtime_bindings::RuntimeBindingsMeta,
+        syscall_handler::SyscallHandlerMeta,
+        MetadataStorage,
     },
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
     utils::register_runtime_symbols,
@@ -332,6 +335,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .insert(SyscallHandlerMeta::new(&SyscallHandler))
         .unwrap();
 
+    // Gas
+    let required_initial_gas = if program
+        .type_declarations
+        .iter()
+        .any(|decl| decl.long_id.generic_id.0.as_str() == "GasBuiltin")
+    {
+        let gas_metadata = GasMetadata::new(&program, MetadataComputationConfig::default());
+
+        let required_initial_gas = { gas_metadata.get_initial_required_gas(&entry_point.id) };
+        metadata.insert(gas_metadata).unwrap();
+        required_initial_gas
+    } else {
+        None
+    };
+
     cairo_native::compile::<CoreType, CoreLibfunc>(
         &context,
         &module,
@@ -379,7 +397,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &entry_point.id,
         params_input,
         &mut serde_json::Serializer::pretty(io::stdout()),
-        None, // TODO: Add gas
+        required_initial_gas,
     )
     .unwrap();
     println!();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-cairo-felt = "0.8.2"
+cairo-felt = "0.8"
 cairo-lang-runner = "2.1.0-rc3"
-libc = "0.2.147"
-starknet-crypto = "0.6.0"
-starknet-curve = "0.4.0"
+libc = "0.2"
+starknet-crypto = "0.6"
+starknet-curve = "0.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-cairo-felt = "0.6.1"
-cairo-lang-runner = "2.0.2"
+cairo-felt = "0.8.2"
+cairo-lang-runner = "2.1.0-rc3"
 libc = "0.2.147"
 starknet-crypto = "0.6.0"
 starknet-curve = "0.4.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-cairo-felt = "0.8"
-cairo-lang-runner = "2.1.0-rc3"
+cairo-felt = "0.8.5"
+cairo-lang-runner = "2.1.0-rc4"
 libc = "0.2"
 starknet-crypto = "0.6"
 starknet-curve = "0.4"

--- a/scripts/bench-hyperfine.sh
+++ b/scripts/bench-hyperfine.sh
@@ -89,7 +89,7 @@ run_bench() {
         --shell=none \
         --warmup 3 \
         --export-markdown "$OUTPUT_DIR/$base_name.md" \
-        "$CAIRO_RUN --available-gas 18446744073709551615 $base_path.cairo" \
+        "$CAIRO_RUN --available-gas 18446744073709551615 -s $base_path.cairo" \
         "echo '[null, 18446744073709551615]' | $JIT_CLI $base_path.cairo $base_name::$base_name::main --inputs -" \
         "$OUTPUT_DIR/$base_name" \
         "$OUTPUT_DIR/$base_name-march-native" \

--- a/scripts/fetch-corelibs.sh
+++ b/scripts/fetch-corelibs.sh
@@ -5,7 +5,7 @@ set -e
 
 git clone \
     --depth 1 \
-    --branch v2.0.2 \
+    --branch v2.1.0-rc3 \
     https://github.com/starkware-libs/cairo.git \
     starkware-cairo
 

--- a/scripts/fetch-corelibs.sh
+++ b/scripts/fetch-corelibs.sh
@@ -5,7 +5,7 @@ set -e
 
 git clone \
     --depth 1 \
-    --branch v2.1.0-rc3 \
+    --branch v2.1.0-rc4 \
     https://github.com/starkware-libs/cairo.git \
     starkware-cairo
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -51,7 +51,7 @@ use crate::{
         CompileError,
     },
     libfuncs::{BranchArg, LibfuncBuilder, LibfuncHelper},
-    metadata::{tail_recursion::TailRecursionMeta, MetadataStorage},
+    metadata::{gas::GasMetadata, tail_recursion::TailRecursionMeta, MetadataStorage},
     types::TypeBuilder,
     utils::generate_function_name,
 };
@@ -68,6 +68,7 @@ use melior::{
     dialect::{arith::CmpiPredicate, cf, func, index, memref},
     ir::{
         attribute::{IntegerAttribute, StringAttribute, TypeAttribute},
+        operation,
         r#type::{FunctionType, MemRefType},
         Attribute, Block, BlockRef, Identifier, Location, Module, Region, Type, Value,
     },

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -8,6 +8,7 @@ use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_diagnostics::DiagnosticAdded;
 use cairo_lang_filesystem::{db::FilesGroup, ids::FileLongId};
+use cairo_lang_lowering::ids::LocationId;
 use cairo_lang_sierra::{
     ids::{ConcreteLibfuncId, ConcreteTypeId, FunctionId},
     program::{Program, StatementIdx},
@@ -24,7 +25,7 @@ mod type_declarations;
 pub struct DebugInfo {
     pub type_declarations: HashMap<ConcreteTypeId, StableLocation>,
     pub libfunc_declarations: HashMap<ConcreteLibfuncId, StableLocation>,
-    pub statements: HashMap<StatementIdx, StableLocation>,
+    pub statements: HashMap<StatementIdx, LocationId>,
     pub funcs: HashMap<FunctionId, StableLocation>,
 }
 
@@ -103,10 +104,14 @@ impl<'c> DebugLocations<'c> {
         let statements = debug_info
             .statements
             .iter()
-            .map(|(statement_idx, stable_loc)| {
+            .map(|(statement_idx, location_id)| {
                 (
                     *statement_idx,
-                    extract_location_from_stable_loc(context, db, *stable_loc),
+                    extract_location_from_stable_loc(
+                        context,
+                        db,
+                        location_id.get(db).stable_location,
+                    ),
                 )
             })
             .collect();

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -6,7 +6,7 @@ use crate::{
     libfuncs::LibfuncBuilder,
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     types::TypeBuilder,
-    utils::register_runtime_symbols,
+    utils,
     values::ValueBuilder,
 };
 use cairo_lang_sierra::{
@@ -167,17 +167,16 @@ where
     let engine = ExecutionEngine::new(&module, 3, &[], false);
 
     #[cfg(feature = "with-runtime")]
-    register_runtime_symbols(&engine);
+    utils::register_runtime_symbols(&engine);
 
     // Execute
     crate::execute::<TType, TLibfunc, D, S>(
-        todo!(),
         &engine,
         &registry,
         function_id,
         params,
         returns,
-        todo!(),
+        None, // TODO: pass gas
     )
     .unwrap_or_else(|e| match &*e {
         crate::error::jit_engine::ErrorImpl::DeserializeError(_) => {

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -170,24 +170,32 @@ where
     register_runtime_symbols(&engine);
 
     // Execute
-    crate::execute::<TType, TLibfunc, D, S>(&engine, &registry, function_id, params, returns)
-        .unwrap_or_else(|e| match &*e {
-            crate::error::jit_engine::ErrorImpl::DeserializeError(_) => {
-                panic!(
-                    "Expected inputs with signature: ({})",
-                    registry
-                        .get_function(function_id)
-                        .unwrap()
-                        .signature
-                        .param_types
-                        .iter()
-                        .map(ToString::to_string)
-                        .intersperse_with(|| ", ".to_string())
-                        .collect::<String>()
-                )
-            }
-            e => panic!("{:?}", e),
-        });
+    crate::execute::<TType, TLibfunc, D, S>(
+        todo!(),
+        &engine,
+        &registry,
+        function_id,
+        params,
+        returns,
+        todo!(),
+    )
+    .unwrap_or_else(|e| match &*e {
+        crate::error::jit_engine::ErrorImpl::DeserializeError(_) => {
+            panic!(
+                "Expected inputs with signature: ({})",
+                registry
+                    .get_function(function_id)
+                    .unwrap()
+                    .signature
+                    .param_types
+                    .iter()
+                    .map(ToString::to_string)
+                    .intersperse_with(|| ", ".to_string())
+                    .collect::<String>()
+            )
+        }
+        e => panic!("{:?}", e),
+    });
 
     Ok(())
 }

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -1,0 +1,100 @@
+use cairo_lang_sierra::{
+    extensions::gas::CostTokenType,
+    ids::FunctionId,
+    program::{Program, StatementIdx},
+};
+use cairo_lang_sierra_ap_change::{ap_change_info::ApChangeInfo, calc_ap_changes};
+use cairo_lang_sierra_gas::{calc_gas_postcost_info, compute_precost_info, gas_info::GasInfo};
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+
+pub struct GasMetadata {
+    pub ap_change_info: ApChangeInfo,
+    pub gas_info: GasInfo,
+    pub available_gas: Option<usize>,
+}
+
+/// Configuration for metadata computation.
+#[derive(Default)]
+pub struct MetadataComputationConfig {
+    pub function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>>,
+}
+
+impl GasMetadata {
+    pub fn new(
+        program: &Program,
+        config: MetadataComputationConfig,
+        available_gas: Option<usize>,
+    ) -> GasMetadata {
+        let pre_gas_info = compute_precost_info(program).unwrap();
+
+        let ap_change_info = calc_ap_changes(program, |idx, token_type| {
+            pre_gas_info.variable_values[(idx, token_type)] as usize
+        })
+        .unwrap();
+
+        let post_function_set_costs = config
+            .function_set_costs
+            .iter()
+            .map(|(func, costs)| {
+                (
+                    func.clone(),
+                    [CostTokenType::Const]
+                        .iter()
+                        .filter_map(|token| costs.get(token).map(|v| (*token, *v)))
+                        .collect(),
+                )
+            })
+            .collect();
+        let post_gas_info =
+            calc_gas_postcost_info(program, post_function_set_costs, &pre_gas_info, |idx| {
+                ap_change_info
+                    .variable_values
+                    .get(&idx)
+                    .copied()
+                    .unwrap_or_default()
+            })
+            .unwrap();
+
+        GasMetadata {
+            ap_change_info,
+            gas_info: pre_gas_info.combine(post_gas_info),
+            available_gas,
+        }
+    }
+
+    // Compute the initial gas required by the function.
+    pub fn get_initial_required_gas(&self, func: &FunctionId) -> usize {
+        // In case we don't have any costs - it means no equations were solved - so the gas builtin
+        // is irrelevant, and we can return any value.
+        if self.gas_info.function_costs.is_empty() {
+            return 0;
+        }
+
+        // Compute the initial gas required by the function.
+        let required_gas = self.gas_info.function_costs[func.clone()]
+            .iter()
+            .map(|(cost_token_type, val)| {
+                let val_usize: usize = (*val).try_into().unwrap();
+                let token_cost = if *cost_token_type == CostTokenType::Const {
+                    1
+                } else {
+                    10_000 // DUMMY_BUILTIN_GAS_COST
+                };
+                val_usize * token_cost
+            })
+            .sum();
+
+        required_gas
+    }
+
+    pub fn get_gas_cost_for_statement(
+        &self,
+        idx: StatementIdx,
+        cost_type: CostTokenType,
+    ) -> Option<i64> {
+        self.gas_info
+            .variable_values
+            .get(&(idx, cost_type))
+            .copied()
+    }
+}

--- a/src/jit_runner.rs
+++ b/src/jit_runner.rs
@@ -5,6 +5,7 @@ use crate::{
         jit_engine::{make_deserializer_error, make_serializer_error, make_type_builder_error},
         JitRunnerError,
     },
+    gas::GasMetadata,
     libfuncs::LibfuncBuilder,
     types::TypeBuilder,
     utils::generate_function_name,
@@ -14,6 +15,7 @@ use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{GenericLibfunc, GenericType},
     ids::{ConcreteTypeId, FunctionId},
+    program::Program,
     program_registry::ProgramRegistry,
 };
 use melior::ExecutionEngine;
@@ -34,11 +36,13 @@ use std::{alloc::Layout, fmt, iter::once, ptr::NonNull};
 /// [`Serializer`] respectively. This method provides an easy way to process the values while also
 /// not requiring recompilation every time the function's signature changes.
 pub fn execute<'de, TType, TLibfunc, D, S>(
+    program: &Program,
     engine: &ExecutionEngine,
     registry: &ProgramRegistry<TType, TLibfunc>,
     function_id: &FunctionId,
     params: D,
     returns: S,
+    gas_metadata: &GasMetadata,
 ) -> Result<S::Ok, JitRunnerError<'de, TType, TLibfunc, D, S>>
 where
     TType: GenericType,

--- a/src/jit_runner.rs
+++ b/src/jit_runner.rs
@@ -2,11 +2,14 @@
 
 use crate::{
     error::{
-        jit_engine::{make_deserializer_error, make_serializer_error, make_type_builder_error},
+        jit_engine::{
+            make_deserializer_error, make_insuficient_gas_error, make_serializer_error,
+            make_type_builder_error,
+        },
         JitRunnerError,
     },
-    gas::GasMetadata,
     libfuncs::LibfuncBuilder,
+    metadata::gas::GasMetadata,
     types::TypeBuilder,
     utils::generate_function_name,
     values::{ValueBuilder, ValueDeserializer, ValueSerializer},
@@ -36,13 +39,12 @@ use std::{alloc::Layout, fmt, iter::once, ptr::NonNull};
 /// [`Serializer`] respectively. This method provides an easy way to process the values while also
 /// not requiring recompilation every time the function's signature changes.
 pub fn execute<'de, TType, TLibfunc, D, S>(
-    program: &Program,
     engine: &ExecutionEngine,
     registry: &ProgramRegistry<TType, TLibfunc>,
     function_id: &FunctionId,
     params: D,
     returns: S,
-    gas_metadata: &GasMetadata,
+    required_initial_gas: Option<u64>,
 ) -> Result<S::Ok, JitRunnerError<'de, TType, TLibfunc, D, S>>
 where
     TType: GenericType,
@@ -62,6 +64,30 @@ where
             params: &entry_point.signature.param_types,
         })
         .map_err(make_deserializer_error)?;
+
+    // If program has a required initial gas, check if a gas builting exists
+    // and check if the passed gas was enough, if so, deduct the required gas before execution.
+    if let Some(required_initial_gas) = required_initial_gas {
+        for (id, param) in entry_point.signature.param_types.iter().zip(params.iter()) {
+            if id.debug_name.as_deref() == Some("GasBuiltin") {
+                let gas_builtin = unsafe { *param.cast::<u64>().as_ptr() };
+
+                if gas_builtin < required_initial_gas {
+                    return Err(make_insuficient_gas_error(
+                        required_initial_gas,
+                        gas_builtin,
+                    ));
+                }
+
+                let starting_gas = gas_builtin - required_initial_gas;
+
+                unsafe {
+                    // update gas with the starting gas
+                    param.cast::<u64>().as_ptr().write(starting_gas);
+                }
+            }
+        }
+    }
 
     let mut complex_results = entry_point.signature.ret_types.len() > 1;
     let (layout, offsets) = entry_point.signature.ret_types.iter().try_fold(

--- a/src/jit_runner.rs
+++ b/src/jit_runner.rs
@@ -9,7 +9,6 @@ use crate::{
         JitRunnerError,
     },
     libfuncs::LibfuncBuilder,
-    metadata::gas::GasMetadata,
     types::TypeBuilder,
     utils::generate_function_name,
     values::{ValueBuilder, ValueDeserializer, ValueSerializer},
@@ -18,7 +17,6 @@ use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{GenericLibfunc, GenericType},
     ids::{ConcreteTypeId, FunctionId},
-    program::Program,
     program_registry::ProgramRegistry,
 };
 use melior::ExecutionEngine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,7 @@ pub mod debug_info;
 pub mod easy;
 pub mod error;
 mod ffi;
+pub mod gas;
 mod jit_runner;
 pub mod libfuncs;
 pub mod metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,6 @@ pub mod debug_info;
 pub mod easy;
 pub mod error;
 mod ffi;
-pub mod gas;
 mod jit_runner;
 pub mod libfuncs;
 pub mod metadata;

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -109,9 +109,6 @@ where
             Self::Array(selector) => self::array::build(
                 context, registry, entry, location, helper, metadata, selector,
             ),
-            Self::Bitwise(info) => {
-                self::bitwise::build(context, registry, entry, location, helper, metadata, info)
-            }
             Self::BranchAlign(info) => self::branch_align::build(
                 context, registry, entry, location, helper, metadata, info,
             ),
@@ -198,6 +195,12 @@ where
             Self::SnapshotTake(info) => self::snapshot_take::build(
                 context, registry, entry, location, helper, metadata, info,
             ),
+            CoreConcreteLibfunc::Sint8(_) => todo!(),
+            CoreConcreteLibfunc::Sint16(_) => todo!(),
+            CoreConcreteLibfunc::Sint32(_) => todo!(),
+            CoreConcreteLibfunc::Sint64(_) => todo!(),
+            CoreConcreteLibfunc::Sint128(_) => todo!(),
+            CoreConcreteLibfunc::Bytes31(_) => todo!(),
         }
     }
 

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -87,7 +87,7 @@ pub fn build_squash<'ctx, 'this, TType, TLibfunc>(
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    _metadata: &mut MetadataStorage,
+    _metadata: &MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()>
 where
@@ -126,8 +126,8 @@ mod test {
             }
         );
 
-        let result = run_program(&program, "run_test", json!([(), (), 0]));
-        assert_eq!(result, json!([null, null, 0, []]));
+        let result = run_program(&program, "run_test", json!([(), (), 600_000]));
+        assert_eq!(result, json!([null, null, 590090, []]));
     }
 
     #[test]
@@ -141,8 +141,8 @@ mod test {
                 dict.get(2)
             }
         );
-        let result = run_program(&program, "run_test", json!([(), (), 0]));
-        assert_eq!(result, json!([null, null, 0, 1]));
+        let result = run_program(&program, "run_test", json!([(), (), 600_000]));
+        assert_eq!(result, json!([null, null, 578950, 1]));
     }
     #[test]
     fn run_dict_insert_ret_dict() {

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -380,8 +380,8 @@ mod test {
             }
         );
 
-        let result = run_program(&program, "run_test", json!([(), (), 0]));
-        assert_eq!(result, json!([null, null, 0, 1]));
+        let result = run_program(&program, "run_test", json!([(), (), 600_000]));
+        assert_eq!(result, json!([null, null, 578950, 1])); // 583000 ?
     }
 
     #[test]

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -26,7 +26,7 @@ use melior::{
     ir::{
         attribute::{IntegerAttribute, StringAttribute},
         r#type::IntegerType,
-        Block, Location, ValueLike,
+        Attribute, Block, Location, ValueLike,
     },
     Context,
 };
@@ -149,14 +149,11 @@ where
 
     let cost = metadata.get::<GasCost>().and_then(|x| x.0);
 
+    let u64_type: melior::ir::Type = IntegerType::new(context, 64).into();
     let gas_cost_val = entry
         .append_operation(arith::constant(
             context,
-            IntegerAttribute::new(
-                cost.unwrap_or(0) as i64,
-                IntegerType::new(context, 64).into(),
-            )
-            .into(),
+            Attribute::parse(context, &format!("{} : {}", cost.unwrap_or(0), u64_type)).unwrap(),
             location,
         ))
         .result(0)?

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -226,6 +226,7 @@ mod test {
 
     #[test]
     fn run_withdraw_gas() {
+        #[rustfmt::skip]
         let program = load_cairo!(
             use gas::withdraw_gas;
 
@@ -240,7 +241,7 @@ mod test {
                     match withdraw_gas() {
                         Option::Some(()) => {
                             i = i - 1;
-                        }
+                        },
                         Option::None(()) => {
                             break;
                         }

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -62,8 +62,8 @@ pub fn build_withdraw_gas<'ctx, 'this, TType, TLibfunc>(
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    _metadata: &mut MetadataStorage,
-    _info: &SignatureOnlyConcreteLibfunc,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -218,3 +218,39 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use crate::utils::test::{load_cairo, run_program};
+    use serde_json::json;
+
+    #[test]
+    fn run_withdraw_gas() {
+        let program = load_cairo!(
+            use gas::withdraw_gas;
+
+            fn run_test() {
+                let mut i = 10;
+
+                loop {
+                    if i == 0 {
+                        break;
+                    }
+
+                    match withdraw_gas() {
+                        Option::Some(()) => {
+                            i = i - 1;
+                        }
+                        Option::None(()) => {
+                            break;
+                        }
+                    };
+                    i = i - 1;
+                }
+            }
+        );
+
+        let result = run_program(&program, "run_test", json!([null, 60000]));
+        assert_eq!(result, json!([null, 44260, [0, [[]]]]));
+    }
+}

--- a/src/libfuncs/uint128.rs
+++ b/src/libfuncs/uint128.rs
@@ -13,9 +13,9 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         int::{
-            unsigned::{UintConstConcreteLibfunc, UintOperationConcreteLibfunc},
+            unsigned::UintOperationConcreteLibfunc,
             unsigned128::{Uint128Concrete, Uint128Traits},
-            IntOperator,
+            IntConstConcreteLibfunc, IntOperator,
         },
         lib_func::SignatureOnlyConcreteLibfunc,
         ConcreteLibfunc, GenericLibfunc, GenericType,
@@ -86,6 +86,9 @@ where
         Uint128Concrete::ToFelt252(info) => {
             build_to_felt252(context, registry, entry, location, helper, metadata, info)
         }
+        Uint128Concrete::Bitwise(info) => {
+            super::bitwise::build(context, registry, entry, location, helper, metadata, info)
+        }
     }
 }
 
@@ -128,7 +131,7 @@ pub fn build_const<'ctx, 'this, TType, TLibfunc>(
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &UintConstConcreteLibfunc<Uint128Traits>,
+    info: &IntConstConcreteLibfunc<Uint128Traits>,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/libfuncs/uint16.rs
+++ b/src/libfuncs/uint16.rs
@@ -12,11 +12,8 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         int::{
-            unsigned::{
-                Uint16Concrete, Uint16Traits, UintConcrete, UintConstConcreteLibfunc,
-                UintOperationConcreteLibfunc,
-            },
-            IntOperator,
+            unsigned::{Uint16Concrete, Uint16Traits, UintConcrete, UintOperationConcreteLibfunc},
+            IntConstConcreteLibfunc, IntOperator,
         },
         lib_func::SignatureOnlyConcreteLibfunc,
         ConcreteLibfunc, GenericLibfunc, GenericType,
@@ -79,6 +76,9 @@ where
         UintConcrete::WideMul(info) => {
             build_widemul(context, registry, entry, location, helper, metadata, info)
         }
+        UintConcrete::Bitwise(info) => {
+            super::bitwise::build(context, registry, entry, location, helper, metadata, info)
+        }
     }
 }
 
@@ -90,7 +90,7 @@ pub fn build_const<'ctx, 'this, TType, TLibfunc>(
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &UintConstConcreteLibfunc<Uint16Traits>,
+    info: &IntConstConcreteLibfunc<Uint16Traits>,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/libfuncs/uint32.rs
+++ b/src/libfuncs/uint32.rs
@@ -12,11 +12,8 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         int::{
-            unsigned::{
-                Uint32Concrete, Uint32Traits, UintConcrete, UintConstConcreteLibfunc,
-                UintOperationConcreteLibfunc,
-            },
-            IntOperator,
+            unsigned::{Uint32Concrete, Uint32Traits, UintConcrete, UintOperationConcreteLibfunc},
+            IntConstConcreteLibfunc, IntOperator,
         },
         lib_func::SignatureOnlyConcreteLibfunc,
         ConcreteLibfunc, GenericLibfunc, GenericType,
@@ -79,6 +76,9 @@ where
         UintConcrete::WideMul(info) => {
             build_widemul(context, registry, entry, location, helper, metadata, info)
         }
+        UintConcrete::Bitwise(info) => {
+            super::bitwise::build(context, registry, entry, location, helper, metadata, info)
+        }
     }
 }
 
@@ -90,7 +90,7 @@ pub fn build_const<'ctx, 'this, TType, TLibfunc>(
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &UintConstConcreteLibfunc<Uint32Traits>,
+    info: &IntConstConcreteLibfunc<Uint32Traits>,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/libfuncs/uint64.rs
+++ b/src/libfuncs/uint64.rs
@@ -12,11 +12,8 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         int::{
-            unsigned::{
-                Uint64Concrete, Uint64Traits, UintConcrete, UintConstConcreteLibfunc,
-                UintOperationConcreteLibfunc,
-            },
-            IntOperator,
+            unsigned::{Uint64Concrete, Uint64Traits, UintConcrete, UintOperationConcreteLibfunc},
+            IntConstConcreteLibfunc, IntOperator,
         },
         lib_func::SignatureOnlyConcreteLibfunc,
         ConcreteLibfunc, GenericLibfunc, GenericType,
@@ -79,6 +76,9 @@ where
         UintConcrete::WideMul(info) => {
             build_widemul(context, registry, entry, location, helper, metadata, info)
         }
+        UintConcrete::Bitwise(info) => {
+            super::bitwise::build(context, registry, entry, location, helper, metadata, info)
+        }
     }
 }
 
@@ -90,7 +90,7 @@ pub fn build_const<'ctx, 'this, TType, TLibfunc>(
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &UintConstConcreteLibfunc<Uint64Traits>,
+    info: &IntConstConcreteLibfunc<Uint64Traits>,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -12,11 +12,8 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         int::{
-            unsigned::{
-                Uint8Concrete, Uint8Traits, UintConcrete, UintConstConcreteLibfunc,
-                UintOperationConcreteLibfunc,
-            },
-            IntOperator,
+            unsigned::{Uint8Concrete, Uint8Traits, UintConcrete, UintOperationConcreteLibfunc},
+            IntConstConcreteLibfunc, IntOperator,
         },
         lib_func::SignatureOnlyConcreteLibfunc,
         ConcreteLibfunc, GenericLibfunc, GenericType,
@@ -79,6 +76,9 @@ where
         UintConcrete::WideMul(info) => {
             build_widemul(context, registry, entry, location, helper, metadata, info)
         }
+        UintConcrete::Bitwise(info) => {
+            super::bitwise::build(context, registry, entry, location, helper, metadata, info)
+        }
     }
 }
 
@@ -90,7 +90,7 @@ pub fn build_const<'ctx, 'this, TType, TLibfunc>(
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &UintConstConcreteLibfunc<Uint8Traits>,
+    info: &IntConstConcreteLibfunc<Uint8Traits>,
 ) -> Result<()>
 where
     TType: GenericType,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -14,6 +14,7 @@ use std::{
     collections::HashMap,
 };
 
+pub mod gas;
 pub mod prime_modulo;
 pub mod realloc_bindings;
 pub mod runtime_bindings;

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -13,6 +13,9 @@ pub struct GasMetadata {
     pub gas_info: GasInfo,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct GasCost(pub Option<u64>);
+
 /// Configuration for metadata computation.
 #[derive(Default)]
 pub struct MetadataComputationConfig {
@@ -86,10 +89,11 @@ impl GasMetadata {
         &self,
         idx: StatementIdx,
         cost_type: CostTokenType,
-    ) -> Option<i64> {
+    ) -> Option<u64> {
         self.gas_info
             .variable_values
             .get(&(idx, cost_type))
             .copied()
+            .map(|x| x as u64)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -154,6 +154,12 @@ where
             Self::Uninitialized(info) => {
                 self::uninitialized::build(context, module, registry, metadata, info)
             }
+            CoreTypeConcrete::Sint8(_) => todo!(),
+            CoreTypeConcrete::Sint16(_) => todo!(),
+            CoreTypeConcrete::Sint32(_) => todo!(),
+            CoreTypeConcrete::Sint64(_) => todo!(),
+            CoreTypeConcrete::Sint128(_) => todo!(),
+            CoreTypeConcrete::Bytes31(_) => todo!(),
         }
     }
 
@@ -235,6 +241,12 @@ where
             },
             CoreTypeConcrete::SegmentArena(_) => Layout::new::<()>(),
             CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.layout(registry)?,
+            CoreTypeConcrete::Sint8(_) => get_integer_layout(8),
+            CoreTypeConcrete::Sint16(_) => get_integer_layout(16),
+            CoreTypeConcrete::Sint32(_) => get_integer_layout(32),
+            CoreTypeConcrete::Sint64(_) => get_integer_layout(64),
+            CoreTypeConcrete::Sint128(_) => get_integer_layout(128),
+            CoreTypeConcrete::Bytes31(_) => todo!(),
         })
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -395,6 +395,7 @@ pub mod test {
         register_runtime_symbols(&engine);
 
         crate::execute::<CoreType, CoreLibfunc, _, _>(
+            todo!(),
             &engine,
             &registry,
             &program
@@ -405,6 +406,7 @@ pub mod test {
                 .id,
             args,
             serde_json::value::Serializer,
+            todo!(),
         )
         .expect("Test program execution failed.")
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -395,7 +395,6 @@ pub mod test {
         register_runtime_symbols(&engine);
 
         crate::execute::<CoreType, CoreLibfunc, _, _>(
-            todo!(),
             &engine,
             &registry,
             &program
@@ -406,7 +405,7 @@ pub mod test {
                 .id,
             args,
             serde_json::value::Serializer,
-            todo!(),
+            None, // TODO: pass gas
         )
         .expect("Test program execution failed.")
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -148,6 +148,12 @@ impl ValueBuilder<CoreType, CoreLibfunc> for CoreTypeConcrete {
             },
             CoreTypeConcrete::SegmentArena(_) => false,
             CoreTypeConcrete::Snapshot(_) => todo!(),
+            CoreTypeConcrete::Sint8(_) => todo!(),
+            CoreTypeConcrete::Sint16(_) => todo!(),
+            CoreTypeConcrete::Sint32(_) => todo!(),
+            CoreTypeConcrete::Sint64(_) => todo!(),
+            CoreTypeConcrete::Sint128(_) => todo!(),
+            CoreTypeConcrete::Bytes31(_) => todo!(),
         }
     }
 
@@ -345,6 +351,12 @@ impl<'a, 'de> DeserializeSeed<'de> for CoreTypeDeserializer<'a, CoreType, CoreLi
                     self::segment_arena::deserialize(deserializer, self.arena, self.registry, info)
                 }
                 CoreTypeConcrete::Snapshot(_) => todo!(),
+                CoreTypeConcrete::Sint8(_) => todo!(),
+                CoreTypeConcrete::Sint16(_) => todo!(),
+                CoreTypeConcrete::Sint32(_) => todo!(),
+                CoreTypeConcrete::Sint64(_) => todo!(),
+                CoreTypeConcrete::Sint128(_) => todo!(),
+                CoreTypeConcrete::Bytes31(_) => todo!(),
             }
         }
     }
@@ -472,6 +484,12 @@ impl<'a> Serialize for CoreTypeSerializer<'a, CoreType, CoreLibfunc> {
                 self::segment_arena::serialize(serializer, self.registry, self.ptr, info)
             },
             CoreTypeConcrete::Snapshot(_) => todo!(),
+            CoreTypeConcrete::Sint8(_) => todo!(),
+            CoreTypeConcrete::Sint16(_) => todo!(),
+            CoreTypeConcrete::Sint32(_) => todo!(),
+            CoreTypeConcrete::Sint64(_) => todo!(),
+            CoreTypeConcrete::Sint128(_) => todo!(),
+            CoreTypeConcrete::Bytes31(_) => todo!(),
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -205,6 +205,7 @@ pub fn run_native_program(
             .id,
         args,
         serde_json::value::Serializer,
+        None, // TODO: pass gas
     )
     .expect("Test program execution failed.")
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,7 +9,7 @@ use cairo_lang_compiler::{
 };
 use cairo_lang_filesystem::db::init_dev_corelib;
 use cairo_lang_runner::{
-    Arg, RunResult, RunResultValue, RunnerError, SierraCasmRunner, StarknetState,
+    Arg, RunResultStarknet, RunResultValue, RunnerError, SierraCasmRunner, StarknetState,
 };
 use cairo_lang_sierra::{
     extensions::core::{CoreLibfunc, CoreType, CoreTypeConcrete},
@@ -242,9 +242,9 @@ pub fn run_vm_program(
     entry_point: &str,
     args: &[Arg],
     gas: Option<usize>,
-) -> Result<RunResult, RunnerError> {
+) -> Result<RunResultStarknet, RunnerError> {
     let runner = &program.2;
-    runner.run_function(
+    runner.run_function_with_starknet_context(
         runner.find_function(entry_point).unwrap(),
         args,
         gas,
@@ -261,7 +261,7 @@ pub fn run_vm_program(
 pub fn compare_outputs(
     program: &Program,
     entry_point: &FunctionId,
-    vm_result: &RunResult,
+    vm_result: &RunResultStarknet,
     native_result: &serde_json::Value,
 ) -> Result<(), TestCaseError> {
     use proptest::prelude::*;
@@ -514,6 +514,12 @@ pub fn compare_outputs(
                     .expect("should be null");
             }
             CoreTypeConcrete::Snapshot(_) => todo!(),
+            CoreTypeConcrete::Sint8(_) => todo!(),
+            CoreTypeConcrete::Sint16(_) => todo!(),
+            CoreTypeConcrete::Sint32(_) => todo!(),
+            CoreTypeConcrete::Sint64(_) => todo!(),
+            CoreTypeConcrete::Sint128(_) => todo!(),
+            CoreTypeConcrete::Bytes31(_) => todo!(),
         }
 
         Ok(())

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -425,21 +425,17 @@ pub fn compare_outputs(
 
                 if let GenericArg::Type(id) = &info.info.long_id.generic_args[1] {
                     // TODO: is there a better way to recognize a boolean?
-                    is_bool = id
-                        .debug_name
-                        .as_ref()
+                    is_bool = dbg!(id.debug_name.as_ref())
                         .unwrap()
                         .as_str()
                         .eq("Tuple<core::bool>");
                 }
 
                 let is_panic = match &info.info.long_id.generic_args[0] {
-                    GenericArg::UserType(info) => info
-                        .debug_name
-                        .as_ref()
+                    GenericArg::UserType(info) => dbg!(info.debug_name.as_ref())
                         .unwrap()
                         .as_str()
-                        .starts_with("core::PanicResult"),
+                        .starts_with("core::panics::PanicResult"),
                     _ => false,
                 };
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -504,7 +504,15 @@ pub fn compare_outputs(
             CoreTypeConcrete::Poseidon(_) => todo!(),
             CoreTypeConcrete::Span(_) => todo!(),
             CoreTypeConcrete::StarkNet(_) => todo!(),
-            CoreTypeConcrete::SegmentArena(_) => todo!(),
+            CoreTypeConcrete::SegmentArena(_) => {
+                // runner: ignore
+                // native: null
+                native_rets
+                    .next()
+                    .unwrap()
+                    .as_null()
+                    .expect("should be null");
+            }
             CoreTypeConcrete::Snapshot(_) => todo!(),
         }
 

--- a/tests/dict.proptest-regressions
+++ b/tests/dict.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 0617cfc2c097fcc2872a85f80b65c56045807f64529d2d51b504e2d17520afd2 # shrinks to a = 0, b = 0

--- a/tests/dict.rs
+++ b/tests/dict.rs
@@ -1,0 +1,48 @@
+use crate::common::{any_felt252, feltn, load_cairo, run_native_program, run_vm_program};
+use cairo_lang_runner::{Arg, SierraCasmRunner};
+use cairo_lang_sierra::program::Program;
+use common::compare_outputs;
+use lazy_static::lazy_static;
+use proptest::prelude::*;
+use serde_json::json;
+
+mod common;
+
+const GAS: usize = usize::MAX;
+
+lazy_static! {
+    static ref DICT_GET_INSERT: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::Default;
+        use dict::Felt252DictTrait;
+
+        fn run_test(key: felt252, val: felt252) -> felt252 {
+            let mut dict: Felt252Dict<felt252> = Default::default();
+            dict.insert(key, val);
+            dict.get(key)
+        }
+    };
+}
+
+proptest! {
+    #[test]
+    #[ignore = "gas mismatch in dicts"]
+    fn dict_get_insert_proptest(a in any_felt252(), b in any_felt252()) {
+        let program = &DICT_GET_INSERT;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.clone()), Arg::Value(b.clone())],
+            Some(GAS),
+        )
+        .unwrap();
+
+        let result_native = run_native_program(program, "run_test", json!([null, null, GAS, feltn(a.to_bigint()), feltn(b.to_bigint())]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+}

--- a/tests/felt252.rs
+++ b/tests/felt252.rs
@@ -71,7 +71,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -92,7 +91,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -113,7 +111,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 }

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -196,6 +196,25 @@ proptest! {
     }
 
     #[test]
+    fn logistic_map_proptest(n in 100..110i32) {
+        let result_vm = run_vm_program(
+            &LOGISTIC_MAP,
+            "run_test",
+            &[Arg::Value(Felt252::new(n))],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(&LOGISTIC_MAP, "run_test", json!([null, GAS, feltn(n)]));
+
+        compare_outputs(
+            &LOGISTIC_MAP.1,
+            &LOGISTIC_MAP.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
     fn factorial_proptest(n in 1..100i32) {
         let result_vm = run_vm_program(
             &FACTORIAL,

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -177,6 +177,25 @@ fn factorial() {
 
 proptest! {
     #[test]
+    fn fib_proptest(n in 0..100i32) {
+        let result_vm = run_vm_program(
+            &FIB,
+            "run_test",
+            &[Arg::Value(Felt252::new(n))],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(&FIB, "run_test", json!([null, GAS, feltn(n)]));
+
+        compare_outputs(
+            &FIB.1,
+            &FIB.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
     fn factorial_proptest(n in 1..100i32) {
         let result_vm = run_vm_program(
             &FACTORIAL,

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -79,11 +79,17 @@ fn fib() {
     let result_vm =
         run_vm_program(&FIB, "run_test", &[Arg::Value(Felt252::new(10))], Some(GAS)).unwrap();
 
+    let gas: u64 = result_vm
+        .gas_counter
+        .unwrap()
+        .to_bigint()
+        .try_into()
+        .unwrap();
     let vm_results = get_run_result(&result_vm.value);
     let vm_result = &vm_results[0];
 
     let result = run_native_program(&FIB, "run_test", json!([null, GAS, felt("10")]));
-    assert_eq!(result, json!([null, GAS, [0, [felt(vm_result)]]]));
+    assert_eq!(result, json!([null, gas, [0, [felt(vm_result)]]]));
 }
 
 #[test]
@@ -96,11 +102,17 @@ fn logistic_map() {
     )
     .unwrap();
 
+    let gas: u64 = result_vm
+        .gas_counter
+        .unwrap()
+        .to_bigint()
+        .try_into()
+        .unwrap();
     let vm_results = get_run_result(&result_vm.value);
     let fib_result = &vm_results[0];
 
     let result = run_native_program(&LOGISTIC_MAP, "run_test", json!([null, GAS, felt("1000")]));
-    assert_eq!(result, json!([null, GAS, [0, [felt(fib_result)]]]));
+    assert_eq!(result, json!([null, gas, [0, [felt(fib_result)]]]));
 }
 
 #[test]
@@ -159,7 +171,6 @@ fn factorial() {
         &FACTORIAL.2.find_function("run_test").unwrap().id,
         &result_vm,
         &result_native,
-        true,
     )
     .unwrap();
 }
@@ -181,7 +192,6 @@ proptest! {
             &FACTORIAL.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -210,7 +220,6 @@ proptest! {
             &PEDERSEN.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 }

--- a/tests/uint.proptest-regressions
+++ b/tests/uint.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5f44bc80d8b3d70527e0018b6063a87bf3b81034d083fb05ea61c4a6264b67f7 # shrinks to a = 0, b = 18446744073709551616

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -114,7 +114,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -135,7 +134,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -156,7 +154,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -177,7 +174,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 
@@ -198,7 +194,6 @@ proptest! {
             &program.2.find_function("run_test").unwrap().id,
             &result_vm,
             &result_native,
-            true,
         )?;
     }
 }

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -94,6 +94,350 @@ lazy_static! {
             program(value.try_into().unwrap())
         }
     };
+
+    // U16
+
+    static ref U16_OVERFLOWING_ADD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u16, rhs: u16) -> u16 {
+            lhs + rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u16 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U16_OVERFLOWING_SUB: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u16, rhs: u16) -> u16 {
+            lhs - rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u16 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U16_SAFE_DIVMOD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u16, rhs: u16) -> (u16, u16) {
+            let q = lhs / rhs;
+            let r = lhs % rhs;
+
+            (q, r)
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> (u16, u16) {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U16_EQUAL: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u16, rhs: u16) -> bool {
+            lhs == rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> bool {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U16_IS_ZERO: (String, Program, SierraCasmRunner) = load_cairo! {
+        use zeroable::IsZeroResult;
+
+        extern fn u16_is_zero(a: u16) -> IsZeroResult<u16> implicits() nopanic;
+
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u16) -> bool {
+            match u16_is_zero(value) {
+                IsZeroResult::Zero(_) => true,
+                IsZeroResult::NonZero(_) => false,
+            }
+        }
+
+        fn run_test(value: felt252) -> bool {
+            program(value.try_into().unwrap())
+        }
+    };
+    static ref U16_SQRT: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::integer::u16_sqrt;
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u16) -> u16 {
+            u16_sqrt(value)
+        }
+
+        fn run_test(value: felt252) -> u16 {
+            program(value.try_into().unwrap())
+        }
+    };
+
+    // U32
+
+    static ref U32_OVERFLOWING_ADD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u32, rhs: u32) -> u32 {
+            lhs + rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u32 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U32_OVERFLOWING_SUB: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u32, rhs: u32) -> u32 {
+            lhs - rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u32 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U32_SAFE_DIVMOD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u32, rhs: u32) -> (u32, u32) {
+            let q = lhs / rhs;
+            let r = lhs % rhs;
+
+            (q, r)
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> (u32, u32) {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U32_EQUAL: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u32, rhs: u32) -> bool {
+            lhs == rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> bool {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U32_IS_ZERO: (String, Program, SierraCasmRunner) = load_cairo! {
+        use zeroable::IsZeroResult;
+
+        extern fn u32_is_zero(a: u32) -> IsZeroResult<u32> implicits() nopanic;
+
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u32) -> bool {
+            match u32_is_zero(value) {
+                IsZeroResult::Zero(_) => true,
+                IsZeroResult::NonZero(_) => false,
+            }
+        }
+
+        fn run_test(value: felt252) -> bool {
+            program(value.try_into().unwrap())
+        }
+    };
+    static ref U32_SQRT: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::integer::u32_sqrt;
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u32) -> u32 {
+            u32_sqrt(value)
+        }
+
+        fn run_test(value: felt252) -> u32 {
+            program(value.try_into().unwrap())
+        }
+    };
+
+    // U64
+
+    static ref U64_OVERFLOWING_ADD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u64, rhs: u64) -> u64 {
+            lhs + rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u64 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U64_OVERFLOWING_SUB: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u64, rhs: u64) -> u64 {
+            lhs - rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u64 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U64_SAFE_DIVMOD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u64, rhs: u64) -> (u64, u64) {
+            let q = lhs / rhs;
+            let r = lhs % rhs;
+
+            (q, r)
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> (u64, u64) {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U64_EQUAL: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u64, rhs: u64) -> bool {
+            lhs == rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> bool {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U64_IS_ZERO: (String, Program, SierraCasmRunner) = load_cairo! {
+        use zeroable::IsZeroResult;
+
+        extern fn u64_is_zero(a: u64) -> IsZeroResult<u64> implicits() nopanic;
+
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u64) -> bool {
+            match u64_is_zero(value) {
+                IsZeroResult::Zero(_) => true,
+                IsZeroResult::NonZero(_) => false,
+            }
+        }
+
+        fn run_test(value: felt252) -> bool {
+            program(value.try_into().unwrap())
+        }
+    };
+    static ref U64_SQRT: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::integer::u64_sqrt;
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u64) -> u64 {
+            u64_sqrt(value)
+        }
+
+        fn run_test(value: felt252) -> u64 {
+            program(value.try_into().unwrap())
+        }
+    };
+
+    // U128
+
+    static ref U128_OVERFLOWING_ADD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u128, rhs: u128) -> u128 {
+            lhs + rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u128 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U128_OVERFLOWING_SUB: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u128, rhs: u128) -> u128 {
+            lhs - rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> u128 {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U128_SAFE_DIVMOD: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u128, rhs: u128) -> (u128, u128) {
+            let q = lhs / rhs;
+            let r = lhs % rhs;
+
+            (q, r)
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> (u128, u128) {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U128_EQUAL: (String, Program, SierraCasmRunner) = load_cairo! {
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(lhs: u128, rhs: u128) -> bool {
+            lhs == rhs
+        }
+
+        fn run_test(lhs: felt252, rhs: felt252) -> bool {
+            program(lhs.try_into().unwrap(), rhs.try_into().unwrap())
+        }
+    };
+    static ref U128_IS_ZERO: (String, Program, SierraCasmRunner) = load_cairo! {
+        use zeroable::IsZeroResult;
+
+        extern fn u128_is_zero(a: u128) -> IsZeroResult<u128> implicits() nopanic;
+
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u128) -> bool {
+            match u128_is_zero(value) {
+                IsZeroResult::Zero(_) => true,
+                IsZeroResult::NonZero(_) => false,
+            }
+        }
+
+        fn run_test(value: felt252) -> bool {
+            program(value.try_into().unwrap())
+        }
+    };
+    static ref U128_SQRT: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::integer::u128_sqrt;
+        use traits::TryInto;
+        use core::option::OptionTrait;
+
+        fn program(value: u128) -> u128 {
+            u128_sqrt(value)
+        }
+
+        fn run_test(value: felt252) -> u128 {
+            program(value.try_into().unwrap())
+        }
+    };
 }
 
 proptest! {
@@ -180,6 +524,414 @@ proptest! {
     #[test]
     fn u8_is_zero_proptest(a in 0..u8::MAX) {
         let program = &U8_IS_ZERO;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    // u16
+
+    #[test]
+    fn u16_overflowing_add_proptest(a in 0..u16::MAX, b in 0..u16::MAX) {
+        let program = &U16_OVERFLOWING_ADD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u16_overflowing_sub_proptest(a in 0..u16::MAX, b in 0..u16::MAX) {
+        let program = &U16_OVERFLOWING_SUB;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u16_safe_divmod_proptest(a in 0..u16::MAX, b in 0..u16::MAX) {
+        let program = &U16_SAFE_DIVMOD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u16_equal_proptest(a in 0..u16::MAX, b in 0..u16::MAX) {
+        let program = &U16_EQUAL;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u16_is_zero_proptest(a in 0..u16::MAX) {
+        let program = &U16_IS_ZERO;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    // u32
+
+    #[test]
+    fn u32_overflowing_add_proptest(a in 0..u32::MAX, b in 0..u32::MAX) {
+        let program = &U32_OVERFLOWING_ADD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u32_overflowing_sub_proptest(a in 0..u32::MAX, b in 0..u32::MAX) {
+        let program = &U32_OVERFLOWING_SUB;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u32_safe_divmod_proptest(a in 0..u32::MAX, b in 0..u32::MAX) {
+        let program = &U32_SAFE_DIVMOD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u32_equal_proptest(a in 0..u32::MAX, b in 0..u32::MAX) {
+        let program = &U32_EQUAL;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u32_is_zero_proptest(a in 0..u32::MAX) {
+        let program = &U32_IS_ZERO;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    // u64
+
+    #[test]
+    fn u64_overflowing_add_proptest(a in 0..u64::MAX, b in 0..u64::MAX) {
+        let program = &U64_OVERFLOWING_ADD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u64_overflowing_sub_proptest(a in 0..u64::MAX, b in 0..u64::MAX) {
+        let program = &U64_OVERFLOWING_SUB;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u64_safe_divmod_proptest(a in 0..u64::MAX, b in 0..u64::MAX) {
+        let program = &U64_SAFE_DIVMOD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u64_equal_proptest(a in 0..u64::MAX, b in 0..u64::MAX) {
+        let program = &U64_EQUAL;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u64_is_zero_proptest(a in 0..u64::MAX) {
+        let program = &U64_IS_ZERO;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    // u128
+
+    #[test]
+    fn u128_overflowing_add_proptest(a in 0..u128::MAX, b in 0..u128::MAX) {
+        let program = &U128_OVERFLOWING_ADD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u128_overflowing_sub_proptest(a in 0..u128::MAX, b in 0..u128::MAX) {
+        let program = &U128_OVERFLOWING_SUB;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u128_safe_divmod_proptest(a in 0..u128::MAX, b in 0..u128::MAX) {
+        let program = &U128_SAFE_DIVMOD;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u128_equal_proptest(a in 0..u128::MAX, b in 0..u128::MAX) {
+        let program = &U128_EQUAL;
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            &[Arg::Value(a.into()), Arg::Value(b.into())],
+            Some(GAS),
+        )
+        .unwrap();
+        let result_native = run_native_program(program, "run_test", json!([null, feltn(a), feltn(b)]));
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )?;
+    }
+
+    #[test]
+    fn u128_is_zero_proptest(a in 0..u128::MAX) {
+        let program = &U128_IS_ZERO;
         let result_vm = run_vm_program(
             program,
             "run_test",


### PR DESCRIPTION
reproduce:

```
cargo b --profile optimized-dev --all-features --examples

rust-lldb target/optimized-dev/examples/erc20  

>> run 
```

currently segfaults:

```
Process 28507 stopped
* thread #1, name = 'main', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00000001018b74cc erc20`mlir::LLVM::detail::TypeToLLVMIRTranslatorImpl::translateType(mlir::Type) + 456
erc20`mlir::LLVM::detail::TypeToLLVMIRTranslatorImpl::translateType:
->  0x1018b74cc <+456>: ldr    x8, [x8]
    0x1018b74d0 <+460>: ldr    x8, [x8, #0x68]
    0x1018b74d4 <+464>: stur   x8, [x29, #-0xd0]
    0x1018b74d8 <+468>: bl     0x1022d7a04               ; mlir::detail::TypeIDResolver<mlir::LLVM::LLVMVoidType, void>::resolveTypeID()
Target 0: (erc20) stopped.
(lldb) bt
* thread #1, name = 'main', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x00000001018b74cc erc20`mlir::LLVM::detail::TypeToLLVMIRTranslatorImpl::translateType(mlir::Type) + 456
    frame #1: 0x00000001023348b0 erc20`convertOperationImpl(mlir::Operation&, llvm::IRBuilderBase&, mlir::LLVM::ModuleTranslation&) + 94504
    frame #2: 0x00000001018a35dc erc20`mlir::LLVM::ModuleTranslation::convertOperation(mlir::Operation&, llvm::IRBuilderBase&) + 248
    frame #3: 0x00000001018a4020 erc20`mlir::LLVM::ModuleTranslation::convertBlock(mlir::Block&, bool, llvm::IRBuilderBase&) + 1636
    frame #4: 0x00000001018a6144 erc20`mlir::LLVM::ModuleTranslation::convertOneFunction(mlir::LLVM::LLVMFuncOp) + 3028
    frame #5: 0x00000001018a99fc erc20`mlir::LLVM::ModuleTranslation::convertFunctions() + 364
    frame #6: 0x00000001018adb3c erc20`mlir::translateModuleToLLVMIR(mlir::Operation*, llvm::LLVMContext&, llvm::StringRef) + 3620
    frame #7: 0x000000010137cb20 erc20`mlir::ExecutionEngine::create(mlir::Operation*, mlir::ExecutionEngineOptions const&) + 1336
    frame #8: 0x000000010202491c erc20`mlirExecutionEngineCreate + 1032
    frame #9: 0x0000000100168e74 erc20`melior::execution_engine::ExecutionEngine::new::h3345be9dca3dfd99(module=<unavailable>, optimization_level=3, shared_library_paths=size=0, enable_object_dump=<unavailable>) at execution_engine.rs:22:17 [opt]
    frame #10: 0x0000000100054230 erc20`erc20::main::he1c0094234c98974 at erc20.rs:367:18 [opt]
    frame #11: 0x00000001000131e4 erc20`std::sys_common::backtrace::__rust_begin_short_backtrace::hbd7e143854fa32eb [inlined] core::ops::function::FnOnce::call_once::h84da7dde1b652bcc((null)=<unavailable>, (null)=<unavailable>) at function.rs:250:5 [opt]
    frame #12: 0x00000001000131e0 erc20`std::sys_common::backtrace::__rust_begin_short_backtrace::hbd7e143854fa32eb(f=<unavailable>) at backtrace.rs:135:18 [opt]
    frame #13: 0x000000010001cf8c erc20`std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h8862944c17d22ddf at rt.rs:166:18 [opt]
    frame #14: 0x000000010259a8c4 erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] core::ops::function::impls::_$LT$impl$u20$core..ops..function..FnOnce$LT$A$GT$$u20$for$u20$$RF$F$GT$::call_once::h3cb7fa06d3cb5387 at function.rs:284:13 [opt]
    frame #15: 0x000000010259a8bc erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panicking::try::do_call::h83545fb2b24a520d at panicking.rs:524:40 [opt]
    frame #16: 0x000000010259a8bc erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panicking::try::h9458cc84c287f3c0 at panicking.rs:488:19 [opt]
    frame #17: 0x000000010259a8bc erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panic::catch_unwind::hb6dba210fe7b63d1 at panic.rs:142:14 [opt]
    frame #18: 0x000000010259a8bc erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::rt::lang_start_internal::_$u7b$$u7b$closure$u7d$$u7d$::h57f44fbc637136aa at rt.rs:148:48 [opt]
    frame #19: 0x000000010259a8bc erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panicking::try::do_call::h35d3f5729023256b at panicking.rs:524:40 [opt]
    frame #20: 0x000000010259a8b8 erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panicking::try::h5bd94e8aa971829b at panicking.rs:488:19 [opt]
    frame #21: 0x000000010259a8b8 erc20`std::rt::lang_start_internal::h96d41f051e353e78 [inlined] std::panic::catch_unwind::h01da9f21100b3b43 at panic.rs:142:14 [opt]
    frame #22: 0x000000010259a8b8 erc20`std::rt::lang_start_internal::h96d41f051e353e78 at rt.rs:148:20 [opt]
    frame #23: 0x0000000100057070 erc20`main + 52
    frame #24: 0x0000000199b43f28 dyld`start + 2236
(lldb) 
```

this is likely a llvm mlir bug like we found not long ago