### PR TITLE
Dry pass manager

### DIFF
--- a/src/bin/cairo-native-compile.rs
+++ b/src/bin/cairo-native-compile.rs
@@ -15,12 +15,12 @@ use cairo_lang_starknet::{
 use cairo_native::{
     debug_info::{DebugInfo, DebugLocations},
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
+    utils::run_pass_manager,
 };
 use clap::Parser;
 use melior::{
     dialect::DialectRegistry,
     ir::{Location, Module},
-    pass::{self, PassManager},
     utility::{register_all_dialects, register_all_llvm_translations},
     Context,
 };
@@ -88,18 +88,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         debug_info.as_ref(),
     )?;
 
-    // lower to llvm dialect
-    let pass_manager = PassManager::new(&context);
-    pass_manager.enable_verifier(true);
-    pass_manager.add_pass(pass::transform::create_canonicalizer());
-    pass_manager.add_pass(pass::conversion::create_scf_to_control_flow());
-    pass_manager.add_pass(pass::conversion::create_arith_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_control_flow_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_func_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_index_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_finalize_mem_ref_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_reconcile_unrealized_casts());
-    pass_manager.run(&mut module)?;
+    run_pass_manager(&context, &mut module)
+        .expect("Could not apply passes to the compiled test program.");
 
     let object = cairo_native::module_to_object(&module)?;
     cairo_native::object_to_shared_lib(&object, &args.output)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -645,7 +645,6 @@ pub mod test {
     use melior::{
         dialect::DialectRegistry,
         ir::{Location, Module},
-        pass::{self, PassManager},
         utility::{register_all_dialects, register_all_passes},
         Context, ExecutionEngine,
     };

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -31,7 +31,7 @@ use cairo_native::{
     },
     starknet::StarkNetSyscallHandler,
     types::felt252::PRIME,
-    utils::{find_entry_point_by_idx, register_runtime_symbols},
+    utils::{find_entry_point_by_idx, register_runtime_symbols, run_pass_manager},
     values::JITValue,
     ExecutionResult,
 };
@@ -44,7 +44,6 @@ use lambdaworks_math::{
 use melior::{
     dialect::DialectRegistry,
     ir::{Location, Module},
-    pass::{self, PassManager},
     utility::{register_all_dialects, register_all_passes},
     Context, ExecutionEngine,
 };
@@ -243,21 +242,7 @@ pub fn run_native_program(
         module.as_operation()
     );
 
-    let pass_manager = PassManager::new(&context);
-    pass_manager.enable_verifier(true);
-    pass_manager.add_pass(pass::transform::create_canonicalizer());
-
-    pass_manager.add_pass(pass::conversion::create_scf_to_control_flow());
-
-    pass_manager.add_pass(pass::conversion::create_arith_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_control_flow_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_func_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_index_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_finalize_mem_ref_to_llvm());
-    pass_manager.add_pass(pass::conversion::create_reconcile_unrealized_casts());
-
-    pass_manager
-        .run(&mut module)
+    run_pass_manager(&context, &mut module)
         .expect("Could not apply passes to the compiled test program.");
 
     let engine = ExecutionEngine::new(&module, 0, &[], false);


### PR DESCRIPTION
# Dry pass manager

## Description

Dry this by creating a utility function where we have a single place that registers passes into a pass manager.
The utils function is named `run_pass_manager`.

## Checklist
- [x] `run_program` in `src/utils.rs`
- [x] `run_native_program` in `tests/common.rs`
- [x] `main `in `src/bin/cairo-native-run.rs` (I supposed it refers to `src/bin/cairo-native-compile.rs`)
- [x] `lower_to_llvm` in `src/context.rs`
