### PR TITLE
Add `LLVM_SYS_170_PREFIX` export to env-macos.sh

### DIFF
--- a/env-macos.sh
+++ b/env-macos.sh
@@ -4,7 +4,9 @@
 # It sets the LLVM environment variables.
 
 MLIR_SYS_170_PREFIX="$(brew --prefix llvm@17)"
+LLVM_SYS_170_PREFIX="$(brew --prefix llvm@17)"
 TABLEGEN_170_PREFIX="$(brew --prefix llvm@17)"
 
 export MLIR_SYS_170_PREFIX
+export LLVM_SYS_170_PREFIX
 export TABLEGEN_170_PREFIX


### PR DESCRIPTION
Following the MacOs setup in the Getting Started section of the README leads to an error when running `make test` as the env var `LLVM_SYS_170_PREFIX` is not set. This PR adds this export to the env-macos.sh script.