### PR TITLE
Make StarknetSyscallHandler trait receive mut self for integration with SiR

### DIFF
--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -88,7 +88,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn storage_read(
-        &self,
+        &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
     ) -> SyscallResult<cairo_felt::Felt252> {
@@ -97,7 +97,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn storage_write(
-        &self,
+        &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
         value: cairo_felt::Felt252,

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -89,7 +89,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn storage_read(
-        &self,
+        &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
     ) -> SyscallResult<cairo_felt::Felt252> {
@@ -98,7 +98,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn storage_write(
-        &self,
+        &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
         value: cairo_felt::Felt252,

--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -78,9 +78,10 @@ pub trait StarkNetSyscallHandler {
         calldata: &[Felt252],
     ) -> SyscallResult<Vec<Felt252>>;
 
-    fn storage_read(&self, address_domain: u32, address: Felt252) -> SyscallResult<Felt252>;
+    fn storage_read(&mut self, address_domain: u32, address: Felt252) -> SyscallResult<Felt252>;
+
     fn storage_write(
-        &self,
+        &mut self,
         address_domain: u32,
         address: Felt252,
         value: Felt252,


### PR DESCRIPTION
# TITLE
In order to modify state, some StarknetSyscallHandler trait methods have to receive a mutable reference to self.
Also, this PR removes the PhantomData used in the SyscallHandlerMeta for the lifetime

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
