### PR TITLE
dev: bump cairo compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab99b420650d41fee19ebaecddae01b5f74363f41dd281e264eb67bb3e8281"
+checksum = "a29e32d28184c60e42f7778eb19565f4a85719b1c1fb2698040533b3585ce2f0"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ba7f4b3f90ebc6c8edb31cfd51d4891f292f12b5c9374b8d1a73cc8fed0ad"
+checksum = "3511173da22f97b672209e8205a9b32a58acd8b8e8105da1484d7e015720b75c"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -461,18 +461,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fd4a5f20c9d629d47dcb4c909575446a546cc648da3dc080b062666c82a1a3"
+checksum = "7283a745b708ed9517da1ffca5ae778ea126a4fa26c1928c1f5b1ae9633072b7"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b621751cbdb1fc2adf1101d5e09d5938be5409c4e0d26b9b70764c2d5f55531"
+checksum = "cf754bdae762f61d376a66637733555d664391d309e4ad243de8aaa3dd2a6c7d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc471db5ba1430d9e9351b6a98f5ee6d46cac02ffc05762b1036f6139a2ed2b"
+checksum = "73dc18e30e2768c3b543cb45fab91096e860abb9329a9120fab89327b0a1502a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4b62e4f164f6972564da9473a44bf9abb3fb49c0e53bb9be5b0d35317b15fc"
+checksum = "76cddc82f049bc22c3c1ab00ef898749cdd70e035f8d3105935c4ce2626ba069"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e94a86a8040ff6abf01a995a114561340de8eee7157dd626dffefcad8d1f865"
+checksum = "442b489a89c5c29cf17daa7f60fb82f2f393a68296a28a437df4c11803ca8bbe"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70d9ad78e5f68afebfc339aac8d05c98dc2ba03cbfbc8c71d2ecc21d0879e7c"
+checksum = "c77820ab89f42eb3fd46d365c55c720fa18984931d5eecd325ad3d5805992163"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60422627250900757d093fae4e5afc26cedaf1c8c592077a095f195914349bd6"
+checksum = "86e561f74ef9bd8c5419524b7079cec046905271c4abdbee404cba6d2bcdf165"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156f4cb17b2cd534166f7456f35107d23320d90d2194010f4f23bbbf809bbba8"
+checksum = "1457c91df00d07cd02ecc68bfdc9c44b30d752088d2d2cc18965a4a7e168e3c0"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf161379bdeb2c0623fa1968011ef0b3705e5cebd5f32ef001f93c5a2435a9"
+checksum = "ad0bfcae383df402157f70087e8e6d3e13c012356d57a2f60662b1c21e6cfabf"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f3bdd22ddc32948bd910778a9774c8a591ea68aea61999184efd49fed889ac"
+checksum = "cd7fff56503361745f9d2e06d860f10f9e7532558d02f59a3243e54e132e6a9f"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793bb251d56ffa69e0807a0c2c86a49c78cb30d0b5f6c475c5e7fd6b8e6d7f46"
+checksum = "9ffbe5c88ebdc18b0799eec3f19c477301d53ad38232ab29d93c96fef38122a4"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b39de6458ce0b911fc41fdc7575b66f3bfc1e3c8690901a2efe8bb1404186"
+checksum = "3713819478e5b0c91b54459690e78325bb2e6ad2a71158799368ac77a3de3e56"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d670b3dc9862b05f7b836b1e7ab063ada41eb9c071fcfca0b13220d50a3aabd"
+checksum = "ed4ac8416d92ecdc90b30791983f8ad8e83017277300ea978232a585f0e2868e"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbea4f6b7b8d892f2367cf064762e8fc9b732c2e2232e21312443ab6dccbfed7"
+checksum = "e3919ca631935c6e6adfb6c7c79cd4e6f48691805fe6be6e8e415ded3d92248b"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59b283e5f09a1c8ce515464b0341f7561acefd8509526a54d1718b3f393c323"
+checksum = "051e20bc4eb91b279d677cdef3d835ce3156f72fffee8d6f37ad2267475c20a4"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283084394140d770fb57085f479c63823807f177ea8d5c30b7ac766ae87b95ce"
+checksum = "35274f05b36f4d7e40eea59d2c65612866f6c4f9759aed11d9ed9e40fe7303c9"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e04b731b7e379074fb0cd54245ff1b9ebfacfc509a86900e817862892d61f7"
+checksum = "96a662438160f8261f148448cac0efd9a5acf1f378bdb68b71c48d740bee08ad"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b706940cffaeece471aee1bbab8b83c7ef24fcf20335e1939a357a873ac731"
+checksum = "56d70f2a3b071dd6d67cf230e3d9bf0fb964b14925fc896dad3ebfea8bda83ba"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f908297ebcf542fa80bfb089684a25f6cdf66b2b4679abfc79608f65028c1d6"
+checksum = "98e66a25ec2aa90ebf273d69cc6968b3f91c27c29761efedd2e0006307c40800"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5429b964d498c8f517973eae538113a47b01d93eb597ced58944d5385055a7"
+checksum = "2ddcfcb623c22ef3e2d7df42af9f005d703df6fcfffac08bf8624389c240da14"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd0ae3d3122417e88a9f801529fd65f3a81483c59916c4906ac1a85f84b897c"
+checksum = "d745fe6f4055814da99ee42c1cbded856cf0945f866e7048cfe0a3c413671286"
 dependencies = [
  "genco",
  "xshell",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3465bc7d80387e26fe4dbfb76c744da8d4d8d324ed2c9f71e5f92bc295153d06"
+checksum = "13200382f707ec4f8857a66cc785f467e945d7e41ad4ce84a8dd8ef08893af02"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn 2.0.43",
  "which",
 ]
 
@@ -336,7 +336,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn 2.0.43",
  "which",
 ]
 
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cca7891c0df31a87740acbcda3f3c04e6516e283b67842386873f3a181fd91"
+checksum = "0dab99b420650d41fee19ebaecddae01b5f74363f41dd281e264eb67bb3e8281"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c4bd031bf62046af88e75b86f419ad7e2317c3b7ee26cbad367f2ff2f2bfa4"
+checksum = "2c4ba7f4b3f90ebc6c8edb31cfd51d4891f292f12b5c9374b8d1a73cc8fed0ad"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -448,7 +448,6 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
  "cairo-lang-parser",
- "cairo-lang-plugins",
  "cairo-lang-project",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
@@ -462,18 +461,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954529b40c914ff089bd06b4cdfa3b51f39fb8769a6f9af92ba745e4a1300bd4"
+checksum = "46fd4a5f20c9d629d47dcb4c909575446a546cc648da3dc080b062666c82a1a3"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2ab80b21943392da07b2ee54f1f7e15ac783ea1567ed27bd4682774713f7ee"
+checksum = "5b621751cbdb1fc2adf1101d5e09d5938be5409c4e0d26b9b70764c2d5f55531"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -488,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07052c58dc014904bfecc6fb253a0461bbdcdd3ac41f1385ac9fba5ef9a0da61"
+checksum = "2cc471db5ba1430d9e9351b6a98f5ee6d46cac02ffc05762b1036f6139a2ed2b"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -500,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac351e6a4af689df90119d95d8fa9441b8ad1b2eef6f4868ed7a1c1808f786c"
+checksum = "8a4b62e4f164f6972564da9473a44bf9abb3fb49c0e53bb9be5b0d35317b15fc"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -510,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f253875f0503f13d2a15e303db4f77a932a84600787a496938d0daf687945d"
+checksum = "1e94a86a8040ff6abf01a995a114561340de8eee7157dd626dffefcad8d1f865"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -524,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa602a50c7d216beb4c261036b024b24f90ce6724d623f1b23f56076584473c"
+checksum = "f70d9ad78e5f68afebfc339aac8d05c98dc2ba03cbfbc8c71d2ecc21d0879e7c"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -538,20 +537,21 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-traits 0.2.17",
  "once_cell",
  "salsa",
+ "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25e847ef219635b837cbfd8eed797a7aa6a4b01e1775065cff67b1d5bfda1fe"
+checksum = "60422627250900757d093fae4e5afc26cedaf1c8c592077a095f195914349bd6"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c109f0b788a95bb86cff0e3917e1ce7d75210020fc53904d2a5e3ba54728adb"
+checksum = "156f4cb17b2cd534166f7456f35107d23320d90d2194010f4f23bbbf809bbba8"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -588,20 +588,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bbbfe1934e11fe3cce4f23cdccd22341ed63af5d76e593234288dd4ba06f56"
+checksum = "3eaf161379bdeb2c0623fa1968011ef0b3705e5cebd5f32ef001f93c5a2435a9"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ba814a9dd17b1341204d8e7bb67775aadebc5138a475bdf176dff0f11999cb"
+checksum = "63f3bdd22ddc32948bd910778a9774c8a591ea68aea61999184efd49fed889ac"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c759ff583b3771e07338433ebc328a9c5a7c845e09e2875d24c0701a252709c9"
+checksum = "793bb251d56ffa69e0807a0c2c86a49c78cb30d0b5f6c475c5e7fd6b8e6d7f46"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -625,7 +625,6 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
- "cairo-lang-sierra-gas",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-sierra-type-size",
  "cairo-lang-starknet",
@@ -641,19 +640,21 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19678648e0efec3f837c0d75b6071bc2afe5c4bc611e177381478c023b72a74c"
+checksum = "e79b39de6458ce0b911fc41fdc7575b66f3bfc1e3c8690901a2efe8bb1404186"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
+ "cairo-lang-plugins",
  "cairo-lang-proc-macros",
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
+ "indoc",
  "itertools 0.11.0",
  "num-bigint",
  "num-traits 0.2.17",
@@ -664,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7d09f0b7461701a9ba5d7a2260551b5026cd8f6efc6ca9ca270f6c0a6fd23"
+checksum = "5d670b3dc9862b05f7b836b1e7ab063ada41eb9c071fcfca0b13220d50a3aabd"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -681,6 +682,7 @@ dependencies = [
  "regex",
  "salsa",
  "serde",
+ "serde_json",
  "sha3",
  "smol_str",
  "thiserror",
@@ -688,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e66740bcfadb365d488ff9c334f68cb4cb6a6cb9666ae12109fc6eee7371116"
+checksum = "bbea4f6b7b8d892f2367cf064762e8fc9b732c2e2232e21312443ab6dccbfed7"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -702,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac27c07af11fcdc9546a9c55c1463cb871fb5b7af1daa3cdf31cfb0872da3d88"
+checksum = "b59b283e5f09a1c8ce515464b0341f7561acefd8509526a54d1718b3f393c323"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -716,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456cd75547a127b8f4088216a419d317c753c6b9188e944846bf3a5193c14797"
+checksum = "283084394140d770fb57085f479c63823807f177ea8d5c30b7ac766ae87b95ce"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -730,6 +732,7 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-syntax",
  "cairo-lang-utils",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "num-bigint",
  "once_cell",
@@ -739,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da74c7c4a2df66b961a982396e0f5221d6594266aed48c76d8c22d5b0d96af5d"
+checksum = "02e04b731b7e379074fb0cd54245ff1b9ebfacfc509a86900e817862892d61f7"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -760,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fdf2dbda71f1ed4e4020914e7494ad32db84dbc75cc8dbf05c06caef678fc8"
+checksum = "29b706940cffaeece471aee1bbab8b83c7ef24fcf20335e1939a357a873ac731"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -770,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9217e979f11980609d13d3a5adea8438ec9345709ddfebca975cc9cd1f85201e"
+checksum = "5f908297ebcf542fa80bfb089684a25f6cdf66b2b4679abfc79608f65028c1d6"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -801,14 +804,15 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
+ "starknet-crypto 0.6.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d461d88e09ba7055822eb42d6b2c2ea38a4eaa5b9e4196d8f63db48c563fb56"
+checksum = "ca5429b964d498c8f517973eae538113a47b01d93eb597ced58944d5385055a7"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -822,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615745282c0c0d3a255c2ac2665a18ae1d163c54285014d85dacda2d5e53637"
+checksum = "4bd0ae3d3122417e88a9f801529fd65f3a81483c59916c4906ac1a85f84b897c"
 dependencies = [
  "genco",
  "xshell",
@@ -832,11 +836,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edcd2fba78af9b753614885464c9b5bf6041b7decba46587c2b0babc4197ac"
+checksum = "3465bc7d80387e26fe4dbfb76c744da8d4d8d324ed2c9f71e5f92bc295153d06"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itertools 0.11.0",
  "num-bigint",
  "num-traits 0.2.17",
@@ -1033,7 +1037,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1413,7 +1417,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1454,7 +1458,7 @@ checksum = "05aa0010e0e391b9a82dc87bfc4dbee3cb8260eec12ad9d83c12788299fa9093"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1519,9 +1523,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "genco"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fd234893ffe9cf5b81224ebb1d21bbe2eeb94d95bac3ea25c97cba7293304d"
+checksum = "98d7af598790738fee616426e669360fa361273b1b9c9b7f30c92fa627605cad"
 dependencies = [
  "genco-macros",
  "relative-path",
@@ -1530,13 +1534,13 @@ dependencies = [
 
 [[package]]
 name = "genco-macros"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c8cd3de2f32ee05ba2adaa90f8d0c354ffa0adeb2d186978d7ae70e5025e9"
+checksum = "d4cf186fea4af17825116f72932fe52cce9a13bae39ff63b4dc0cfdb3fb4bde1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1731,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -2026,7 +2030,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.38",
+ "syn 2.0.43",
  "tblgen",
  "unindent",
 ]
@@ -2354,7 +2358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -2471,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2481,7 +2485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2862,22 +2866,22 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3063,7 +3067,7 @@ checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
  "starknet-curve 0.4.0",
  "starknet-ff",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3149,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3251,7 +3255,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3263,7 +3267,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "test-case-core",
 ]
 
@@ -3284,7 +3288,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3367,14 +3371,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -3392,7 +3396,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3418,7 +3433,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3587,7 +3602,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -3609,7 +3624,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3810,7 +3825,7 @@ checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3830,5 +3845,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ with-runtime = ["cairo-native-runtime"]
 
 [dependencies]
 bumpalo = "3.14"
-cairo-lang-compiler = "2.3.1"
-cairo-lang-defs = "2.3.1"
-cairo-lang-diagnostics = "2.3.1"
-cairo-lang-filesystem = "2.3.1"
-cairo-lang-lowering = "2.3.1"
-cairo-lang-sierra = "2.3.1"
-cairo-lang-sierra-generator = "2.3.1"
+cairo-lang-compiler = "2.4.0"
+cairo-lang-defs = "2.4.0"
+cairo-lang-diagnostics = "2.4.0"
+cairo-lang-filesystem = "2.4.0"
+cairo-lang-lowering = "2.4.0"
+cairo-lang-sierra = "2.4.0"
+cairo-lang-sierra-generator = "2.4.0"
 educe = "0.5.5"
 id-arena = "2.2"
 itertools = "0.12"
@@ -44,34 +44,36 @@ melior = { version = "0.15.0", features = ["ods-dialects"] }
 mlir-sys = "0.2.1"
 num-bigint = "0.4.4"
 num-traits = "0.2"
-starknet-types-core = { version = "0.0.5", default-features = false, features = ["serde"] }
+starknet-types-core = { version = "0.0.5", default-features = false, features = [
+  "serde",
+] }
 tempfile = "3.6"
 thiserror = "1.0"
 tracing = "0.1"
 
 
 # CLI dependencies
-cairo-lang-sierra-ap-change = "2.3.1"
-cairo-lang-sierra-gas = "2.3.1"
-cairo-lang-starknet = "2.3.1"
-cairo-lang-utils = "2.3.1"
+cairo-lang-sierra-ap-change = "2.4.1"
+cairo-lang-sierra-gas = "2.4.1"
+cairo-lang-starknet = "2.4.1"
+cairo-lang-utils = "2.4.1"
 cairo-native-runtime = { path = "runtime", optional = true }
 clap = { version = "4.3", features = ["derive"], optional = true }
 libloading = "0.8.1"
 tracing-subscriber = { version = "0.3", features = [
-    "env-filter",
+  "env-filter",
 ], optional = true }
 
 [dev-dependencies]
 cairo-felt = "0.8.5"
-cairo-lang-runner = "2.3.1"
+cairo-lang-runner = "2.4.1"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.1"
 pretty_assertions_sorted = "1.2.3"
 proptest = "1.2"
 test-case = "3.2.1"
 walkdir = "2"
-serde_json = { version = "1.0"}
+serde_json = { version = "1.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ with-runtime = ["cairo-native-runtime"]
 
 [dependencies]
 bumpalo = "3.14"
-cairo-lang-compiler = "2.4.0"
-cairo-lang-defs = "2.4.0"
-cairo-lang-diagnostics = "2.4.0"
-cairo-lang-filesystem = "2.4.0"
-cairo-lang-lowering = "2.4.0"
-cairo-lang-sierra = "2.4.0"
-cairo-lang-sierra-generator = "2.4.0"
+cairo-lang-compiler = "2.4.2"
+cairo-lang-defs = "2.4.2"
+cairo-lang-diagnostics = "2.4.2"
+cairo-lang-filesystem = "2.4.2"
+cairo-lang-lowering = "2.4.2"
+cairo-lang-sierra = "2.4.2"
+cairo-lang-sierra-generator = "2.4.2"
 educe = "0.5.5"
 id-arena = "2.2"
 itertools = "0.12"
@@ -53,10 +53,10 @@ tracing = "0.1"
 
 
 # CLI dependencies
-cairo-lang-sierra-ap-change = "2.4.1"
-cairo-lang-sierra-gas = "2.4.1"
-cairo-lang-starknet = "2.4.1"
-cairo-lang-utils = "2.4.1"
+cairo-lang-sierra-ap-change = "2.4.2"
+cairo-lang-sierra-gas = "2.4.2"
+cairo-lang-starknet = "2.4.2"
+cairo-lang-utils = "2.4.2"
 cairo-native-runtime = { path = "runtime", optional = true }
 clap = { version = "4.3", features = ["derive"], optional = true }
 libloading = "0.8.1"
@@ -66,7 +66,7 @@ tracing-subscriber = { version = "0.3", features = [
 
 [dev-dependencies]
 cairo-felt = "0.8.5"
-cairo-lang-runner = "2.4.1"
+cairo-lang-runner = "2.4.2"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.1"
 pretty_assertions_sorted = "1.2.3"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 UNAME := $(shell uname)
-CAIRO_2_VERSION=2.4.1
+CAIRO_2_VERSION=2.4.2
 
 check-llvm:
 ifndef MLIR_SYS_170_PREFIX

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 UNAME := $(shell uname)
-CAIRO_2_VERSION=2.3.1
+CAIRO_2_VERSION=2.4.1
 
 check-llvm:
 ifndef MLIR_SYS_170_PREFIX

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -138,7 +138,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 fn load_contract(path: impl AsRef<Path>) -> Program {
     let mut db = RootDatabase::builder().detect_corelib().build().unwrap();
     let main_crate_ids = setup_project(&mut db, path.as_ref()).unwrap();
-    (*compile_prepared_db(
+    compile_prepared_db(
         &mut db,
         main_crate_ids,
         CompilerConfig {
@@ -146,8 +146,7 @@ fn load_contract(path: impl AsRef<Path>) -> Program {
             ..Default::default()
         },
     )
-    .unwrap())
-    .clone()
+    .unwrap()
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 starknet-types-core = { version = "0.0.5", default-features = false, features = [
   "serde",
 ] }
-cairo-lang-runner = "=2.4.1"
+cairo-lang-runner = "=2.4.2"
 libc = "0.2"
 starknet-crypto = "0.6"
 starknet-curve = "0.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-starknet-types-core = { version = "0.0.5", default-features = false, features = ["serde"] }
-cairo-lang-runner = "=2.3"
+starknet-types-core = { version = "0.0.5", default-features = false, features = [
+  "serde",
+] }
+cairo-lang-runner = "=2.4.1"
 libc = "0.2"
 starknet-crypto = "0.6"
 starknet-curve = "0.4"

--- a/src/bin/cairo-native-compile.rs
+++ b/src/bin/cairo-native-compile.rs
@@ -2,6 +2,7 @@ use cairo_lang_compiler::{
     compile_prepared_db, db::RootDatabase, diagnostics::DiagnosticsReporter,
     project::setup_project, CompilerConfig,
 };
+use cairo_lang_defs::plugin::{NamedPlugin, PluginSuite};
 use cairo_lang_sierra::{
     extensions::core::{CoreLibfunc, CoreType},
     program::Program,
@@ -105,15 +106,14 @@ fn load_program<'c>(
         Some("cairo") if !is_contract => {
             let mut db = RootDatabase::builder().detect_corelib().build()?;
             let main_crate_ids = setup_project(&mut db, path)?;
-            let program = (*compile_prepared_db(
+            let program = compile_prepared_db(
                 &mut db,
                 main_crate_ids,
                 CompilerConfig {
                     replace_ids: true,
                     ..Default::default()
                 },
-            )?)
-            .clone();
+            )?;
 
             let debug_locations = if let Some(context) = context {
                 let debug_info = DebugInfo::extract(&db, &program).map_err(|_| {
@@ -131,10 +131,13 @@ fn load_program<'c>(
         }
         Some("cairo") if is_contract => {
             // mimics cairo_lang_starknet::contract_class::compile_path
+            let mut plugins = PluginSuite::default();
+            plugins
+                .add_plugin::<StarkNetPlugin>()
+                .add_inline_macro_plugin_ex(SelectorMacro::NAME, Arc::new(SelectorMacro));
             let mut db = RootDatabase::builder()
                 .detect_corelib()
-                .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-                .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
+                .with_plugin_suite(plugins)
                 .build()?;
 
             let main_crate_ids = setup_project(&mut db, Path::new(&path))?;

--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -105,15 +105,14 @@ fn load_program(path: &Path) -> Result<Program, Box<dyn std::error::Error>> {
         Some("cairo") => {
             let mut db = RootDatabase::builder().detect_corelib().build()?;
             let main_crate_ids = setup_project(&mut db, path)?;
-            (*compile_prepared_db(
+            compile_prepared_db(
                 &mut db,
                 main_crate_ids,
                 CompilerConfig {
                     replace_ids: true,
                     ..Default::default()
                 },
-            )?)
-            .clone()
+            )?
         }
         Some("sierra") => {
             let program_src = fs::read_to_string(path)?;

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -70,9 +70,9 @@ where
 {
     let src_ty = registry.build_type(context, helper, registry, metadata, &info.from_ty)?;
     let dst_ty = registry.build_type(context, helper, registry, metadata, &info.to_ty)?;
-    assert!(info.from_nbits >= info.to_nbits);
+    assert!(info.from_info.nbits >= info.to_info.nbits);
 
-    if info.from_nbits == info.to_nbits {
+    if info.from_info.nbits == info.to_info.nbits {
         let k0 = entry
             .append_operation(arith::constant(
                 context,
@@ -105,7 +105,7 @@ where
         let n_bits = entry
             .append_operation(arith::constant(
                 context,
-                IntegerAttribute::new(info.to_nbits.try_into()?, src_ty).into(),
+                IntegerAttribute::new(info.to_info.nbits.try_into()?, src_ty).into(),
                 location,
             ))
             .result(0)?

--- a/src/libfuncs/nullable.rs
+++ b/src/libfuncs/nullable.rs
@@ -58,9 +58,9 @@ where
         NullableConcreteLibfunc::MatchNullable(info) => {
             build_match_nullable(context, registry, entry, location, helper, metadata, info)
         }
-        NullableConcreteLibfunc::MatchNullableSnapshot(_) => {
-            todo!()
-        }
+        NullableConcreteLibfunc::MatchNullableSnapshot(info) => build_match_nullable_snapshot(
+            context, registry, entry, location, helper, metadata, info,
+        ),
     }
 }
 
@@ -171,6 +171,26 @@ where
     block_is_not_null.append_operation(helper.br(1, &[arg], location));
 
     Ok(())
+}
+
+/// Generate MLIR operations for the `match_nullable_snapshot` libfunc.
+#[allow(clippy::too_many_arguments)]
+fn build_match_nullable_snapshot<'ctx, 'this, TType, TLibfunc>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<TType, TLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &SignatureAndTypeConcreteLibfunc,
+) -> Result<()>
+where
+    TType: GenericType,
+    TLibfunc: GenericLibfunc,
+    <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
+    <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
+{
+    build_match_nullable(context, registry, entry, location, helper, metadata, info)
 }
 
 #[cfg(test)]
@@ -284,6 +304,58 @@ mod test {
                     debug_name: None
                 }
             ),
+        );
+    }
+
+    #[test]
+    fn run_match_nullable_snapshot() {
+        let program = load_cairo!(
+            use nullable::{null, NullableTrait, FromNullableResult, match_nullable_snapshot};
+
+            fn run_test(x: u8) -> u8 {
+                let a = if x == 0 {
+                    @null()
+                } else {
+                    @NullableTrait::new(x)
+                };
+                let b = match match_nullable_snapshot(a) {
+                    FromNullableResult::Null => 99_u8,
+                    FromNullableResult::NotNull(value) => *(value.unbox()),
+                };
+                b
+            }
+        );
+
+        run_program_assert_output(&program, "run_test", &[4u8.into()], 4u8.into());
+        run_program_assert_output(&program, "run_test", &[0u8.into()], 99u8.into());
+    }
+
+    #[test]
+    fn run_match_nullable_snapshot_array() {
+        let program = load_cairo!(
+            use nullable::{null, NullableTrait, FromNullableResult, match_nullable_snapshot};
+            use array::ArrayTrait;
+
+            fn run_test() -> u8 {
+                let mut numbers = ArrayTrait::new();
+                numbers.append(4_u8);
+                numbers.append(3_u8);
+                numbers.append(2_u8);
+                numbers.append(1_u8);
+                let a = @NullableTrait::new(numbers);
+                let b = match match_nullable_snapshot(a) {
+                    FromNullableResult::Null => 99_u8,
+                    FromNullableResult::NotNull(value) => *(value.unbox())[0],
+                };
+                b
+            }
+        );
+
+        run_program_assert_output(
+            &program,
+            "run_test",
+            &[4u8.into()],
+            jit_enum!(0, jit_struct!(4u8.into())),
         );
     }
 }

--- a/src/libfuncs/nullable.rs
+++ b/src/libfuncs/nullable.rs
@@ -58,6 +58,9 @@ where
         NullableConcreteLibfunc::MatchNullable(info) => {
             build_match_nullable(context, registry, entry, location, helper, metadata, info)
         }
+        NullableConcreteLibfunc::MatchNullableSnapshot(_) => {
+            todo!()
+        }
     }
 }
 

--- a/src/libfuncs/sint16.rs
+++ b/src/libfuncs/sint16.rs
@@ -210,7 +210,7 @@ where
         &[],
         location,
     ));
-    // Check wether the result is positive to distinguish between undeflowing & overflowing results
+    // Check wether the result is positive to distinguish between underflowing & overflowing results
     block_overflow.append_operation(helper.cond_br(
         context,
         is_positive,
@@ -218,7 +218,7 @@ where
         [&[range_check, op_result], &[range_check, op_result]],
         location,
     ));
-    // No Oveflow/Underflow -> In range result
+    // No Overflow/Underflow -> In range result
     block_not_overflow.append_operation(helper.br(0, &[range_check, op_result], location));
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,6 +97,7 @@ pub fn cairo_to_sierra(program: &Path) -> Arc<Program> {
             },
         )
         .unwrap()
+        .into()
     } else {
         let source = std::fs::read_to_string(program).unwrap();
         Arc::new(
@@ -749,7 +750,7 @@ pub mod test {
 
         let module_name = program_file.path().with_extension("");
         let module_name = module_name.file_name().unwrap().to_str().unwrap();
-        (module_name.to_string(), (*program).clone())
+        (module_name.to_string(), program)
     }
 
     pub fn run_program(

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -59,7 +59,6 @@ use std::{
     ops::Neg,
     path::Path,
     str::FromStr,
-    sync::Arc,
 };
 
 #[allow(unused_macros)]
@@ -126,16 +125,13 @@ pub fn load_cairo_str(program_str: &str) -> (String, Program, SierraCasmRunner) 
         Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("corelib/src"),
     );
     let main_crate_ids = setup_project(&mut db, program_file.path()).unwrap();
-    let program = Arc::try_unwrap(
-        compile_prepared_db(
-            &mut db,
-            main_crate_ids.clone(),
-            CompilerConfig {
-                replace_ids: true,
-                ..Default::default()
-            },
-        )
-        .unwrap(),
+    let program = compile_prepared_db(
+        &mut db,
+        main_crate_ids.clone(),
+        CompilerConfig {
+            replace_ids: true,
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -160,16 +156,13 @@ pub fn load_cairo_path(program_path: &str) -> (String, Program, SierraCasmRunner
         Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("corelib/src"),
     );
     let main_crate_ids = setup_project(&mut db, program_file).unwrap();
-    let program = Arc::try_unwrap(
-        compile_prepared_db(
-            &mut db,
-            main_crate_ids.clone(),
-            CompilerConfig {
-                replace_ids: true,
-                ..Default::default()
-            },
-        )
-        .unwrap(),
+    let program = compile_prepared_db(
+        &mut db,
+        main_crate_ids.clone(),
+        CompilerConfig {
+            replace_ids: true,
+            ..Default::default()
+        },
     )
     .unwrap();
 


### PR DESCRIPTION
# Bump cairo compiler 

## Description
Bumps the cairo compiler dependency to 2.4.1.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
