### PR TITLE
Make `cache::aot` & `cache::jit` modules public

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,8 @@
 pub use self::{aot::AotProgramCache, jit::JitProgramCache};
 use std::hash::Hash;
 
-mod aot;
-mod jit;
+pub mod aot;
+pub mod jit;
 
 #[derive(Debug)]
 pub enum ProgramCache<'a, K>


### PR DESCRIPTION
The structs and methods in both of these modules are public but their modules are not. This makes it impossible to create a `PorgramCache` from starknet_in_rust
