### PR TITLE
Pass gas to syscalls, fix examples, allow cairo-native-dump to compile contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           wget -O - -c https://github.com/est31/cargo-udeps/releases/download/v0.1.42/cargo-udeps-v0.1.42-x86_64-unknown-linux-gnu.tar.gz | tar -xz
           cargo-udeps-*/cargo-udeps udeps --all-targets --all-features
 
-  coverage:
-    name: test and coverage
+  test:
+    name: test (linux, amd64)
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -84,8 +84,6 @@ jobs:
         uses: dtolnay/rust-toolchain@1.72.1
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
       - name: add llvm deb repository
         uses: myci-actions/add-deb-repo@10
         with:
@@ -97,13 +95,7 @@ jobs:
       - name: Fetch corelibs.
         run: ./scripts/fetch-corelibs.sh
       - name: test and generate coverage
-        run: make coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: lcov.info
-          fail_ci_if_error: true
+        run: make test
   test_macos:
     name: Test (macOS, Apple silicon)
     runs-on: [self-hosted, macOS]
@@ -123,3 +115,30 @@ jobs:
         run: ./scripts/fetch-corelibs.sh
       - name: Run tests
         run: make test
+  coverage:
+    name: coverage
+    runs-on: [self-hosted, macOS]
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      MLIR_SYS_170_PREFIX: /opt/homebrew/opt/llvm@17
+      TABLEGEN_170_PREFIX: /opt/homebrew/opt/llvm@17
+      RUST_LOG: debug
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup rust env
+        uses: dtolnay/rust-toolchain@1.72.1
+      - name: Retreive cached dependecies
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Fetch corelibs.
+        run: ./scripts/fetch-corelibs.sh
+      - name: test and generate coverage
+        run: make coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: sudo apt-get install llvm-17 llvm-17-dev llvm-17-runtime clang-17 clang-tools-17 lld-17 libpolly-17-dev libmlir-17-dev mlir-17-tools
       - name: Fetch corelibs.
         run: ./scripts/fetch-corelibs.sh
-      - name: test and generate coverage
+      - name: test
         run: make test
   test_macos:
     name: Test (macOS, Apple silicon)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -67,15 +67,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -255,6 +255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,7 +312,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -326,7 +335,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -392,9 +401,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cairo-felt"
@@ -473,7 +482,7 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
  "salsa",
  "smol_str",
@@ -500,7 +509,7 @@ checksum = "c35dddbc63b2a4870891cc74498726aa32bfaa518596352f9bb101411cc4c584"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
 ]
 
@@ -534,7 +543,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
  "log",
  "num-bigint",
@@ -593,7 +602,7 @@ checksum = "170838817fc33ddb65e0a9480526df0b226b148a0fca0a5cd7071be4c6683157"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -742,7 +751,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
  "num-bigint",
  "once_cell",
@@ -856,7 +865,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f974b6e859f0b09c0f13ec8188c96e9e8bbb5da04214f911dbb5bcda67cb812b"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
  "num-bigint",
  "num-integer",
@@ -929,7 +938,7 @@ dependencies = [
  "bitvec",
  "cairo-felt",
  "generic-array",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "hex",
  "keccak",
  "lazy_static",
@@ -1018,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1028,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1048,7 +1057,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1163,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -1331,9 +1346,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1447,9 +1462,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "good_lp"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869f19637130a4e8e1c3f3f83df4a00a169c1d3a77a2b2ff41736b14497c4027"
+checksum = "fa124423ded10046a849fa0ae9747c541895557f1af177e0890b09879e7e9e7d"
 dependencies = [
  "fnv",
  "minilp",
@@ -1460,6 +1475,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1481,13 +1505,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash 0.8.3",
  "allocator-api2",
  "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1571,12 +1608,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "serde",
 ]
 
@@ -1682,10 +1719,12 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fb4af667c516476b1f55d9a364104a5d5dc9b2a8546f4e4f64456ff915384"
+checksum = "66ebb7299e567bbc393b50eef9de8db7728605567b7e5cc31634e34b4c8875ba"
 dependencies = [
+ "heapless",
+ "rand",
  "rayon",
  "thiserror",
 ]
@@ -1696,7 +1735,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -1723,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1754,9 +1793,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "lock_api"
@@ -1803,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "melior"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef783d9a469417b3df9397257cfbf86f4dd276b2d1c4d432955e66bd4a395e5"
+checksum = "c91ea0e9e00979f692a52fb127a2d352e358535168dece6fd4e7948fd7714db5"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1816,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "melior-macro"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165b9f5ace52622d79b0928792fa45842d880ddca592cff7bb42527d1db3e854"
+checksum = "2ef4083994160cca85418ff2099183160787db26ab4ef5840bcf73472f678590"
 dependencies = [
  "comrak",
  "convert_case",
@@ -1826,16 +1865,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.37",
+ "syn 2.0.38",
  "tblgen",
  "unindent",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -2145,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
 ]
 
 [[package]]
@@ -2246,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2285,28 +2324,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.4.0",
  "lazy_static",
  "num-traits 0.2.16",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2438,13 +2477,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
+ "regex-automata 0.3.9",
  "regex-syntax 0.7.5",
 ]
 
@@ -2459,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2513,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2646,7 +2685,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2703,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -2759,6 +2798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sprs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,6 +2816,12 @@ dependencies = [
  "num-complex",
  "num-traits 0.1.43",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"
@@ -2817,7 +2871,7 @@ checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
  "starknet-curve 0.4.0",
  "starknet-ff",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2888,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2990,7 +3044,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3002,7 +3056,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "test-case-core",
 ]
 
@@ -3023,7 +3077,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3130,7 +3184,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3157,7 +3211,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3320,7 +3374,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -3342,7 +3396,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3474,9 +3528,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
@@ -3543,5 +3597,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ id-arena = "2.2"
 itertools = "0.11"
 lazy_static = "1.4"
 libc = "0.2.147"
-melior = { version = "0.12.1", features = ["ods-dialects"] }
+melior = { version = "0.12.2", features = ["ods-dialects"] }
 mlir-sys = "0.2.1"
 num-bigint = "0.4.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,10 @@ tracing-subscriber = { version = "0.3", features = [
 cairo-lang-sierra-gas = "2.2.0"
 cairo-lang-sierra-ap-change = "2.2.0"
 cairo-lang-utils = "2.2.0"
+cairo-lang-starknet = "2.2.0"
 
 [dev-dependencies]
 cairo-lang-runner = "2.2.0"
-cairo-lang-starknet = "2.2.0"
 lambdaworks-math = "0.1"
 num-traits = "0.2"
 pretty_assertions = "1.4"

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -318,7 +318,7 @@ fn main() {
     let sierra_program = contract.extract_sierra_program().unwrap();
 
     // uncomment to save the contract sierra program
-    // std::fs::write("echo.sierra", sierra_program.to_string()).unwrap();
+    // std::fs::write("erc20.sierra", sierra_program.to_string()).unwrap();
 
     /* uncomment to find all the functions in the program you can call
     let names: Vec<_> = sierra_program

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -14,12 +14,19 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 struct SyscallHandler;
 
 impl StarkNetSyscallHandler for SyscallHandler {
-    fn get_block_hash(&self, block_number: u64) -> SyscallResult<cairo_felt::Felt252> {
+    fn get_block_hash(
+        &self,
+        block_number: u64,
+        _gas: &mut u64,
+    ) -> SyscallResult<cairo_felt::Felt252> {
         println!("Called `get_block_hash({block_number})` from MLIR.");
         Ok(Felt252::from_bytes_be(b"get_block_hash ok"))
     }
 
-    fn get_execution_info(&self) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
+    fn get_execution_info(
+        &self,
+        _gas: &mut u64,
+    ) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
         println!("Called `get_execution_info()` from MLIR.");
         Ok(ExecutionInfo {
             block_info: BlockInfo {
@@ -48,6 +55,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         contract_address_salt: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
         deploy_from_zero: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_felt::Felt252, Vec<cairo_felt::Felt252>)> {
         println!("Called `deploy({class_hash}, {contract_address_salt}, {calldata:?}, {deploy_from_zero})` from MLIR.");
         Ok((
@@ -56,7 +64,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         ))
     }
 
-    fn replace_class(&self, class_hash: cairo_felt::Felt252) -> SyscallResult<()> {
+    fn replace_class(&self, class_hash: cairo_felt::Felt252, _gas: &mut u64) -> SyscallResult<()> {
         println!("Called `replace_class({class_hash})` from MLIR.");
         Ok(())
     }
@@ -66,6 +74,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         class_hash: cairo_felt::Felt252,
         function_selector: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
         println!(
             "Called `library_call({class_hash}, {function_selector}, {calldata:?})` from MLIR."
@@ -78,6 +87,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         address: cairo_felt::Felt252,
         entry_point_selector: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
         println!(
             "Called `call_contract({address}, {entry_point_selector}, {calldata:?})` from MLIR."
@@ -89,6 +99,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
+        _gas: &mut u64,
     ) -> SyscallResult<cairo_felt::Felt252> {
         println!("Called `storage_read({address_domain}, {address})` from MLIR.");
         Ok(address * &Felt252::new(3))
@@ -99,6 +110,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         address_domain: u32,
         address: cairo_felt::Felt252,
         value: cairo_felt::Felt252,
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `storage_write({address_domain}, {address}, {value})` from MLIR.");
         Ok(())
@@ -108,6 +120,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         keys: &[cairo_felt::Felt252],
         data: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `emit_event({keys:?}, {data:?})` from MLIR.");
         Ok(())
@@ -117,12 +130,13 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         to_address: cairo_felt::Felt252,
         payload: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `send_message_to_l1({to_address}, {payload:?})` from MLIR.");
         Ok(())
     }
 
-    fn keccak(&self, input: &[u64]) -> SyscallResult<cairo_native::starknet::U256> {
+    fn keccak(&self, input: &[u64], _gas: &mut u64) -> SyscallResult<cairo_native::starknet::U256> {
         println!("Called `keccak({input:?})` from MLIR.");
         Ok(U256(Felt252::from(1234567890).to_le_bytes()))
     }
@@ -131,6 +145,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -139,6 +154,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -146,6 +162,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     fn secp256k1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -154,6 +171,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -162,6 +180,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -170,6 +189,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -178,6 +198,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -185,6 +206,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     fn secp256r1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -193,6 +215,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -201,6 +224,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -1,7 +1,9 @@
 use cairo_felt::Felt252;
 use cairo_lang_compiler::CompilerConfig;
+use cairo_lang_starknet::contract_class::{compile_path, starknet_compile};
 use cairo_native::context::NativeContext;
 use cairo_native::executor::NativeExecutor;
+use cairo_native::utils::{felt252_bigint, felt252_short_str};
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
@@ -15,12 +17,19 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 struct SyscallHandler;
 
 impl StarkNetSyscallHandler for SyscallHandler {
-    fn get_block_hash(&self, block_number: u64) -> SyscallResult<cairo_felt::Felt252> {
+    fn get_block_hash(
+        &self,
+        block_number: u64,
+        _gas: &mut u64,
+    ) -> SyscallResult<cairo_felt::Felt252> {
         println!("Called `get_block_hash({block_number})` from MLIR.");
         Ok(Felt252::from_bytes_be(b"get_block_hash ok"))
     }
 
-    fn get_execution_info(&self) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
+    fn get_execution_info(
+        &self,
+        _gas: &mut u64,
+    ) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
         println!("Called `get_execution_info()` from MLIR.");
         Ok(ExecutionInfo {
             block_info: BlockInfo {
@@ -49,6 +58,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         contract_address_salt: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
         deploy_from_zero: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_felt::Felt252, Vec<cairo_felt::Felt252>)> {
         println!("Called `deploy({class_hash}, {contract_address_salt}, {calldata:?}, {deploy_from_zero})` from MLIR.");
         Ok((
@@ -57,7 +67,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         ))
     }
 
-    fn replace_class(&self, class_hash: cairo_felt::Felt252) -> SyscallResult<()> {
+    fn replace_class(&self, class_hash: cairo_felt::Felt252, _gas: &mut u64) -> SyscallResult<()> {
         println!("Called `replace_class({class_hash})` from MLIR.");
         Ok(())
     }
@@ -67,6 +77,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         class_hash: cairo_felt::Felt252,
         function_selector: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
         println!(
             "Called `library_call({class_hash}, {function_selector}, {calldata:?})` from MLIR."
@@ -79,6 +90,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         address: cairo_felt::Felt252,
         entry_point_selector: cairo_felt::Felt252,
         calldata: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<Vec<cairo_felt::Felt252>> {
         println!(
             "Called `call_contract({address}, {entry_point_selector}, {calldata:?})` from MLIR."
@@ -90,6 +102,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         address_domain: u32,
         address: cairo_felt::Felt252,
+        _gas: &mut u64,
     ) -> SyscallResult<cairo_felt::Felt252> {
         println!("Called `storage_read({address_domain}, {address})` from MLIR.");
         Ok(address * &Felt252::new(3))
@@ -100,6 +113,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         address_domain: u32,
         address: cairo_felt::Felt252,
         value: cairo_felt::Felt252,
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `storage_write({address_domain}, {address}, {value})` from MLIR.");
         Ok(())
@@ -109,6 +123,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         keys: &[cairo_felt::Felt252],
         data: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `emit_event({keys:?}, {data:?})` from MLIR.");
         Ok(())
@@ -118,12 +133,13 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &mut self,
         to_address: cairo_felt::Felt252,
         payload: &[cairo_felt::Felt252],
+        _gas: &mut u64,
     ) -> SyscallResult<()> {
         println!("Called `send_message_to_l1({to_address}, {payload:?})` from MLIR.");
         Ok(())
     }
 
-    fn keccak(&self, input: &[u64]) -> SyscallResult<cairo_native::starknet::U256> {
+    fn keccak(&self, input: &[u64], _gas: &mut u64) -> SyscallResult<cairo_native::starknet::U256> {
         println!("Called `keccak({input:?})` from MLIR.");
         Ok(U256(Felt252::from(1234567890).to_le_bytes()))
     }
@@ -132,6 +148,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -140,6 +157,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -147,6 +165,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     fn secp256k1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -155,6 +174,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -163,6 +183,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -171,6 +192,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -179,6 +201,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -186,6 +209,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     fn secp256r1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
+        _gas: &mut u64,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -194,6 +218,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -202,6 +227,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
         &self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
+        _gas: &mut u64,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -274,14 +300,30 @@ fn main() {
         format!("{}/a", std::env::var("CARGO_MANIFEST_DIR").unwrap()),
     );
 
-    let sierra_program = cairo_lang_compiler::compile_cairo_project_at_path(
-        Path::new("programs/examples/hello_starknet.cairo"),
+    let path = Path::new("programs/examples/hello_starknet.cairo");
+
+    let contract = compile_path(
+        path,
+        None,
         CompilerConfig {
             replace_ids: true,
             ..Default::default()
         },
     )
     .unwrap();
+
+    let sierra_program = contract.extract_sierra_program().unwrap();
+
+    // uncomment to save the contract sierra program
+    // std::fs::write("echo.sierra", sierra_program.to_string()).unwrap();
+
+    /* uncomment to find all the functions in the program you can call
+    let names: Vec<_> = sierra_program
+        .funcs
+        .iter()
+        .map(|x| x.id.debug_name.as_ref()).collect();
+    println!("{names:#?}");
+    */
 
     let native_context = NativeContext::new();
 
@@ -296,9 +338,33 @@ fn main() {
         .as_ptr()
         .as_ptr() as *const () as usize;
 
-    let fn_id = find_function_id(&sierra_program, "hello_starknet::hello_starknet::main");
+    // Call the echo function from the contract using the generated wrapper.
+
+    let fn_id = find_function_id(
+        &sierra_program,
+        "hello_starknet::hello_starknet::Echo::__wrapper_echo",
+    );
     let required_init_gas = native_program.get_required_init_gas(fn_id);
-    let params = json!([(), u64::MAX, syscall_addr,]);
+
+    let params = json!([
+        // range check
+        null,
+        // gas
+        u64::MAX,
+        // system
+        syscall_addr,
+        // Struct<Span<Array<felt>>>
+        [
+            // Span<Array<felt>>
+            [
+                // contract state
+                // (empty)
+
+                // function arguments
+                felt252_bigint(1)
+            ]
+        ],
+    ]);
     let returns = &mut serde_json::Serializer::pretty(io::stdout());
 
     let native_executor = NativeExecutor::new(native_program);
@@ -307,5 +373,6 @@ fn main() {
         .execute(fn_id, params, returns, required_init_gas)
         .unwrap();
 
+    println!();
     println!("Cairo program was compiled and executed succesfully.");
 }

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -1,9 +1,9 @@
 use cairo_felt::Felt252;
 use cairo_lang_compiler::CompilerConfig;
-use cairo_lang_starknet::contract_class::{compile_path, starknet_compile};
+use cairo_lang_starknet::contract_class::compile_path;
 use cairo_native::context::NativeContext;
 use cairo_native::executor::NativeExecutor;
-use cairo_native::utils::{felt252_bigint, felt252_short_str};
+use cairo_native::utils::felt252_bigint;
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},

--- a/programs/erc20.cairo
+++ b/programs/erc20.cairo
@@ -21,7 +21,6 @@ trait IERC20<TContractState> {
 
 #[starknet::contract]
 mod erc_20 {
-    use zeroable::Zeroable;
     use starknet::get_caller_address;
     use starknet::contract_address_const;
     use starknet::ContractAddress;
@@ -186,4 +185,3 @@ mod erc_20 {
         }
     }
 }
-

--- a/programs/examples/hello_starknet.cairo
+++ b/programs/examples/hello_starknet.cairo
@@ -1,157 +1,17 @@
-use core::{
-    array::ArrayTrait, clone::Clone, debug::PrintTrait, option::OptionTrait,
-    starknet::{
-        call_contract_syscall, class_hash_try_from_felt252, contract_address_try_from_felt252,
-        deploy_syscall, emit_event_syscall, get_block_hash_syscall, get_execution_info_syscall,
-        keccak_syscall, library_call_syscall, replace_class_syscall, send_message_to_l1_syscall,
-        storage_address_try_from_felt252, storage_read_syscall, storage_write_syscall,
-    }
-};
-
-fn main() {
-    match call_contract_syscall(
-        contract_address_try_from_felt252(1234).unwrap(),
-        5678,
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        }
-    ) {
-        Result::Ok(x) => x.snapshot.clone().print(),
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  call_contract'.print();
-        }
+#[starknet::contract]
+mod Echo {
+    #[storage]
+    struct Storage {
+        balance: felt252,
     }
 
-    match deploy_syscall(
-        class_hash_try_from_felt252(1234).unwrap(),
-        2345,
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        },
-        true,
-    ) {
-        Result::Ok((x, y)) => {
-            x.print();
-            y.snapshot.clone().print();
-        },
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  call_contract'.print();
-        }
+    #[constructor]
+    fn constructor(ref self: ContractState, initial_balance: felt252) {
+        self.balance.write(initial_balance);
     }
 
-    match emit_event_syscall(
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        },
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(8765);
-            data.append(4321);
-            data.span()
-        }
-    ) {
-        Result::Ok(_) => {},
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  emit_event'.print();
-        }
-    }
-
-    match get_block_hash_syscall(0_u64) {
-        Result::Ok(x) => x.print(),
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  get_block_hash'.print();
-        },
-    }
-    match get_execution_info_syscall() {
-        Result::Ok(_) => {},
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  get_execution_info'.print();
-        },
-    }
-
-    match keccak_syscall(
-        {
-            let mut data = ArrayTrait::<u64>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        }
-    ) {
-        Result::Ok(x) => x.print(),
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  keccak'.print();
-        },
-    }
-
-    match library_call_syscall(
-        class_hash_try_from_felt252(1234).unwrap(),
-        5678,
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        }
-    ) {
-        Result::Ok(x) => x.snapshot.clone().print(),
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  library_call'.print();
-        }
-    }
-
-    match replace_class_syscall(class_hash_try_from_felt252(1234).unwrap()) {
-        Result::Ok(_) => {},
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  replace_class'.print();
-        }
-    }
-
-    match send_message_to_l1_syscall(
-        1248,
-        {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append(1234);
-            data.append(5678);
-            data.span()
-        }
-    ) {
-        Result::Ok(_) => {},
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  call_contract'.print();
-        }
-    }
-
-    match storage_read_syscall(0, storage_address_try_from_felt252(1234).unwrap()) {
-        Result::Ok(x) => x.print(),
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  storage_read'.print();
-        }
-    }
-
-    match storage_write_syscall(0, storage_address_try_from_felt252(1234).unwrap(), 2345) {
-        Result::Ok(_) => {},
-        Result::Err(e) => {
-            'Syscall returned an error:'.print();
-            '  storage_write'.print();
-        }
+    #[external(v0)]
+    fn echo(ref self: ContractState, value: felt252) -> felt252 {
+        value
     }
 }

--- a/scripts/test-erc20.sh
+++ b/scripts/test-erc20.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
-# Donwload the ERC20 contract from the Cairo repository and compile with the
-# Sierra compiler. The output is a MLIR file.
-
-curl https://raw.githubusercontent.com/starkware-libs/cairo/b4e049a13b62dc493ac378747af8e0908c1b86b7/crates/cairo-lang-starknet/test_data/erc20.sierra > erc20.sierra
+# Tests whether the erc20 contract compiles.
 
 cargo run --profile=optimized-dev \
     --features=build-cli,with-runtime \
-    --bin="cairo-native-dump" -- erc20.sierra
-
-rm erc20.sierra
+    --bin="cairo-native-dump" -- programs/erc20.cairo --starknet

--- a/src/debug_info/statements.rs
+++ b/src/debug_info/statements.rs
@@ -84,10 +84,11 @@ fn map_sierra_to_pre_sierra_statements<'a>(
             PreSierraStatement::PushValues(_) => panic!(),
         };
 
-        let (lhs_idx, _lhs_statement) = lhs_iter.next().unwrap();
-        // TODO: Assert lhs_statement == rhs_statement.
+        if let Some((lhs_idx, _lhs_statement)) = lhs_iter.next() {
+            // TODO: Assert lhs_statement == rhs_statement.
 
-        mappings.insert(StatementIdx(lhs_idx), rhs_statement);
+            mappings.insert(StatementIdx(lhs_idx), rhs_statement);
+        }
     }
 
     mappings


### PR DESCRIPTION
- Allows cairo-native-dump to compile contracts passing the --starknet flag.
- Removed the erc20.sierra, we can now test with the erc20.cairo program directly.
- Fixed the starknet example with a real simple contract.
- Pass gas to syscalls because some need it to do some checks or substract from it.
