### PR TITLE
Fix `snapshot_take` for non-trivially-copyable types (ex. `Array<T>`).

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -513,7 +513,7 @@ where
                     &param.id,
                     registry
                         .get_type(ty)?
-                        .build(context, module, registry, metadata_storage)
+                        .build(context, module, registry, metadata_storage, ty)
                         .map_err(make_type_builder_error(ty))?,
                 ))
             })
@@ -574,6 +574,7 @@ where
                                                         module,
                                                         registry,
                                                         metadata_storage,
+                                                        &var_info.ty,
                                                     )
                                                     .map_err(make_type_builder_error(&var_info.ty))
                                             },
@@ -701,7 +702,7 @@ where
     type_ids.iter().map(|id| {
         registry
             .get_type(id)?
-            .build(context, module, registry, metadata_storage)
+            .build(context, module, registry, metadata_storage, id)
             .map_err(make_type_builder_error(id))
     })
 }

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -87,8 +87,8 @@ where
 
 impl<TType, TLibfunc> LibfuncBuilder<TType, TLibfunc> for CoreConcreteLibfunc
 where
-    TType: GenericType,
-    TLibfunc: GenericLibfunc<Concrete = Self>,
+    TType: 'static + GenericType,
+    TLibfunc: 'static + GenericLibfunc<Concrete = Self>,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
 {
     type Error = CoreLibfuncBuilderError;

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -183,9 +183,7 @@ where
 
     let (elem_ty, elem_layout) =
         registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
-    let elem_stride = elem_layout
-        .pad_to_align()
-        .size();
+    let elem_stride = elem_layout.pad_to_align().size();
 
     let op_ptr = entry.append_operation(llvm::extract_value(
         context,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -101,9 +102,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let array_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(
         OperationBuilder::new("llvm.mlir.null", location)
@@ -164,16 +169,19 @@ where
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
 
-    let array_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
     let opaque_ptr_ty = llvm::r#type::opaque_pointer(context);
 
-    let elem_concrete_ty = registry.get_type(&info.ty)?;
-    let elem_ty = elem_concrete_ty.build(context, helper, registry, metadata)?;
+    let elem_ty = registry.build_type(context, helper, registry, metadata, &info.ty)?;
 
     let elem_stride = registry
         .get_type(&info.ty)?
@@ -373,9 +381,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let array_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
 
@@ -413,13 +425,16 @@ where
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
 
-    let array_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
 
-    let elem_concrete_ty = registry.get_type(&info.ty)?;
-    let elem_layout = elem_concrete_ty.layout(registry)?;
-    let elem_ty = elem_concrete_ty.build(context, helper, registry, metadata)?;
+    let (elem_ty, elem_layout) =
+        registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
@@ -557,13 +572,16 @@ where
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
 
-    let array_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
-    let elem_concrete_ty = registry.get_type(&info.ty)?;
-    let elem_layout = elem_concrete_ty.layout(registry)?;
-    let elem_ty = elem_concrete_ty.build(context, helper, registry, metadata)?;
+    let (elem_ty, elem_layout) =
+        registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let elem_stride = registry
         .get_type(&info.ty)?
@@ -834,13 +852,21 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let array_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
-    let elem_concrete_ty = registry.get_type(&info.branch_signatures()[0].vars[1].ty)?;
-    let elem_layout = elem_concrete_ty.layout(registry)?;
-    let elem_ty = elem_concrete_ty.build(context, helper, registry, metadata)?;
+    let (elem_ty, elem_layout) = registry.build_type_with_layout(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
@@ -977,13 +1003,16 @@ where
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
 
-    let array_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let array_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
 
-    let elem_concrete_ty = registry.get_type(&info.ty)?;
-    let elem_layout = elem_concrete_ty.layout(registry)?;
-    let elem_ty = elem_concrete_ty.build(context, helper, registry, metadata)?;
+    let (elem_ty, elem_layout) =
+        registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -181,11 +181,9 @@ where
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
     let opaque_ptr_ty = llvm::r#type::opaque_pointer(context);
 
-    let elem_ty = registry.build_type(context, helper, registry, metadata, &info.ty)?;
-
-    let elem_stride = registry
-        .get_type(&info.ty)?
-        .layout(registry)?
+    let (elem_ty, elem_layout) =
+        registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
+    let elem_stride = elem_layout
         .pad_to_align()
         .size();
 

--- a/src/libfuncs/bool.rs
+++ b/src/libfuncs/bool.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -228,9 +229,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let enum_ty = registry.get_type(&info.param_signatures()[0].ty)?;
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let tag_bits = enum_ty
         .variants()

--- a/src/libfuncs/box.rs
+++ b/src/libfuncs/box.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -125,9 +126,8 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let inner_type = registry.get_type(&info.ty)?;
-    let inner_layout = inner_type.layout(registry)?;
-    let inner_ty = inner_type.build(context, helper, registry, metadata)?;
+    let (inner_ty, inner_layout) =
+        registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let op = entry.append_operation(llvm::load(
         context,

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -67,12 +68,8 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let src_ty = registry
-        .get_type(&info.from_ty)?
-        .build(context, helper, registry, metadata)?;
-    let dst_ty = registry
-        .get_type(&info.to_ty)?
-        .build(context, helper, registry, metadata)?;
+    let src_ty = registry.build_type(context, helper, registry, metadata, &info.from_ty)?;
+    let dst_ty = registry.build_type(context, helper, registry, metadata, &info.to_ty)?;
     assert!(info.from_nbits >= info.to_nbits);
 
     if info.from_nbits == info.to_nbits {

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -15,7 +15,7 @@ use crate::{
         felt252::{register_prime_modulo_meta, Felt252},
         TypeBuilder,
     },
-    utils::get_integer_layout,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -904,9 +904,13 @@ where
             context,
             entry.argument(0)?.into(),
             DenseI64ArrayAttribute::new(context, &[0]),
-            registry
-                .get_type(&info.branch_signatures()[0].vars[0].ty)?
-                .build(context, helper, registry, metadata)?,
+            registry.build_type(
+                context,
+                helper,
+                registry,
+                metadata,
+                &info.branch_signatures()[0].vars[0].ty,
+            )?,
             location,
         ))
         .result(0)?
@@ -916,9 +920,13 @@ where
             context,
             entry.argument(0)?.into(),
             DenseI64ArrayAttribute::new(context, &[1]),
-            registry
-                .get_type(&info.branch_signatures()[0].vars[1].ty)?
-                .build(context, helper, registry, metadata)?,
+            registry.build_type(
+                context,
+                helper,
+                registry,
+                metadata,
+                &info.branch_signatures()[0].vars[1].ty,
+            )?,
             location,
         ))
         .result(0)?
@@ -944,9 +952,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let ec_point_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let ec_point_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let point = entry
         .append_operation(llvm::undef(ec_point_ty, location))

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
-    utils::padding_needed_for,
+    utils::{padding_needed_for, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -89,9 +89,13 @@ where
             .unwrap(),
     )?;
 
-    let enum_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let enum_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(arith::constant(
         context,
@@ -208,9 +212,13 @@ where
             .unwrap(),
     )?;
 
-    let enum_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let enum_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let op0 = helper.init_block().append_operation(arith::constant(
         context,

--- a/src/libfuncs/felt252.rs
+++ b/src/libfuncs/felt252.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     types::{felt252::Felt252, TypeBuilder},
-    utils::mlir_asm,
+    utils::{mlir_asm, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -81,9 +81,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let bool_ty = IntegerType::new(context, 1).into();
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
     let i256 = IntegerType::new(context, 256).into();
     let i512 = IntegerType::new(context, 512).into();
 
@@ -227,9 +231,13 @@ where
         _ => info.c.to_biguint().unwrap(),
     };
 
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let attr_c = Attribute::parse(context, &format!("{value} : {felt252_ty}")).unwrap();
 

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -62,9 +63,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let _dict_ptr_type = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let _dict_ptr_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let segment_arena = entry.argument(0)?.into();
 

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -13,7 +13,7 @@ use crate::{
         MetadataStorage,
     },
     types::TypeBuilder,
-    utils::get_integer_layout,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -81,16 +81,29 @@ where
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
 
-    let key_type = registry.get_type(&info.param_signatures()[1].ty)?;
-    let key_ty = key_type.build(context, helper, registry, metadata)?;
-    let key_layout = key_type.layout(registry)?;
+    let (key_ty, key_layout) = registry.build_type_with_layout(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
 
-    let entry_type = registry.get_type(&info.branch_signatures()[0].vars[0].ty)?;
-    let entry_ty = entry_type.build(context, helper, registry, metadata)?;
+    let entry_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
-    let value_type = registry.get_type(&info.branch_signatures()[0].vars[1].ty)?;
-    let value_ty = value_type.build(context, helper, registry, metadata)?;
-    let value_layout = value_type.layout(registry)?;
+    let (value_ty, value_layout) = registry.build_type_with_layout(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let dict_ptr = entry.argument(0)?.into();
     let key_value = entry.argument(1)?.into();

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     metadata::{tail_recursion::TailRecursionMeta, MetadataStorage},
     types::TypeBuilder,
-    utils::generate_function_name,
+    utils::{generate_function_name, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{function_call::FunctionCallConcreteLibfunc, GenericLibfunc, GenericType},
@@ -49,13 +49,7 @@ where
     let result_types = info.signature.branch_signatures[0]
         .vars
         .iter()
-        .map(|x| {
-            Result::Ok(
-                registry
-                    .get_type(&x.ty)?
-                    .build(context, helper, registry, metadata)?,
-            )
-        })
+        .map(|x| Result::Ok(registry.build_type(context, helper, registry, metadata, &x.ty)?))
         .collect::<Result<Vec<_>>>()?;
 
     if let Some(tailrec_meta) = metadata.get_mut::<TailRecursionMeta>() {

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     metadata::{gas::GasCost, MetadataStorage},
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -200,9 +201,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let builtin_costs_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let builtin_costs_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     // TODO: Implement libfunc.
     let op0 = entry.append_operation(llvm::undef(builtin_costs_ty, location));

--- a/src/libfuncs/mem.rs
+++ b/src/libfuncs/mem.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -98,9 +99,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let target_type = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let target_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let op = entry.append_operation(llvm::undef(target_type, location));
     let value_undef = op.result(0)?.into();

--- a/src/libfuncs/nullable.rs
+++ b/src/libfuncs/nullable.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -121,8 +122,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let param_type = registry.get_type(&info.param_signatures()[0].ty)?;
-    let param_ty = param_type.build(context, helper, registry, metadata)?;
+    let param_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let arg = entry.argument(0)?.into();
 

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     types::TypeBuilder,
-    utils::get_integer_layout,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -74,9 +74,13 @@ where
         .get_mut::<RuntimeBindingsMeta>()
         .expect("Runtime library not available.");
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
 
     let i256_ty = IntegerType::new(context, 256).into();
     let layout_i256 = get_integer_layout(256);

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     types::TypeBuilder,
-    utils::get_integer_layout,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -73,9 +73,13 @@ where
         .get_mut::<RuntimeBindingsMeta>()
         .expect("Runtime library not available.");
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
 
     let i256_ty = IntegerType::new(context, 256).into();
     let layout_i256 = get_integer_layout(256);

--- a/src/libfuncs/snapshot_take.rs
+++ b/src/libfuncs/snapshot_take.rs
@@ -39,15 +39,24 @@ where
     // TODO: Should this act like dup like it does now? or are there special requirements. So far it seems to work.
     // TODO: Handle non-trivially-copyable types (ex. arrays) and maybe update docs.
 
+    let original_value = entry.argument(0)?.into();
     let cloned_value = match metadata
         .get_mut::<SnapshotClonesMeta<TType, TLibfunc>>()
         .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
     {
-        Some(invoke_fn) => invoke_fn(context, registry, entry, location, helper, metadata)?,
-        None => entry.argument(0)?.into(),
+        Some(invoke_fn) => invoke_fn(
+            context,
+            registry,
+            entry,
+            location,
+            helper,
+            metadata,
+            original_value,
+        )?,
+        None => original_value,
     };
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), cloned_value], location));
+    entry.append_operation(helper.br(0, &[original_value, cloned_value], location));
 
     Ok(())
 }

--- a/src/libfuncs/snapshot_take.rs
+++ b/src/libfuncs/snapshot_take.rs
@@ -8,7 +8,7 @@ use crate::{
         libfuncs::{Error, Result},
         CoreTypeBuilderError,
     },
-    metadata::MetadataStorage,
+    metadata::{snapshot_clones::SnapshotClonesMeta, MetadataStorage},
     types::TypeBuilder,
 };
 use cairo_lang_sierra::{
@@ -22,28 +22,32 @@ use melior::{
 
 /// Generate MLIR operations for the `snapshot_take` libfunc.
 pub fn build<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
-    _registry: &ProgramRegistry<TType, TLibfunc>,
+    context: &'ctx Context,
+    registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    _metadata: &mut MetadataStorage,
-    _info: &SignatureOnlyConcreteLibfunc,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()>
 where
-    TType: GenericType,
-    TLibfunc: GenericLibfunc,
+    TType: 'static + GenericType,
+    TLibfunc: 'static + GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     // TODO: Should this act like dup like it does now? or are there special requirements. So far it seems to work.
     // TODO: Handle non-trivially-copyable types (ex. arrays) and maybe update docs.
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), entry.argument(0)?.into()],
-        location,
-    ));
+    let cloned_value = match metadata
+        .get_mut::<SnapshotClonesMeta<TType, TLibfunc>>()
+        .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
+    {
+        Some(invoke_fn) => invoke_fn(context, registry, entry, location, helper, metadata)?,
+        None => entry.argument(0)?.into(),
+    };
+
+    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), cloned_value], location));
 
     Ok(())
 }

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -12,7 +12,7 @@ use crate::{
     metadata::MetadataStorage,
     starknet::handler::StarkNetSyscallHandlerCallbacks,
     types::TypeBuilder,
-    utils::get_integer_layout,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -2636,30 +2636,23 @@ where
         let mut layout = tag_layout;
         let output = [
             {
-                let payload_ty = llvm::r#type::r#struct(
+                let (p0_ty, p0_layout) = registry.build_type_with_layout(
                     context,
-                    &[
-                        registry
-                            .get_type(&info.branch_signatures()[0].vars[2].ty)?
-                            .build(context, helper, registry, metadata)?,
-                        registry
-                            .get_type(&info.branch_signatures()[0].vars[3].ty)?
-                            .build(context, helper, registry, metadata)?,
-                    ],
-                    false,
-                );
-                let payload_layout = {
-                    let layout = registry
-                        .get_type(&info.branch_signatures()[0].vars[2].ty)?
-                        .layout(registry)?;
-                    layout
-                        .extend(
-                            registry
-                                .get_type(&info.branch_signatures()[0].vars[3].ty)?
-                                .layout(registry)?,
-                        )?
-                        .0
-                };
+                    helper,
+                    registry,
+                    metadata,
+                    &info.branch_signatures()[0].vars[2].ty,
+                )?;
+                let (p1_ty, p1_layout) = registry.build_type_with_layout(
+                    context,
+                    helper,
+                    registry,
+                    metadata,
+                    &info.branch_signatures()[0].vars[3].ty,
+                )?;
+
+                let payload_ty = llvm::r#type::r#struct(context, &[p0_ty, p1_ty], false);
+                let payload_layout = p0_layout.extend(p1_layout)?.0;
 
                 let full_layout = tag_layout.extend(payload_layout)?.0;
                 layout = Layout::from_size_align(
@@ -2670,11 +2663,13 @@ where
                 (payload_ty, payload_layout)
             },
             {
-                let concrete_payload_ty =
-                    registry.get_type(&info.branch_signatures()[1].vars[2].ty)?;
-
-                let payload_ty = concrete_payload_ty.build(context, helper, registry, metadata)?;
-                let payload_layout = concrete_payload_ty.layout(registry)?;
+                let (payload_ty, payload_layout) = registry.build_type_with_layout(
+                    context,
+                    helper,
+                    registry,
+                    metadata,
+                    &info.branch_signatures()[1].vars[2].ty,
+                )?;
 
                 let full_layout = tag_layout.extend(payload_layout)?.0;
                 layout = Layout::from_size_align(

--- a/src/libfuncs/struct.rs
+++ b/src/libfuncs/struct.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -65,9 +66,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let struct_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let struct_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let mut acc = entry.append_operation(llvm::undef(struct_ty, location));
     for i in 0..info.param_signatures().len() {
@@ -101,9 +106,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let struct_ty = registry
-        .get_type(&info.param_signatures()[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let struct_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[0].ty,
+    )?;
 
     let mut fields = Vec::<Value>::with_capacity(info.branch_signatures()[0].vars.len());
     for i in 0..info.branch_signatures()[0].vars.len() {

--- a/src/libfuncs/uint128.rs
+++ b/src/libfuncs/uint128.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
-    utils::mlir_asm,
+    utils::{mlir_asm, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -107,9 +107,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let u128_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let u128_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let bswap_intrin_attr = StringAttribute::new(context, "llvm.bswap.i128").into();
 
@@ -140,9 +144,13 @@ where
 {
     let value = info.c;
 
-    let u128_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let u128_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
 
     let attr_c = Attribute::parse(context, &format!("{value} : {u128_ty}")).unwrap();
 
@@ -727,9 +735,13 @@ where
     let origin_type = lhs.r#type();
 
     let target_type = IntegerType::new(context, 256).into();
-    let guarantee_type = registry
-        .get_type(&info.output_types()[0][2])?
-        .build(context, helper, registry, metadata)?;
+    let guarantee_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][2],
+    )?;
 
     let op = entry.append_operation(arith::extui(lhs, target_type, location));
     let lhs = op.result(0)?.into();

--- a/src/libfuncs/uint16.rs
+++ b/src/libfuncs/uint16.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -99,9 +100,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let value = info.c;
-    let value_ty = registry
-        .get_type(&info.signature.branch_signatures[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let value_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.signature.branch_signatures[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(arith::constant(
         context,
@@ -297,9 +302,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let target_type = registry
-        .get_type(&info.output_types()[0][0])?
-        .build(context, helper, registry, metadata)?;
+    let target_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][0],
+    )?;
     let lhs: Value = entry.argument(0)?.into();
     let rhs: Value = entry.argument(1)?.into();
 
@@ -332,9 +341,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
     let value: Value = entry.argument(0)?.into();
 
     let op = entry.append_operation(arith::extui(value, felt252_ty, location));
@@ -630,12 +643,20 @@ where
     let range_check: Value = entry.argument(0)?.into();
     let value: Value = entry.argument(1)?.into();
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
-    let result_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
+    let result_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let op = entry.append_operation(arith::constant(
         context,

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -80,9 +81,13 @@ where
     let i128_ty = IntegerType::new(context, 128).into();
     let i256_ty = IntegerType::new(context, 256).into();
 
-    let guarantee_type = registry
-        .get_type(&info.output_types()[0][3])?
-        .build(context, helper, registry, metadata)?;
+    let guarantee_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][3],
+    )?;
 
     let lhs_struct: Value = entry.argument(1)?.into();
     let rhs_struct: Value = entry.argument(2)?.into();

--- a/src/libfuncs/uint32.rs
+++ b/src/libfuncs/uint32.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -99,9 +100,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let value = info.c;
-    let value_ty = registry
-        .get_type(&info.signature.branch_signatures[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let value_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.signature.branch_signatures[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(arith::constant(
         context,
@@ -297,9 +302,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let target_type = registry
-        .get_type(&info.output_types()[0][0])?
-        .build(context, helper, registry, metadata)?;
+    let target_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][0],
+    )?;
     let lhs: Value = entry.argument(0)?.into();
     let rhs: Value = entry.argument(1)?.into();
 
@@ -332,9 +341,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
     let value: Value = entry.argument(0)?.into();
 
     let op = entry.append_operation(arith::extui(value, felt252_ty, location));
@@ -630,12 +643,20 @@ where
     let range_check: Value = entry.argument(0)?.into();
     let value: Value = entry.argument(1)?.into();
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
-    let result_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
+    let result_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let op = entry.append_operation(arith::constant(
         context,

--- a/src/libfuncs/uint64.rs
+++ b/src/libfuncs/uint64.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -99,9 +100,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let value = info.c;
-    let value_ty = registry
-        .get_type(&info.signature.branch_signatures[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let value_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.signature.branch_signatures[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(arith::constant(
         context,
@@ -298,9 +303,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let target_type = registry
-        .get_type(&info.output_types()[0][0])?
-        .build(context, helper, registry, metadata)?;
+    let target_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][0],
+    )?;
     let lhs: Value = entry.argument(0)?.into();
     let rhs: Value = entry.argument(1)?.into();
 
@@ -333,9 +342,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
     let value: Value = entry.argument(0)?.into();
 
     let op = entry.append_operation(arith::extui(value, felt252_ty, location));
@@ -631,12 +644,20 @@ where
     let range_check: Value = entry.argument(0)?.into();
     let value: Value = entry.argument(1)?.into();
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
-    let result_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
+    let result_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let op = entry.append_operation(arith::constant(
         context,

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     metadata::MetadataStorage,
     types::TypeBuilder,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -99,9 +100,13 @@ where
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
     let value = info.c;
-    let value_ty = registry
-        .get_type(&info.signature.branch_signatures[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let value_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.signature.branch_signatures[0].vars[0].ty,
+    )?;
 
     let op0 = entry.append_operation(arith::constant(
         context,
@@ -297,9 +302,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let target_type = registry
-        .get_type(&info.output_types()[0][0])?
-        .build(context, helper, registry, metadata)?;
+    let target_type = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.output_types()[0][0],
+    )?;
     let lhs: Value = entry.argument(0)?.into();
     let rhs: Value = entry.argument(1)?.into();
 
@@ -332,9 +341,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let felt252_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[0].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[0].ty,
+    )?;
     let value: Value = entry.argument(0)?.into();
 
     let op = entry.append_operation(arith::extui(value, felt252_ty, location));
@@ -620,12 +633,20 @@ where
     let range_check: Value = entry.argument(0)?.into();
     let value: Value = entry.argument(1)?.into();
 
-    let felt252_ty = registry
-        .get_type(&info.param_signatures()[1].ty)?
-        .build(context, helper, registry, metadata)?;
-    let result_ty = registry
-        .get_type(&info.branch_signatures()[0].vars[1].ty)?
-        .build(context, helper, registry, metadata)?;
+    let felt252_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.param_signatures()[1].ty,
+    )?;
+    let result_ty = registry.build_type(
+        context,
+        helper,
+        registry,
+        metadata,
+        &info.branch_signatures()[0].vars[1].ty,
+    )?;
 
     let op = entry.append_operation(arith::constant(
         context,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -18,6 +18,7 @@ pub mod gas;
 pub mod prime_modulo;
 pub mod realloc_bindings;
 pub mod runtime_bindings;
+pub mod snapshot_clones;
 pub mod syscall_handler;
 pub mod tail_recursion;
 
@@ -88,6 +89,17 @@ impl MetadataStorage {
         self.entries
             .get_mut(&TypeId::of::<T>())
             .map(|meta| meta.downcast_mut::<T>().unwrap())
+    }
+
+    pub fn get_or_insert_with<T>(&mut self, meta_gen: impl FnOnce() -> T) -> &mut T
+    where
+        T: Any,
+    {
+        self.entries
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(meta_gen()))
+            .downcast_mut::<T>()
+            .unwrap()
     }
 }
 

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -1,0 +1,104 @@
+use super::MetadataStorage;
+use crate::{
+    error::{libfuncs, CoreTypeBuilderError},
+    libfuncs::{LibfuncBuilder, LibfuncHelper},
+    types::{TypeBuilder, WithSelf},
+};
+use cairo_lang_sierra::{
+    extensions::{GenericLibfunc, GenericType},
+    ids::ConcreteTypeId,
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    ir::{Block, Location, Value},
+    Context,
+};
+use std::{collections::HashMap, sync::Arc};
+
+pub type CloneFn<TType, TLibfunc, P> = for<'ctx, 'this> fn(
+    &'ctx Context,
+    &ProgramRegistry<TType, TLibfunc>,
+    &'this Block<'ctx>,
+    Location<'ctx>,
+    &LibfuncHelper<'ctx, 'this>,
+    &mut MetadataStorage,
+    WithSelf<P>,
+) -> libfuncs::Result<Value<'ctx, 'this>>;
+
+type CloneFnWrapper<TType, TLibfunc> = Arc<
+    dyn for<'ctx, 'this> Fn(
+        &'ctx Context,
+        &ProgramRegistry<TType, TLibfunc>,
+        &'this Block<'ctx>,
+        Location<'ctx>,
+        &LibfuncHelper<'ctx, 'this>,
+        &mut MetadataStorage,
+    ) -> libfuncs::Result<Value<'ctx, 'this>>,
+>;
+
+// #[derive(Debug)]
+pub struct SnapshotClonesMeta<TType, TLibfunc>
+where
+    TType: 'static + GenericType,
+    TLibfunc: 'static + GenericLibfunc,
+    <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
+    <TLibfunc as GenericLibfunc>::Concrete:
+        LibfuncBuilder<TType, TLibfunc, Error = libfuncs::Error>,
+{
+    mappings: HashMap<ConcreteTypeId, CloneFnWrapper<TType, TLibfunc>>,
+}
+
+impl<TType, TLibfunc> SnapshotClonesMeta<TType, TLibfunc>
+where
+    TType: 'static + GenericType,
+    TLibfunc: 'static + GenericLibfunc,
+    <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
+    <TLibfunc as GenericLibfunc>::Concrete:
+        LibfuncBuilder<TType, TLibfunc, Error = libfuncs::Error>,
+{
+    pub fn register<P>(
+        &mut self,
+        id: ConcreteTypeId,
+        handler: CloneFn<TType, TLibfunc, P>,
+        params: P,
+    ) where
+        P: 'static,
+    {
+        let self_ty = id.clone();
+        self.mappings.insert(
+            id,
+            Arc::new(
+                move |context, registry, entry, location, helper, metadata| {
+                    handler(
+                        context,
+                        registry,
+                        entry,
+                        location,
+                        helper,
+                        metadata,
+                        WithSelf::new(&self_ty, &params),
+                    )
+                },
+            ),
+        );
+    }
+
+    pub fn wrap_invoke(&self, id: &ConcreteTypeId) -> Option<CloneFnWrapper<TType, TLibfunc>> {
+        self.mappings.get(id).cloned()
+    }
+}
+
+impl<TType, TLibfunc> Default for SnapshotClonesMeta<TType, TLibfunc>
+where
+    TType: GenericType,
+    TLibfunc: GenericLibfunc,
+    <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
+    <TLibfunc as GenericLibfunc>::Concrete:
+        LibfuncBuilder<TType, TLibfunc, Error = libfuncs::Error>,
+{
+    fn default() -> Self {
+        Self {
+            mappings: Default::default(),
+        }
+    }
+}

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -23,6 +23,7 @@ pub type CloneFn<TType, TLibfunc, P> = for<'ctx, 'this> fn(
     &LibfuncHelper<'ctx, 'this>,
     &mut MetadataStorage,
     WithSelf<P>,
+    Value<'ctx, 'this>,
 ) -> libfuncs::Result<Value<'ctx, 'this>>;
 
 type CloneFnWrapper<TType, TLibfunc> = Arc<
@@ -33,6 +34,7 @@ type CloneFnWrapper<TType, TLibfunc> = Arc<
         Location<'ctx>,
         &LibfuncHelper<'ctx, 'this>,
         &mut MetadataStorage,
+        Value<'this, 'ctx>,
     ) -> libfuncs::Result<Value<'ctx, 'this>>,
 >;
 
@@ -68,7 +70,7 @@ where
         self.mappings.insert(
             id,
             Arc::new(
-                move |context, registry, entry, location, helper, metadata| {
+                move |context, registry, entry, location, helper, metadata, value| {
                     handler(
                         context,
                         registry,
@@ -77,6 +79,7 @@ where
                         helper,
                         metadata,
                         WithSelf::new(&self_ty, &params),
+                        value,
                     )
                 },
             ),

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -207,7 +207,7 @@ where
 
             entry.append_operation(llvm::call_intrinsic(
                 context,
-                StringAttribute::new(context, "llvm.memcpy.inline"),
+                StringAttribute::new(context, "llvm.memcpy"),
                 &[dst_ptr, src_ptr, dst_len_bytes, is_volatile],
                 &[],
                 location,

--- a/src/types/bitwise.rs
+++ b/src/types/bitwise.rs
@@ -3,7 +3,7 @@
 //! The bitwise type is used in the VM for computing bitwise operations. Since this can be done
 //! natively in MLIR, this type is effectively an unit type.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -26,7 +26,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/box.rs
+++ b/src/types/box.rs
@@ -12,7 +12,7 @@
 //! pub struct Box<T>(pub T);
 //! ```
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -35,7 +35,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoAndTypeConcreteType,
+    _info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/builtin_costs.rs
+++ b/src/types/builtin_costs.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -25,7 +25,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/ec_op.rs
+++ b/src/types/ec_op.rs
@@ -3,7 +3,7 @@
 //! The ec operation type is used in the VM for computing bitwise operations. Since this can be done
 //! natively in MLIR, this type is effectively an unit type.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -26,7 +26,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/ec_point.rs
+++ b/src/types/ec_point.rs
@@ -1,6 +1,6 @@
 //! # Elliptic curve point type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -23,7 +23,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/ec_state.rs
+++ b/src/types/ec_state.rs
@@ -1,6 +1,6 @@
 //! # Elliptic curve state type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -23,7 +23,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/felt252.rs
+++ b/src/types/felt252.rs
@@ -4,7 +4,7 @@
 //! [finite field](https://en.wikipedia.org/wiki/Finite_field) modulo
 //! [a prime number](struct@self::PRIME).
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
@@ -42,7 +42,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -5,7 +5,7 @@
 //! This type is represented as a pointer to a heap allocated Rust hashmap, interacted through the runtime functions to
 //! insert and get elements.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -28,7 +28,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoAndTypeConcreteType,
+    _info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/felt252_dict_entry.rs
+++ b/src/types/felt252_dict_entry.rs
@@ -11,7 +11,7 @@
 //! |   2   | `!llvm.ptr`    | Pointer to the dictionary (rust) |
 //!
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -34,7 +34,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoAndTypeConcreteType,
+    _info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/gas_builtin.rs
+++ b/src/types/gas_builtin.rs
@@ -2,7 +2,7 @@
 //!
 //! The gas builtin is just a number indicating how many
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -24,7 +24,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/non_zero.rs
+++ b/src/types/non_zero.rs
@@ -12,10 +12,11 @@
 //! pub struct NonZero<T>(pub T);
 //! ```
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{types::InfoAndTypeConcreteType, GenericLibfunc, GenericType},
@@ -34,14 +35,12 @@ pub fn build<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoAndTypeConcreteType,
+    info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    registry
-        .get_type(&info.ty)?
-        .build(context, module, registry, metadata)
+    registry.build_type(context, module, registry, metadata, &info.ty)
 }

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -5,7 +5,7 @@
 //! This is so we only check if the ptr is nullptr for nulability, instead of using a enum in this case.
 //! TODO
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -28,7 +28,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoAndTypeConcreteType,
+    _info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/pedersen.rs
+++ b/src/types/pedersen.rs
@@ -2,7 +2,7 @@
 //!
 //! Type representing the Pedersen hash builtin.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -25,7 +25,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/poseidon.rs
+++ b/src/types/poseidon.rs
@@ -2,7 +2,7 @@
 //!
 //! Type representing the Poseidon builtin.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -25,7 +25,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/range_check.rs
+++ b/src/types/range_check.rs
@@ -3,7 +3,7 @@
 //! The range check type is used in the VM for checking whether values are in a specific range.
 //! Since this can be done natively in MLIR, this type is effectively an unit type.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -26,7 +26,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/segment_arena.rs
+++ b/src/types/segment_arena.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -25,7 +25,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/squashed_felt252_dict.rs
+++ b/src/types/squashed_felt252_dict.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -25,7 +25,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoAndTypeConcreteType,
+    _info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/stark_net.rs
+++ b/src/types/stark_net.rs
@@ -21,7 +21,7 @@
 
 // TODO: Maybe the types used here can be i251 instead of i252.
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -46,29 +46,49 @@ pub fn build<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    selector: &StarkNetTypeConcrete,
+    selector: WithSelf<StarkNetTypeConcrete>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    match selector {
-        StarkNetTypeConcrete::ClassHash(info) => {
-            build_class_hash(context, module, registry, metadata, info)
-        }
-        StarkNetTypeConcrete::ContractAddress(info) => {
-            build_contract_address(context, module, registry, metadata, info)
-        }
-        StarkNetTypeConcrete::StorageBaseAddress(info) => {
-            build_storage_base_address(context, module, registry, metadata, info)
-        }
-        StarkNetTypeConcrete::StorageAddress(info) => {
-            build_storage_address(context, module, registry, metadata, info)
-        }
-        StarkNetTypeConcrete::System(info) => {
-            build_system(context, module, registry, metadata, info)
-        }
+    match &*selector {
+        StarkNetTypeConcrete::ClassHash(info) => build_class_hash(
+            context,
+            module,
+            registry,
+            metadata,
+            WithSelf::new(selector.self_ty(), info),
+        ),
+        StarkNetTypeConcrete::ContractAddress(info) => build_contract_address(
+            context,
+            module,
+            registry,
+            metadata,
+            WithSelf::new(selector.self_ty(), info),
+        ),
+        StarkNetTypeConcrete::StorageBaseAddress(info) => build_storage_base_address(
+            context,
+            module,
+            registry,
+            metadata,
+            WithSelf::new(selector.self_ty(), info),
+        ),
+        StarkNetTypeConcrete::StorageAddress(info) => build_storage_address(
+            context,
+            module,
+            registry,
+            metadata,
+            WithSelf::new(selector.self_ty(), info),
+        ),
+        StarkNetTypeConcrete::System(info) => build_system(
+            context,
+            module,
+            registry,
+            metadata,
+            WithSelf::new(selector.self_ty(), info),
+        ),
         StarkNetTypeConcrete::Secp256Point(_) => todo!(),
     }
 }
@@ -78,7 +98,7 @@ pub fn build_class_hash<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoOnlyConcreteType,
+    info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
@@ -94,7 +114,7 @@ pub fn build_contract_address<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoOnlyConcreteType,
+    info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
@@ -110,7 +130,7 @@ pub fn build_storage_base_address<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoOnlyConcreteType,
+    info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
@@ -126,7 +146,7 @@ pub fn build_storage_address<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoOnlyConcreteType,
+    info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
@@ -142,7 +162,7 @@ pub fn build_system<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint128.rs
+++ b/src/types/uint128.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 128-bit integer type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -22,7 +22,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint128_mul_guarantee.rs
+++ b/src/types/uint128_mul_guarantee.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 128-bit multiplication guarantee type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -23,7 +23,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint16.rs
+++ b/src/types/uint16.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 16-bit integer type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -22,7 +22,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint32.rs
+++ b/src/types/uint32.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 32-bit integer type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -22,7 +22,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint64.rs
+++ b/src/types/uint64.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 64-bit integer type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -22,7 +22,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uint8.rs
+++ b/src/types/uint8.rs
@@ -1,6 +1,6 @@
 //! # Unsigned 8-bit integer type
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
@@ -22,7 +22,7 @@ pub fn build<'ctx, TType, TLibfunc>(
     _module: &Module<'ctx>,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     _metadata: &mut MetadataStorage,
-    _info: &InfoOnlyConcreteType,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,

--- a/src/types/uninitialized.rs
+++ b/src/types/uninitialized.rs
@@ -2,10 +2,11 @@
 //!
 //! TODO
 
-use super::TypeBuilder;
+use super::{TypeBuilder, WithSelf};
 use crate::{
     error::types::{Error, Result},
     metadata::MetadataStorage,
+    utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{types::InfoAndTypeConcreteType, GenericLibfunc, GenericType},
@@ -24,14 +25,12 @@ pub fn build<'ctx, TType, TLibfunc>(
     module: &Module<'ctx>,
     registry: &ProgramRegistry<TType, TLibfunc>,
     metadata: &mut MetadataStorage,
-    info: &InfoAndTypeConcreteType,
+    info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>>
 where
     TType: GenericType,
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    registry
-        .get_type(&info.ty)?
-        .build(context, module, registry, metadata)
+    registry.build_type(context, module, registry, metadata, &info.ty)
 }


### PR DESCRIPTION
# Fix `snapshot_take` for non-trivially-copyable types

## Description

  - Add a new metadata for overriding `snapshot_take`'s default behavior.
  - Override the behavior of `Array<T>` to clone the data instead of just sharing the pointer.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
