### PR TITLE
Implement `struct_snapshot_deconstruct` libfunc

### DIFF
--- a/src/libfuncs/struct.rs
+++ b/src/libfuncs/struct.rs
@@ -47,7 +47,7 @@ where
             build_deconstruct(context, registry, entry, location, helper, metadata, info)
         }
         StructConcreteLibfunc::SnapshotDeconstruct(info) => {
-            build_snapshot_deconstruct(context, registry, entry, location, helper, metadata, info)
+            build_deconstruct(context, registry, entry, location, helper, metadata, info)
         }
     }
 }
@@ -94,51 +94,6 @@ where
 
 /// Generate MLIR operations for the `struct_deconstruct` libfunc.
 pub fn build_deconstruct<'ctx, 'this, TType, TLibfunc>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<TType, TLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()>
-where
-    TType: GenericType,
-    TLibfunc: GenericLibfunc,
-    <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
-    <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
-{
-    let struct_ty = registry.build_type(
-        context,
-        helper,
-        registry,
-        metadata,
-        &info.param_signatures()[0].ty,
-    )?;
-
-    let mut fields = Vec::<Value>::with_capacity(info.branch_signatures()[0].vars.len());
-    for i in 0..info.branch_signatures()[0].vars.len() {
-        fields.push(
-            entry
-                .append_operation(llvm::extract_value(
-                    context,
-                    entry.argument(0)?.into(),
-                    DenseI64ArrayAttribute::new(context, &[i.try_into()?]),
-                    crate::ffi::get_struct_field_type_at(&struct_ty, i),
-                    location,
-                ))
-                .result(0)?
-                .into(),
-        );
-    }
-
-    entry.append_operation(helper.br(0, &fields, location));
-
-    Ok(())
-}
-
-/// Generate MLIR operations for the `struct_deconstruct` libfunc.
-pub fn build_snapshot_deconstruct<'ctx, 'this, TType, TLibfunc>(
     context: &'ctx Context,
     registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -43,6 +43,7 @@ mod common;
 #[test_case("tests/cases/structs/bigger.cairo")]
 #[test_case("tests/cases/structs/enum_member.cairo")]
 #[test_case("tests/cases/structs/nested.cairo")]
+#[test_case("tests/cases/structs/struct_snapshot_deconstruct.cairo")]
 // gas
 #[test_case("tests/cases/gas/available_gas.cairo" => ignore["unimplemented"])]
 // bool

--- a/tests/cases/structs/struct_snapshot_deconstruct.cairo
+++ b/tests/cases/structs/struct_snapshot_deconstruct.cairo
@@ -1,0 +1,18 @@
+use array::ArrayTrait;
+
+#[derive(Drop)]
+struct A {
+    a: Array::<felt252>,
+    b: felt252,
+}
+
+fn bar(a: @Array::<felt252>, b: @felt252) -> felt252 {
+    *a[0] + *b
+}
+
+fn main() -> felt252 {
+    let mut numbers = ArrayTrait::new();
+    numbers.append(6);
+    let s = @A { a: numbers, b: 1}; 
+    bar(s.a, s.b)
+}


### PR DESCRIPTION
The implementation of `struct_deconstruct` libfunc already handles snapshots of structs propperly, so this PR is quite short
