### PR TITLE
Use smaller numbers in alexandria_math tests

### DIFF
--- a/tests/alexandria.rs
+++ b/tests/alexandria.rs
@@ -39,9 +39,9 @@ fn compare_inputless_function(function_name: &str) {
 
 // alexandria_math
 #[test_case("fib")]
-#[test_case("karatsuba" => ignore["System out of memory"])]
+#[test_case("karatsuba")]
 #[test_case("armstrong_number")]
-#[test_case("aliquot_sum" => ignore["System out of memory"])]
+#[test_case("aliquot_sum")]
 #[test_case("collatz_sequence" => ignore["Result mismatch"])]
 #[test_case("extended_euclidean_algorithm")]
 // alexandria_data_structures

--- a/tests/alexandria/src/lib.cairo
+++ b/tests/alexandria/src/lib.cairo
@@ -6,7 +6,7 @@ mod alexandria {
     }
 
     fn karatsuba() -> u128 {
-        alexandria_math::karatsuba::multiply(3754192357923759273591, 18492875)
+        alexandria_math::karatsuba::multiply(711, 1849)
     }
 
     fn armstrong_number() -> bool {
@@ -14,7 +14,7 @@ mod alexandria {
     }
 
     fn aliquot_sum() -> u128 {
-        alexandria_math::aliquot_sum::aliquot_sum(67472587892687682)
+        alexandria_math::aliquot_sum::aliquot_sum(674725)
     }
 
     fn collatz_sequence() -> Array<u128> {


### PR DESCRIPTION
The functions `karatsuba` & `aliquot_sum` cause the vm to run out of memory and cairo native to fail with a stack overflow error when big numbers are used
