### PR TITLE
Fix `llvm.getelementptr` offset bug.

### DIFF
--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -493,7 +493,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -559,7 +559,7 @@ where
             context,
             Attribute::parse(
                 context,
-                "3618502788666131106986593281521497120414687020801267626233049500247285301248 : i252",
+                "106710729501573572985208420194530329073740042555888586719489 : i252",
             )
             .unwrap(),
             location,
@@ -978,7 +978,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -1341,7 +1341,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -1934,7 +1934,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -2233,7 +2233,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -2525,7 +2525,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -2983,7 +2983,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -3336,7 +3336,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -3735,7 +3735,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -4060,7 +4060,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])
@@ -4432,7 +4432,7 @@ where
                         ),
                         (
                             Identifier::new(context, "elem_type"),
-                            TypeAttribute::new(variant_tys[1].0).into(),
+                            TypeAttribute::new(IntegerType::new(context, 8).into()).into(),
                         ),
                     ])
                     .add_operands(&[result_ptr])

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -155,20 +155,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -710,20 +699,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -1039,20 +1017,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -1612,20 +1579,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -1995,20 +1951,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -2294,20 +2239,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -2586,20 +2520,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -3069,20 +2992,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -3397,20 +3309,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -3796,20 +3697,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),
@@ -4121,20 +4011,9 @@ where
 {
     // Extract self pointer.
     let ptr = entry
-        .append_operation(llvm::get_element_ptr(
-            context,
-            entry.argument(1)?.into(),
-            DenseI32ArrayAttribute::new(context, &[0]),
-            llvm::r#type::opaque_pointer(context),
-            llvm::r#type::opaque_pointer(context),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr = entry
         .append_operation(llvm::load(
             context,
-            ptr,
+            entry.argument(1)?.into(),
             llvm::r#type::opaque_pointer(context),
             location,
             LoadStoreOptions::default(),


### PR DESCRIPTION
# Fix `llvm.getelementptr` offset bug

## Description

We were computing a byte offset on a pointer taking into account the actual type, causing the offset to be off by a factor of the actual type's length.

In other words, we were calculating the offset as if it were a C pointer, whereas we needed a byte offset. Example:
```c
my_type_t *ptr;

// Wrong:
my_type_t *offset_ptr = ptr + offset;

//  Right:
my_type_t *offset_ptr = (my_type_t *) (((void *) ptr) + offset);
```

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
