### PR TITLE
revert back to remaining_gas for syscalls

### DIFF
--- a/src/execution_result.rs
+++ b/src/execution_result.rs
@@ -11,7 +11,7 @@ use std::fmt::{self};
 /// Starknet contract execution result.
 #[derive(Debug, Default)]
 pub struct NativeExecutionResult {
-    pub gas_consumed: u128,
+    pub remaining_gas: u128,
     pub failure_flag: bool,
     pub return_values: Vec<Felt252>,
     pub error_msg: Option<String>,
@@ -45,12 +45,12 @@ impl NativeExecutionResult {
             where
                 A: SeqAccess<'de>,
             {
-                let mut gas_consumed: u128 = 0;
+                let mut remaining_gas: u128 = 0;
 
                 for ret_type in self.ret_types {
                     match ret_type {
                         CoreTypeConcrete::GasBuiltin(_) => {
-                            gas_consumed = seq.next_element()?.unwrap();
+                            remaining_gas = seq.next_element()?.unwrap();
                         }
                         CoreTypeConcrete::RangeCheck(_) => {
                             seq.next_element::<Value>()?;
@@ -83,7 +83,7 @@ impl NativeExecutionResult {
                                         serde_json::from_value(return_values).unwrap();
 
                                     Ok(NativeExecutionResult {
-                                        gas_consumed,
+                                        remaining_gas,
                                         return_values: return_values[0][0]
                                             .iter()
                                             .map(|felt_bytes| u32_vec_to_felt(felt_bytes))
@@ -125,7 +125,7 @@ impl NativeExecutionResult {
                                     .to_owned();
 
                                     Ok(NativeExecutionResult {
-                                        gas_consumed,
+                                        remaining_gas,
                                         failure_flag: failure_flag == 1,
                                         return_values: felt_error,
                                         error_msg: Some(str_error),

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -526,23 +526,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -2613,23 +2602,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -28,7 +28,8 @@ use melior::{
     },
     ir::{
         attribute::{
-            DenseI32ArrayAttribute, DenseI64ArrayAttribute, IntegerAttribute, TypeAttribute,
+            DenseI32ArrayAttribute, DenseI64ArrayAttribute, IntegerAttribute, StringAttribute,
+            TypeAttribute,
         },
         operation::OperationBuilder,
         r#type::IntegerType,
@@ -526,9 +527,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -1020,9 +1023,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -1392,9 +1397,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -1994,9 +2001,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -2302,9 +2311,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -2603,9 +2614,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -3070,9 +3083,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -3432,9 +3447,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -3840,9 +3857,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -4174,9 +4193,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?
@@ -4555,9 +4576,11 @@ where
         .into();
 
     let gas_consumed = entry
-        .append_operation(arith::subi(
-            entry.argument(0)?.into(),
-            remaining_gas,
+        .append_operation(llvm::call_intrinsic(
+            context,
+            StringAttribute::new(context, "llvm.usub.sat"),
+            &[entry.argument(0)?.into(), remaining_gas],
+            &[remaining_gas.r#type()],
             location,
         ))
         .result(0)?

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -1011,23 +1011,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -1385,23 +1374,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -1989,23 +1967,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -2299,23 +2266,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -3060,25 +3016,14 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(
         helper.cond_br(
             result_tag,
             [1, 0],
             [
-                &[gas_consumed, entry.argument(1)?.into(), payload_err],
+                &[remaining_gas, entry.argument(1)?.into(), payload_err],
                 &[
-                    gas_consumed,
+                    remaining_gas,
                     entry.argument(1)?.into(),
                     entry
                         .append_operation(llvm::extract_value(
@@ -3424,23 +3369,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -3834,23 +3768,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -4170,23 +4093,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));
@@ -4553,23 +4465,12 @@ where
         .result(0)?
         .into();
 
-    let gas_consumed = entry
-        .append_operation(llvm::call_intrinsic(
-            context,
-            StringAttribute::new(context, "llvm.usub.sat"),
-            &[entry.argument(0)?.into(), remaining_gas],
-            &[remaining_gas.r#type()],
-            location,
-        ))
-        .result(0)?
-        .into();
-
     entry.append_operation(helper.cond_br(
         result_tag,
         [1, 0],
         [
-            &[gas_consumed, entry.argument(1)?.into(), payload_err],
-            &[gas_consumed, entry.argument(1)?.into(), payload_ok],
+            &[remaining_gas, entry.argument(1)?.into(), payload_err],
+            &[remaining_gas, entry.argument(1)?.into(), payload_ok],
         ],
         location,
     ));

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -28,8 +28,7 @@ use melior::{
     },
     ir::{
         attribute::{
-            DenseI32ArrayAttribute, DenseI64ArrayAttribute, IntegerAttribute, StringAttribute,
-            TypeAttribute,
+            DenseI32ArrayAttribute, DenseI64ArrayAttribute, IntegerAttribute, TypeAttribute,
         },
         operation::OperationBuilder,
         r#type::IntegerType,

--- a/tests/starknet/keccak.rs
+++ b/tests/starknet/keccak.rs
@@ -321,6 +321,6 @@ fn keccak_test() {
     );
 
     assert!(!result.failure_flag);
-    assert_eq!(result.gas_consumed, 1000);
+    assert_eq!(result.remaining_gas, 1000);
     assert_eq!(result.return_values, vec![1.into()]);
 }

--- a/tests/starknet/keccak.rs
+++ b/tests/starknet/keccak.rs
@@ -321,6 +321,6 @@ fn keccak_test() {
     );
 
     assert!(!result.failure_flag);
-    assert_eq!(result.remaining_gas, 1000);
+    assert_eq!(result.remaining_gas, 18446744073709421435);
     assert_eq!(result.return_values, vec![1.into()]);
 }


### PR DESCRIPTION
Gas consumed is calculated on the SiR part, not here, got confused about that.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
