### PR TITLE
fix gas in starknet syscalls, improve and use NativeExecutionResult

### DIFF
--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -12,7 +12,6 @@ use cairo_native::{
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
     utils::{felt252_bigint, felt252_short_str},
 };
-use itertools::Itertools;
 use serde_json::json;
 use std::path::Path;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -1,13 +1,18 @@
 use cairo_felt::Felt252;
 use cairo_lang_compiler::CompilerConfig;
+use cairo_lang_sierra::extensions::core::{CoreLibfunc, CoreType, CoreTypeConcrete};
+use cairo_lang_sierra::program_registry::ProgramRegistry;
 use cairo_lang_starknet::contract_class::compile_path;
 use cairo_native::context::NativeContext;
+use cairo_native::execution_result::NativeExecutionResult;
 use cairo_native::executor::NativeExecutor;
+use cairo_native::utils::find_entry_point_by_idx;
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
     utils::{felt252_bigint, felt252_short_str, find_function_id},
 };
+use itertools::Itertools;
 use serde_json::json;
 use std::io;
 use std::path::Path;
@@ -27,7 +32,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn get_execution_info(
-        &self,
+        &mut self,
         _gas: &mut u128,
     ) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
         println!("Called `get_execution_info()` from MLIR.");
@@ -323,7 +328,10 @@ fn main() {
     )
     .unwrap();
 
+    let entry_point = contract.entry_points_by_type.constructor.get(0).unwrap();
     let sierra_program = contract.extract_sierra_program().unwrap();
+    let program_registry: ProgramRegistry<CoreType, CoreLibfunc> =
+        ProgramRegistry::new(&sierra_program).unwrap();
 
     // uncomment to save the contract sierra program
     // std::fs::write("erc20.sierra", sierra_program.to_string()).unwrap();
@@ -350,10 +358,16 @@ fn main() {
         .as_ptr()
         .as_ptr() as *const () as usize;
 
-    let fn_id = find_function_id(
-        &sierra_program,
-        "erc20::erc20::erc_20::__wrapper_constructor",
-    );
+    let entry_point_fn =
+        find_entry_point_by_idx(&sierra_program, entry_point.function_idx).unwrap();
+    let ret_types: Vec<&CoreTypeConcrete> = entry_point_fn
+        .signature
+        .ret_types
+        .iter()
+        .map(|x| program_registry.get_type(x).unwrap())
+        .collect();
+    let fn_id = &entry_point_fn.id;
+
     let required_init_gas = native_program.get_required_init_gas(fn_id);
 
     let params = json!([
@@ -383,13 +397,20 @@ fn main() {
         ]
     ]);
 
-    let returns = &mut serde_json::Serializer::pretty(io::stdout());
-
     let native_executor = NativeExecutor::new(native_program);
+
+    let mut writer: Vec<u8> = Vec::new();
+    let returns = &mut serde_json::Serializer::new(&mut writer);
 
     native_executor
         .execute(fn_id, params, returns, required_init_gas)
-        .unwrap();
+        .expect("failed to execute the given contract");
+
+    let result = NativeExecutionResult::deserialize_from_ret_types(
+        &mut serde_json::Deserializer::from_slice(&writer),
+        &ret_types,
+    )
+    .expect("failed to serialize starknet execution result");
 
     // Useful code to print a short felt string returned from the json, in case it panics
     /*
@@ -405,4 +426,5 @@ fn main() {
     */
 
     println!("Cairo program was compiled and executed succesfully.");
+    println!("{result:#?}");
 }

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -10,11 +10,10 @@ use cairo_native::utils::find_entry_point_by_idx;
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
-    utils::{felt252_bigint, felt252_short_str, find_function_id},
+    utils::{felt252_bigint, felt252_short_str},
 };
 use itertools::Itertools;
 use serde_json::json;
-use std::io;
 use std::path::Path;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -1,9 +1,12 @@
 use cairo_felt::Felt252;
 use cairo_lang_compiler::CompilerConfig;
+use cairo_lang_sierra::extensions::core::{CoreLibfunc, CoreType, CoreTypeConcrete};
+use cairo_lang_sierra::program_registry::ProgramRegistry;
 use cairo_lang_starknet::contract_class::compile_path;
 use cairo_native::context::NativeContext;
+use cairo_native::execution_result::NativeExecutionResult;
 use cairo_native::executor::NativeExecutor;
-use cairo_native::utils::felt252_bigint;
+use cairo_native::utils::{felt252_bigint, find_entry_point_by_idx};
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
@@ -27,7 +30,7 @@ impl StarkNetSyscallHandler for SyscallHandler {
     }
 
     fn get_execution_info(
-        &self,
+        &mut self,
         _gas: &mut u128,
     ) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
         println!("Called `get_execution_info()` from MLIR.");
@@ -320,7 +323,10 @@ fn main() {
     )
     .unwrap();
 
+    let entry_point = contract.entry_points_by_type.constructor.get(0).unwrap();
     let sierra_program = contract.extract_sierra_program().unwrap();
+    let program_registry: ProgramRegistry<CoreType, CoreLibfunc> =
+        ProgramRegistry::new(&sierra_program).unwrap();
 
     // uncomment to save the contract sierra program
     // std::fs::write("echo.sierra", sierra_program.to_string()).unwrap();
@@ -348,10 +354,17 @@ fn main() {
 
     // Call the echo function from the contract using the generated wrapper.
 
-    let fn_id = find_function_id(
-        &sierra_program,
-        "hello_starknet::hello_starknet::Echo::__wrapper_echo",
-    );
+    let entry_point_fn =
+        find_entry_point_by_idx(&sierra_program, entry_point.function_idx).unwrap();
+
+    let ret_types: Vec<&CoreTypeConcrete> = entry_point_fn
+        .signature
+        .ret_types
+        .iter()
+        .map(|x| program_registry.get_type(x).unwrap())
+        .collect();
+
+    let fn_id = &entry_point_fn.id;
     let required_init_gas = native_program.get_required_init_gas(fn_id);
 
     let params = json!([
@@ -373,14 +386,22 @@ fn main() {
             ]
         ],
     ]);
-    let returns = &mut serde_json::Serializer::pretty(io::stdout());
-
     let native_executor = NativeExecutor::new(native_program);
+
+    let mut writer: Vec<u8> = Vec::new();
+    let returns = &mut serde_json::Serializer::new(&mut writer);
 
     native_executor
         .execute(fn_id, params, returns, required_init_gas)
-        .unwrap();
+        .expect("failed to execute the given contract");
+
+    let result = NativeExecutionResult::deserialize_from_ret_types(
+        &mut serde_json::Deserializer::from_slice(&writer),
+        &ret_types,
+    )
+    .expect("failed to serialize starknet execution result");
 
     println!();
     println!("Cairo program was compiled and executed succesfully.");
+    println!("{result:#?}");
 }

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -10,10 +10,9 @@ use cairo_native::utils::{felt252_bigint, find_entry_point_by_idx};
 use cairo_native::{
     metadata::syscall_handler::SyscallHandlerMeta,
     starknet::{BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256},
-    utils::find_function_id,
 };
 use serde_json::json;
-use std::{io, path::Path};
+use std::path::Path;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[derive(Debug)]

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -525,12 +525,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -1010,12 +1019,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -1373,12 +1391,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -1966,12 +1993,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -2265,12 +2301,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -2557,12 +2602,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -3015,14 +3069,23 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(
         helper.cond_br(
             result_tag,
             [1, 0],
             [
-                &[remaining_gas, entry.argument(1)?.into(), payload_err],
+                &[gas_consumed, entry.argument(1)?.into(), payload_err],
                 &[
-                    remaining_gas,
+                    gas_consumed,
                     entry.argument(1)?.into(),
                     entry
                         .append_operation(llvm::extract_value(
@@ -3182,15 +3245,11 @@ where
     let input_arg_ptr_ty = llvm::r#type::pointer(
         llvm::r#type::r#struct(
             context,
-            &[llvm::r#type::r#struct(
-                context,
-                &[
-                    llvm::r#type::pointer(IntegerType::new(context, 64).into(), 0),
-                    IntegerType::new(context, 32).into(),
-                    IntegerType::new(context, 32).into(),
-                ],
-                false,
-            )],
+            &[
+                llvm::r#type::pointer(IntegerType::new(context, 64).into(), 0),
+                IntegerType::new(context, 32).into(),
+                IntegerType::new(context, 32).into(),
+            ],
             false,
         ),
         0,
@@ -3372,12 +3431,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -3771,12 +3839,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -4096,12 +4173,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -4468,12 +4554,21 @@ where
         .result(0)?
         .into();
 
+    let gas_consumed = entry
+        .append_operation(arith::subi(
+            entry.argument(0)?.into(),
+            remaining_gas,
+            location,
+        ))
+        .result(0)?
+        .into();
+
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[remaining_gas, entry.argument(1)?.into(), payload_err],
-            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
+            &[gas_consumed, entry.argument(1)?.into(), payload_err],
+            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));

--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -57,7 +57,7 @@ pub trait StarkNetSyscallHandler {
         block_number: u64,
         remaining_gas: &mut u128,
     ) -> SyscallResult<Felt252>;
-    fn get_execution_info(&self, remaining_gas: &mut u128) -> SyscallResult<ExecutionInfo>;
+    fn get_execution_info(&mut self, remaining_gas: &mut u128) -> SyscallResult<ExecutionInfo>;
 
     fn deploy(
         &mut self,
@@ -434,7 +434,6 @@ pub(crate) mod handler {
             gas: &mut u128,
             block_number: u64,
         ) {
-            // TODO: Handle gas.
             let result = ptr.get_block_hash(block_number, gas);
 
             *result_ptr = match result {
@@ -453,7 +452,6 @@ pub(crate) mod handler {
             ptr: &mut T,
             gas: &mut u128,
         ) {
-            // TODO: handle gas
             let result = ptr.get_execution_info(gas);
 
             *result_ptr = match result {
@@ -525,7 +523,6 @@ pub(crate) mod handler {
             calldata: *const (*const Felt252Abi, u32, u32),
             deploy_from_zero: bool,
         ) {
-            // TODO: handle gas
             let class_hash = Felt252::from_bytes_be(&{
                 let mut data = class_hash.0;
                 data.reverse();
@@ -580,7 +577,6 @@ pub(crate) mod handler {
             gas: &mut u128,
             class_hash: &Felt252Abi,
         ) {
-            // TODO: Handle gas.
             let class_hash = Felt252::from_bytes_be(&{
                 let mut data = class_hash.0;
                 data.reverse();
@@ -607,7 +603,6 @@ pub(crate) mod handler {
             function_selector: &Felt252Abi,
             calldata: *const (*const Felt252Abi, u32, u32),
         ) {
-            // TODO: handle gas
             let class_hash = Felt252::from_bytes_be(&{
                 let mut data = class_hash.0;
                 data.reverse();
@@ -658,7 +653,6 @@ pub(crate) mod handler {
             entry_point_selector: &Felt252Abi,
             calldata: *const (*const Felt252Abi, u32, u32),
         ) {
-            // TODO: handle gas
             let address = Felt252::from_bytes_be(&{
                 let mut data = address.0;
                 data.reverse();
@@ -708,7 +702,6 @@ pub(crate) mod handler {
             address_domain: u32,
             address: &Felt252Abi,
         ) {
-            // TODO: Handle gas.
             let address = Felt252::from_bytes_be(&{
                 let mut data = address.0;
                 data.reverse();
@@ -735,7 +728,6 @@ pub(crate) mod handler {
             address: &Felt252Abi,
             value: &Felt252Abi,
         ) {
-            // TODO: Handle gas.
             let address = Felt252::from_bytes_be(&{
                 let mut data = address.0;
                 data.reverse();
@@ -766,8 +758,6 @@ pub(crate) mod handler {
             keys: *const (*const Felt252Abi, u32, u32),
             data: *const (*const Felt252Abi, u32, u32),
         ) {
-            // TODO: Handle gas.
-
             let keys: Vec<_> = unsafe {
                 let len = (*keys).1 as usize;
                 std::slice::from_raw_parts((*keys).0, len)
@@ -816,7 +806,6 @@ pub(crate) mod handler {
             to_address: &Felt252Abi,
             payload: *const (*const Felt252Abi, u32, u32),
         ) {
-            // TODO: handle gas
             let to_address = Felt252::from_bytes_be(&{
                 let mut data = to_address.0;
                 data.reverse();
@@ -855,7 +844,6 @@ pub(crate) mod handler {
             gas: &mut u128,
             input: *const (*const u64, u32, u32),
         ) {
-            // TODO: handle gas
             let input = unsafe {
                 let len = (*input).1 as usize;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,16 +101,15 @@ pub fn find_entry_point<'a>(
         .find(|x| x.id.debug_name.as_deref() == Some(entry_point))
 }
 
-/// Given a string representing a function name, searches in the program for the id corresponding to said function, and returns a reference to it.
-pub fn find_function<'a>(
-    program: &'a Program,
-    function_name: &str,
-) -> &'a GenFunction<StatementIdx> {
+/// Returns the given entry point if present.
+pub fn find_entry_point_by_idx(
+    program: &Program,
+    entry_point_idx: usize,
+) -> Option<&GenFunction<StatementIdx>> {
     program
         .funcs
         .iter()
-        .find(|x| x.id.debug_name.as_deref() == Some(function_name))
-        .unwrap()
+        .find(|x| x.id.id == entry_point_idx as u64)
 }
 
 /// Given a string representing a function name, searches in the program for the id corresponding to said function, and returns a reference to it.

--- a/tests/starknet/keccak.rs
+++ b/tests/starknet/keccak.rs
@@ -1,6 +1,5 @@
 use cairo_felt::Felt252;
 use cairo_lang_compiler::CompilerConfig;
-use cairo_lang_sierra::program::Program;
 use cairo_lang_starknet::contract_class::{compile_path, ContractClass};
 use cairo_native::starknet::{
     BlockInfo, ExecutionInfo, StarkNetSyscallHandler, SyscallResult, TxInfo, U256,
@@ -292,7 +291,7 @@ lazy_static! {
     static ref KECCAK_CONTRACT: ContractClass = {
         let path = Path::new("tests/starknet/contracts/test_keccak.cairo");
 
-        let contract = compile_path(
+        compile_path(
             path,
             None,
             CompilerConfig {
@@ -300,9 +299,7 @@ lazy_static! {
                 ..Default::default()
             },
         )
-        .unwrap();
-
-        contract
+        .unwrap()
     };
 }
 
@@ -310,14 +307,6 @@ lazy_static! {
 fn keccak_test() {
     // uncomment to save the contract sierra program
     // std::fs::write("echo.sierra", sierra_program.to_string()).unwrap();
-
-    /* uncomment to find all the functions in the program you can call
-    let names: Vec<_> = sierra_program
-        .funcs
-        .iter()
-        .map(|x| x.id.debug_name.as_ref()).collect();
-    println!("{names:#?}");
-    */
 
     let contract = &KECCAK_CONTRACT;
 
@@ -334,6 +323,4 @@ fn keccak_test() {
     assert!(!result.failure_flag);
     assert_eq!(result.gas_consumed, 1000);
     assert_eq!(result.return_values, vec![1.into()]);
-
-    dbg!(&result);
 }


### PR DESCRIPTION
Fixes gas so that the syscalls return the gas consumed.

Gas is now also properly handled in the NativeExecutionResult deserializer.

Use NativeExecutionResult in the tests and examples.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
