### PR TITLE
wip: fix Err syscall wrongly loaded

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -312,6 +312,14 @@ where
     ///
     /// This method will also store the returned values so that they can be moved into the state and
     /// used later on when required.
+    ///
+    /// ## Branches
+    /// A array of 2 indexes that point to a result in the results array.
+    ///
+    /// The `branches[0]` is for the true branch.
+    ///
+    /// The `branches[1]` is for the false branch.
+    ///
     // TODO: Allow one block to be libfunc-internal.
     pub fn cond_br(
         &self,

--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -406,7 +406,9 @@ pub(crate) mod handler {
         }
 
         unsafe fn alloc_mlir_array<E: Clone>(data: &[E]) -> (NonNull<E>, u32, u32) {
-            let ptr = libc::malloc(Layout::array::<E>(data.len()).unwrap().size()) as *mut E;
+            let data_layout = Layout::array::<E>(data.len()).unwrap();
+
+            let ptr = libc::malloc(data_layout.size()) as *mut E;
 
             let len: u32 = data.len().try_into().unwrap();
             for (i, val) in data.iter().enumerate() {
@@ -747,7 +749,9 @@ pub(crate) mod handler {
                         payload: ManuallyDrop::new(()),
                     }),
                 },
-                Err(e) => Self::wrap_error(&e),
+                Err(e) => {
+                    Self::wrap_error(&e)
+                },
             };
         }
 


### PR DESCRIPTION
Still havent found the fix but looking into it

while doing https://github.com/lambdaclass/starknet_in_rust/pull/1102 i found a bug, the felt error was not there and the deserialization crashed (its now fixed with a deserialization error, but it should find the felt because its passed)

When a syscall returns a Err (that always contains a vec of felts) it wont see the vec of felts but they are there
I think the problem here is how we handle the return syscall payload in the starknet libfuncs, when the return type is () we use a hack to get the enum type have 2 variants (but we cant make a concretetypeid from nowhere so we copy the variant from the other err branch)
We also build the ok and err payload always regardless of whether the enum tag is 0 or 1 for each variant, i think the problem lies there (edited) 


