### PR TITLE
Avoid panicking when deserializing a native execution result

### DIFF
--- a/src/execution_result.rs
+++ b/src/execution_result.rs
@@ -107,11 +107,22 @@ impl NativeExecutionResult {
                                         .map(|felt_bytes| u32_vec_to_felt(felt_bytes))
                                         .collect();
 
-                                    let str_error =
-                                        String::from_utf8(felt_error[0].to_be_bytes().to_vec())
-                                            .unwrap()
-                                            .trim_start_matches('\0')
-                                            .to_owned();
+                                    let str_error = String::from_utf8(
+                                        felt_error
+                                            .get(0)
+                                            .ok_or_else(|| {
+                                                de::Error::custom(
+                                                    "error getting felt error message",
+                                                )
+                                            })?
+                                            .to_be_bytes()
+                                            .to_vec(),
+                                    )
+                                    .map_err(|_| {
+                                        de::Error::custom("error parsing error from utf8")
+                                    })?
+                                    .trim_start_matches('\0')
+                                    .to_owned();
 
                                     Ok(NativeExecutionResult {
                                         gas_consumed,


### PR DESCRIPTION
Avoid panicking (and thus causing sometimes a segfault) when deserializing a native execution result

Small isolated PR I extracted from #327

It makes it so it doesnt panic and returns a deserialization error

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
