### PR TITLE
Add builtin usage stats.

### DIFF
--- a/programs/benches/factorial_2M.c
+++ b/programs/benches/factorial_2M.c
@@ -1,25 +1,23 @@
-#include <stddef.h>
+#include <assert.h>
 #include <stdint.h>
 
 
 typedef struct factorial_return_values
 {
+    uint64_t range_check_counter;
     unsigned __int128 remaining_gas;
     struct {
         uint8_t discriminant;
-        union {
-            uint64_t ok[4];
-            struct {
-                void* ptr;
-                uint32_t len;
-                uint32_t cap;
-            } err;
-        };
+        struct {
+            void* ptr;
+            uint32_t len;
+            uint32_t cap;
+        } err;
     } result;
 } factorial_return_values_t;
 
 
-static void run_bench(factorial_return_values_t*, void*, uint64_t)
+static void run_bench(factorial_return_values_t*, uint64_t)
 __attribute__((weakref("_mlir_ciface_factorial_2M::factorial_2M::main(f1)")));
 
 
@@ -27,9 +25,8 @@ int main()
 {
     factorial_return_values_t return_values;
 
-    run_bench(&return_values, NULL, 0);
+    run_bench(&return_values, 0);
+    assert(return_values.result.discriminant == 0);
 
-    // discriminant 0 == Result::Ok
-    // return value 0 == ok in hyperfine
-    return return_values.result.discriminant;
+    return 0;
 }

--- a/programs/benches/factorial_2M.cairo
+++ b/programs/benches/factorial_2M.cairo
@@ -6,9 +6,14 @@ fn factorial(value: felt252, n: felt252) -> felt252 {
     }
 }
 
-fn main() -> felt252 {
+fn main() {
     // Make sure that factorial(10) == 3628800
     let y: felt252 = factorial(1, 10);
     assert(3628800 == y, 'failed test');
-    factorial(1, 2000000)
+
+    let result = factorial(1, 2000000);
+    assert(
+        result == 0x4d6e41de886ac83938da3456ccf1481182687989ead34d9d35236f0864575a0,
+        'invalid result'
+    );
 }

--- a/programs/benches/fib_2M.c
+++ b/programs/benches/fib_2M.c
@@ -1,26 +1,23 @@
-#include <dlfcn.h>
-#include <stddef.h>
+#include <assert.h>
 #include <stdint.h>
 
 
 typedef struct fib_return_values
 {
+    uint64_t range_check_counter;
     unsigned __int128 remaining_gas;
     struct {
         uint8_t discriminant;
-        union {
-            uint64_t ok[4];
-            struct {
-                void *ptr;
-                uint32_t len;
-                uint32_t cap;
-            } err;
-        };
+        struct {
+            void *ptr;
+            uint32_t len;
+            uint32_t cap;
+        } err;
     } result;
 } fib_return_values_t;
 
 
-static void run_bench(fib_return_values_t *, void *, uint64_t)
+static void run_bench(fib_return_values_t *, uint64_t)
     __attribute__((weakref("_mlir_ciface_fib_2M::fib_2M::main(f1)")));
 
 
@@ -28,9 +25,8 @@ int main()
 {
     fib_return_values_t return_values;
 
-    run_bench(&return_values, NULL, 0);
+    run_bench(&return_values, 0);
+    assert(return_values.result.discriminant == 0);
 
-    // discriminant 0 == Result::Ok
-    // return value 0 == ok in hyperfine
-    return return_values.result.discriminant;
+    return 0;
 }

--- a/programs/benches/fib_2M.cairo
+++ b/programs/benches/fib_2M.cairo
@@ -5,8 +5,13 @@ fn fib(a: felt252, b: felt252, n: felt252) -> felt252 {
     }
 }
 
-fn main() -> felt252 {
+fn main() {
     let y: felt252 = fib(0, 1, 10);
     assert(55 == y, 'failed test'); // check fib is correct
-    fib(0, 1, 2000000) // 2m
+
+    let result = fib(0, 1, 2000000);
+    assert(
+        result == 0x79495858064f7881b9eff3a923642b2990b5a4342da5470eb2251df58d9acfb,
+        'invalid result'
+    );
 }

--- a/programs/benches/logistic_map.c
+++ b/programs/benches/logistic_map.c
@@ -1,25 +1,23 @@
-#include <stddef.h>
+#include <assert.h>
 #include <stdint.h>
 
 
 typedef struct map_return_values
 {
+    uint64_t range_check_counter;
     unsigned __int128 remaining_gas;
     struct {
         uint8_t discriminant;
-        union {
-            uint64_t ok[4];
-            struct {
-                void *ptr;
-                uint32_t len;
-                uint32_t cap;
-            } err;
-        };
+        struct {
+            void *ptr;
+            uint32_t len;
+            uint32_t cap;
+        } err;
     } result;
 } map_return_values_t;
 
 
-static void run_bench(map_return_values_t *, void *, uint64_t)
+static void run_bench(map_return_values_t *, uint64_t)
     __attribute__((weakref("_mlir_ciface_logistic_map::logistic_map::main(f2)")));
 
 
@@ -27,7 +25,8 @@ int main()
 {
     map_return_values_t return_values;
 
-    run_bench(&return_values, NULL, 0);
+    run_bench(&return_values, 0);
+    assert(return_values.result.discriminant == 0);
 
     return 0;
 }

--- a/programs/benches/logistic_map.cairo
+++ b/programs/benches/logistic_map.cairo
@@ -6,13 +6,13 @@ fn iterate_map(r: felt252, x: felt252) -> felt252 {
     r * x * -x
 }
 
-fn main() -> felt252 {
+fn main() {
     // Initial value.
     let mut x = 1234567890123456789012345678901234567890;
 
     // Iterate the map.
     let mut i = 15000;
-    loop {
+    let result = loop {
         x = iterate_map(4, x);
 
         if i == 0 {
@@ -20,5 +20,10 @@ fn main() -> felt252 {
         }
 
         i = i - 1;
-    }
+    };
+
+    assert(
+        result == 0x12d35a3ae9fe7c56f194b12b34d567a844432acd2b7da993a158c15447a424d,
+        'invalid result'
+    );
 }

--- a/src/execution_result.rs
+++ b/src/execution_result.rs
@@ -4,11 +4,22 @@ use crate::{
 };
 use starknet_types_core::felt::Felt;
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BuiltinStats {
+    pub bitwise: usize,
+    pub ec_op: usize,
+    pub range_check: usize,
+    pub pedersen: usize,
+    pub poseidon: usize,
+    pub segment_arena: usize,
+}
+
 /// The result of the JIT execution.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExecutionResult {
     pub remaining_gas: Option<u128>,
     pub return_value: JitValue,
+    pub builtin_stats: BuiltinStats,
 }
 
 /// Starknet contract execution result.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -538,7 +538,6 @@ fn parse_result(
 
     // Align the pointer to the actual return value.
     if let Some(return_ptr) = &mut return_ptr {
-        dbg!(type_id);
         let layout = type_info.layout(registry).unwrap();
         let align_offset = return_ptr
             .cast::<u8>()
@@ -705,7 +704,11 @@ fn parse_result(
             }
         }
         CoreTypeConcrete::Felt252Dict(_) => match return_ptr {
-            Some(return_ptr) => JitValue::from_jit(return_ptr, type_id, registry),
+            Some(return_ptr) => JitValue::from_jit(
+                unsafe { *return_ptr.cast::<NonNull<()>>().as_ref() },
+                type_id,
+                registry,
+            ),
             None => JitValue::from_jit(
                 NonNull::new(ret_registers[0] as *mut ()).unwrap(),
                 type_id,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -312,7 +312,7 @@ impl<'a> ArgumentMapper<'a> {
 
         // x86_64's max alignment is 8 bytes.
         #[cfg(target_arch = "x86_64")]
-        assert!(align < 16);
+        assert!(align <= 8);
 
         #[cfg(target_arch = "aarch64")]
         if align == 16 {
@@ -324,15 +324,18 @@ impl<'a> ArgumentMapper<'a> {
                 }
             } else if self.invoke_data.len() + 1 >= 8 {
                 self.invoke_data.push(0);
-            } else if self.invoke_data.len() + values.len() >= 8 {
-                let chunk;
-                (chunk, values) = if values.len() >= 4 {
-                    values.split_at(4)
-                } else {
-                    (values, [].as_slice())
-                };
-                self.invoke_data.extend(chunk);
-                self.invoke_data.push(0);
+            } else {
+                let new_len = self.invoke_data.len() + values.len();
+                if new_len >= 8 && new_len % 2 != 0 {
+                    let chunk;
+                    (chunk, values) = if values.len() >= 4 {
+                        values.split_at(4)
+                    } else {
+                        (values, [].as_slice())
+                    };
+                    self.invoke_data.extend(chunk);
+                    self.invoke_data.push(0);
+                }
             }
         }
 

--- a/src/libfuncs/ap_tracking.rs
+++ b/src/libfuncs/ap_tracking.rs
@@ -53,7 +53,7 @@ where
     }
 }
 
-/// Generate MLIR operations for the `enable_ap_tracking.` libfunc.
+/// Generate MLIR operations for the `enable_ap_tracking` libfunc.
 pub fn build_enable<'ctx, 'this, TType, TLibfunc>(
     _context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -430,13 +430,19 @@ where
         &info.param_signatures()[1].ty,
     )?;
 
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let (elem_ty, elem_layout) =
         registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
 
-    let range_check = entry.argument(0)?.into();
     let array_val = entry.argument(1)?.into();
     let index_val = entry.argument(2)?.into();
 
@@ -1007,13 +1013,19 @@ where
         &info.param_signatures()[1].ty,
     )?;
 
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let (elem_ty, elem_layout) =
         registry.build_type_with_layout(context, helper, registry, metadata, &info.ty)?;
 
     let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
 
-    let range_check = entry.argument(0)?.into();
     let array_val = entry.argument(1)?.into();
     let index_val = entry.argument(2)?.into();
     let length_val = entry.argument(3)?.into();

--- a/src/libfuncs/bitwise.rs
+++ b/src/libfuncs/bitwise.rs
@@ -21,7 +21,7 @@ use melior::{
 
 /// Generate MLIR operations for the `bitwise` libfunc.
 pub fn build<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -35,6 +35,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let bitwise = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs = entry.argument(1)?.into();
     let rhs = entry.argument(2)?.into();
 
@@ -53,12 +60,7 @@ where
 
     entry.append_operation(helper.br(
         0,
-        &[
-            entry.argument(0)?.into(),
-            logical_and,
-            logical_xor,
-            logical_or,
-        ],
+        &[bitwise, logical_and, logical_xor, logical_or],
         location,
     ));
     Ok(())

--- a/src/libfuncs/bytes31.rs
+++ b/src/libfuncs/bytes31.rs
@@ -141,7 +141,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -66,6 +66,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let src_ty = registry.build_type(context, helper, registry, metadata, &info.from_ty)?;
     let dst_ty = registry.build_type(context, helper, registry, metadata, &info.to_ty)?;
     assert!(info.from_info.nbits >= info.to_info.nbits);
@@ -133,10 +140,7 @@ where
             context,
             is_in_range,
             [0, 1],
-            [
-                &[entry.argument(0)?.into(), result],
-                &[entry.argument(0)?.into()],
-            ],
+            [&[range_check, result], &[range_check]],
             location,
         ));
     };

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -262,6 +262,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let ec_point_ty = llvm::r#type::r#struct(
         context,
         &[
@@ -342,10 +349,7 @@ where
         context,
         result,
         [0, 1],
-        [
-            &[entry.argument(0)?.into(), point],
-            &[entry.argument(0)?.into()],
-        ],
+        [&[range_check, point], &[range_check]],
         location,
     ));
     Ok(())
@@ -481,6 +485,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let ec_op = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let felt252_ty = IntegerType::new(context, 252).into();
     let ec_state_ty = llvm::r#type::r#struct(
         context,
@@ -590,7 +601,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), state], location));
+    entry.append_operation(helper.br(0, &[ec_op, state], location));
     Ok(())
 }
 

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -99,7 +99,12 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check = entry.argument(0)?.into();
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
     let current_gas = entry.argument(1)?.into();
 
     let cost = metadata.get::<GasCost>().and_then(|x| x.0);
@@ -164,7 +169,12 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check = entry.argument(0)?.into();
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
     let current_gas = entry.argument(1)?.into();
 
     let cost = metadata.get::<GasCost>().and_then(|x| x.0);

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -74,6 +74,13 @@ where
         .get_mut::<RuntimeBindingsMeta>()
         .expect("Runtime library not available.");
 
+    let pedersen_builtin = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let felt252_ty = registry.build_type(
         context,
         helper,
@@ -85,7 +92,6 @@ where
     let i256_ty = IntegerType::new(context, 256).into();
     let layout_i256 = get_integer_layout(256);
 
-    let pedersen_builtin = entry.argument(0)?.into();
     let lhs = entry.argument(1)?.into();
     let rhs = entry.argument(2)?.into();
 

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -73,6 +73,13 @@ where
         .get_mut::<RuntimeBindingsMeta>()
         .expect("Runtime library not available.");
 
+    let poseidon_builtin = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let felt252_ty = registry.build_type(
         context,
         helper,
@@ -84,7 +91,6 @@ where
     let i256_ty = IntegerType::new(context, 256).into();
     let layout_i256 = get_integer_layout(256);
 
-    let poseidon_builtin = entry.argument(0)?.into();
     let op0 = entry.argument(1)?.into();
     let op1 = entry.argument(2)?.into();
     let op2 = entry.argument(3)?.into();

--- a/src/libfuncs/sint128.rs
+++ b/src/libfuncs/sint128.rs
@@ -125,7 +125,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -219,6 +225,7 @@ where
     ));
     // No Oveflow/Underflow -> In range result
     block_not_overflow.append_operation(helper.br(0, &[range_check, op_result], location));
+
     Ok(())
 }
 
@@ -350,7 +357,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -406,8 +419,8 @@ where
         .append_operation(arith::trunci(value, result_ty, location))
         .result(0)?
         .into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())
@@ -428,7 +441,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -450,7 +469,6 @@ where
         [&[range_check, result], &[range_check, result]],
         location,
     ));
-
     Ok(())
 }
 

--- a/src/libfuncs/sint16.rs
+++ b/src/libfuncs/sint16.rs
@@ -126,7 +126,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -220,6 +226,7 @@ where
     ));
     // No Overflow/Underflow -> In range result
     block_not_overflow.append_operation(helper.br(0, &[range_check, op_result], location));
+
     Ok(())
 }
 
@@ -395,7 +402,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -451,8 +464,8 @@ where
         .append_operation(arith::trunci(value, result_ty, location))
         .result(0)?
         .into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())
@@ -473,7 +486,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -495,7 +514,6 @@ where
         [&[range_check, result], &[range_check, result]],
         location,
     ));
-
     Ok(())
 }
 

--- a/src/libfuncs/sint32.rs
+++ b/src/libfuncs/sint32.rs
@@ -126,7 +126,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -395,7 +401,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -473,7 +485,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 

--- a/src/libfuncs/sint64.rs
+++ b/src/libfuncs/sint64.rs
@@ -126,7 +126,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -220,6 +226,7 @@ where
     ));
     // No Oveflow/Underflow -> In range result
     block_not_overflow.append_operation(helper.br(0, &[range_check, op_result], location));
+
     Ok(())
 }
 
@@ -395,7 +402,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -451,8 +464,8 @@ where
         .append_operation(arith::trunci(value, result_ty, location))
         .result(0)?
         .into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())
@@ -473,7 +486,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -495,7 +514,6 @@ where
         [&[range_check, result], &[range_check, result]],
         location,
     ));
-
     Ok(())
 }
 

--- a/src/libfuncs/sint8.rs
+++ b/src/libfuncs/sint8.rs
@@ -126,7 +126,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -220,6 +226,7 @@ where
     ));
     // No Oveflow/Underflow -> In range result
     block_not_overflow.append_operation(helper.br(0, &[range_check, op_result], location));
+
     Ok(())
 }
 
@@ -395,7 +402,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -473,7 +486,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -495,7 +514,6 @@ where
         [&[range_check, result], &[range_check, result]],
         location,
     ));
-
     Ok(())
 }
 

--- a/src/libfuncs/stark_net.rs
+++ b/src/libfuncs/stark_net.rs
@@ -599,6 +599,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value = entry.argument(1)?.into();
 
     let limit = entry
@@ -628,10 +635,7 @@ where
         context,
         is_in_range,
         [0, 1],
-        [
-            &[entry.argument(0)?.into(), value],
-            &[entry.argument(0)?.into()],
-        ],
+        [&[range_check, value], &[range_check]],
         location,
     ));
     Ok(())
@@ -685,6 +689,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value = entry.argument(1)?.into();
 
     let limit = entry
@@ -714,10 +725,7 @@ where
         context,
         is_in_range,
         [0, 1],
-        [
-            &[entry.argument(0)?.into(), value],
-            &[entry.argument(0)?.into()],
-        ],
+        [&[range_check, value], &[range_check]],
         location,
     ));
     Ok(())
@@ -1462,6 +1470,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let k_limit = entry
         .append_operation(arith::constant(
             context,
@@ -1500,7 +1515,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), value], location));
+    entry.append_operation(helper.br(0, &[range_check, value], location));
     Ok(())
 }
 
@@ -1587,6 +1602,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value = entry.argument(1)?.into();
 
     let limit = entry
@@ -1616,10 +1638,7 @@ where
         context,
         is_in_range,
         [0, 1],
-        [
-            &[entry.argument(0)?.into(), value],
-            &[entry.argument(0)?.into()],
-        ],
+        [&[range_check, value], &[range_check]],
         location,
     ));
     Ok(())

--- a/src/libfuncs/uint128.rs
+++ b/src/libfuncs/uint128.rs
@@ -107,6 +107,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let bitwise = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let u128_ty = registry.build_type(
         context,
         helper,
@@ -122,7 +129,7 @@ where
         ; res = "llvm.call_intrinsic"(arg1) { "intrin" = bswap_intrin_attr } : (u128_ty) -> u128_ty
     };
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), res], location));
+    entry.append_operation(helper.br(0, &[bitwise, res], location));
     Ok(())
 }
 
@@ -165,7 +172,7 @@ where
 
 /// Generate MLIR operations for the `u128_safe_divmod` libfunc.
 pub fn build_divmod<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -179,6 +186,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -188,11 +202,7 @@ where
     let op = entry.append_operation(arith::remui(lhs, rhs, location));
     let result_rem = op.result(0)?.into();
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), result_div, result_rem],
-        location,
-    ));
+    entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
 }
 
@@ -234,7 +244,7 @@ where
     Ok(())
 }
 
-/// Generate MLIR operations for the `u128_from_felt252` libfunc.
+/// Generate MLIR operations for the `u128s_from_felt252` libfunc.
 pub fn build_from_felt252<'ctx, 'this, TType, TLibfunc>(
     context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
@@ -250,6 +260,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let arg1 = entry.argument(1)?.into();
 
     let k1 = entry
@@ -310,10 +327,7 @@ where
         context,
         is_wide,
         [1, 0],
-        [
-            &[entry.argument(0)?.into(), msb_bits, lsb_bits],
-            &[entry.argument(0)?.into(), lsb_bits],
-        ],
+        [&[range_check, msb_bits, lsb_bits], &[range_check, lsb_bits]],
         location,
     ));
     Ok(())
@@ -373,7 +387,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -447,6 +467,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i64_ty = IntegerType::new(context, 64).into();
     let i128_ty = IntegerType::new(context, 128).into();
 
@@ -692,7 +719,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 
@@ -785,7 +812,7 @@ where
 
 /// Generate MLIR operations for the `u128_guarantee_verify` libfunc.
 pub fn build_guarantee_verify<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -799,7 +826,14 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into()], location));
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
+    entry.append_operation(helper.br(0, &[range_check], location));
     Ok(())
 }
 

--- a/src/libfuncs/uint16.rs
+++ b/src/libfuncs/uint16.rs
@@ -134,7 +134,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -264,7 +270,7 @@ where
 
 /// Generate MLIR operations for the `u16_safe_divmod` libfunc.
 pub fn build_divmod<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -277,6 +283,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -286,11 +299,7 @@ where
     let op = entry.append_operation(arith::remui(lhs, rhs, location));
     let result_rem = op.result(0)?.into();
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), result_div, result_rem],
-        location,
-    ));
+    entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
 }
 
@@ -383,6 +392,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i8_ty = IntegerType::new(context, 8).into();
     let i16_ty = IntegerType::new(context, 16).into();
 
@@ -628,7 +644,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 
@@ -648,7 +664,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -698,8 +720,8 @@ where
 
     let op = block_success.append_operation(arith::trunci(value, result_ty, location));
     let value = op.result(0)?.into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -79,6 +79,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i128_ty = IntegerType::new(context, 128).into();
     let i256_ty = IntegerType::new(context, 256).into();
 
@@ -273,7 +280,7 @@ where
 
     entry.append_operation(helper.br(
         0,
-        &[entry.argument(0)?.into(), result_div, result_rem, guarantee],
+        &[range_check, result_div, result_rem, guarantee],
         location,
     ));
     Ok(())
@@ -379,6 +386,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i128_ty = IntegerType::new(context, 128).into();
     let i256_ty = IntegerType::new(context, 256).into();
 
@@ -673,7 +687,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 

--- a/src/libfuncs/uint32.rs
+++ b/src/libfuncs/uint32.rs
@@ -134,7 +134,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -264,7 +270,7 @@ where
 
 /// Generate MLIR operations for the `u32_safe_divmod` libfunc.
 pub fn build_divmod<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -277,6 +283,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -286,11 +299,7 @@ where
     let op = entry.append_operation(arith::remui(lhs, rhs, location));
     let result_rem = op.result(0)?.into();
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), result_div, result_rem],
-        location,
-    ));
+    entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
 }
 
@@ -383,6 +392,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i16_ty = IntegerType::new(context, 16).into();
     let i32_ty = IntegerType::new(context, 32).into();
 
@@ -628,7 +644,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 
@@ -648,7 +664,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -698,8 +720,8 @@ where
 
     let op = block_success.append_operation(arith::trunci(value, result_ty, location));
     let value = op.result(0)?.into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())

--- a/src/libfuncs/uint512.rs
+++ b/src/libfuncs/uint512.rs
@@ -66,6 +66,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i128_ty = IntegerType::new(context, 128).into();
     let i512_ty = IntegerType::new(context, 512).into();
 
@@ -391,7 +398,7 @@ where
     entry.append_operation(helper.br(
         0,
         &[
-            entry.argument(0)?.into(),
+            range_check,
             result_div_val,
             result_rem_val,
             guarantee,

--- a/src/libfuncs/uint64.rs
+++ b/src/libfuncs/uint64.rs
@@ -134,7 +134,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -264,7 +270,7 @@ where
 
 /// Generate MLIR operations for the `u64_safe_divmod` libfunc.
 pub fn build_divmod<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -277,6 +283,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -286,12 +299,7 @@ where
     let op = entry.append_operation(arith::remui(lhs, rhs, location));
     let result_rem = op.result(0)?.into();
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), result_div, result_rem],
-        location,
-    ));
-
+    entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
 }
 
@@ -384,6 +392,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i32_ty = IntegerType::new(context, 32).into();
     let i64_ty = IntegerType::new(context, 64).into();
 
@@ -629,7 +644,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 
@@ -649,7 +664,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(
@@ -699,8 +720,8 @@ where
 
     let op = block_success.append_operation(arith::trunci(value, result_ty, location));
     let value = op.result(0)?.into();
-    block_success.append_operation(helper.br(0, &[range_check, value], location));
 
+    block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));
 
     Ok(())

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -134,7 +134,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -264,7 +270,7 @@ where
 
 /// Generate MLIR operations for the `u8_safe_divmod` libfunc.
 pub fn build_divmod<'ctx, 'this, TType, TLibfunc>(
-    _context: &'ctx Context,
+    context: &'ctx Context,
     _registry: &ProgramRegistry<TType, TLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
@@ -277,6 +283,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
@@ -286,11 +299,7 @@ where
     let op = entry.append_operation(arith::remui(lhs, rhs, location));
     let result_rem = op.result(0)?.into();
 
-    entry.append_operation(helper.br(
-        0,
-        &[entry.argument(0)?.into(), result_div, result_rem],
-        location,
-    ));
+    entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
 }
 
@@ -383,6 +392,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
+    let range_check = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let i8_ty = IntegerType::new(context, 8).into();
 
     let k1 = entry
@@ -618,7 +634,7 @@ where
         .result(0)?
         .into();
 
-    entry.append_operation(helper.br(0, &[entry.argument(0)?.into(), result], location));
+    entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
 }
 
@@ -638,7 +654,13 @@ where
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = CoreTypeBuilderError>,
     <TLibfunc as GenericLibfunc>::Concrete: LibfuncBuilder<TType, TLibfunc, Error = Error>,
 {
-    let range_check: Value = entry.argument(0)?.into();
+    let range_check: Value = super::increment_builtin_counter::<TType, TLibfunc>(
+        context,
+        entry,
+        location,
+        entry.argument(0)?.into(),
+    )?;
+
     let value: Value = entry.argument(1)?.into();
 
     let felt252_ty = registry.build_type(

--- a/src/types.rs
+++ b/src/types.rs
@@ -394,7 +394,7 @@ where
                 | CoreTypeConcrete::RangeCheck(_)
                 | CoreTypeConcrete::Pedersen(_)
                 | CoreTypeConcrete::Poseidon(_)
-                | CoreTypeConcrete::StarkNet(_)
+                | CoreTypeConcrete::StarkNet(StarkNetTypeConcrete::System(_))
                 | CoreTypeConcrete::SegmentArena(_)
         )
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -464,15 +464,17 @@ where
 
     fn is_zst(&self, registry: &ProgramRegistry<TType, TLibfunc>) -> bool {
         match self {
+            // Builtin counters:
             CoreTypeConcrete::Bitwise(_)
             | CoreTypeConcrete::EcOp(_)
-            | CoreTypeConcrete::BuiltinCosts(_)
             | CoreTypeConcrete::RangeCheck(_)
             | CoreTypeConcrete::Pedersen(_)
             | CoreTypeConcrete::Poseidon(_)
-            | CoreTypeConcrete::SegmentArena(_)
-            | CoreTypeConcrete::Uint128MulGuarantee(_) => true,
+            | CoreTypeConcrete::SegmentArena(_) => false,
+            // Other builtins:
+            CoreTypeConcrete::BuiltinCosts(_) | CoreTypeConcrete::Uint128MulGuarantee(_) => true,
 
+            // Normal types:
             CoreTypeConcrete::Array(_)
             | CoreTypeConcrete::Box(_)
             | CoreTypeConcrete::Bytes31(_)
@@ -496,6 +498,7 @@ where
             | CoreTypeConcrete::StarkNet(_)
             | CoreTypeConcrete::Nullable(_) => false,
 
+            // Containers:
             CoreTypeConcrete::NonZero(info)
             | CoreTypeConcrete::Uninitialized(info)
             | CoreTypeConcrete::Snapshot(info) => {
@@ -503,6 +506,7 @@ where
                 type_info.is_zst(registry)
             }
 
+            // Enums and structs:
             CoreTypeConcrete::Enum(info) => {
                 info.variants.is_empty()
                     || (info.variants.len() == 1
@@ -529,9 +533,9 @@ where
                     .extend(get_integer_layout(32))?
                     .0
             }
-            CoreTypeConcrete::Bitwise(_) => Layout::new::<()>(),
+            CoreTypeConcrete::Bitwise(_) => Layout::new::<u64>(),
             CoreTypeConcrete::Box(_) => Layout::new::<*mut ()>(),
-            CoreTypeConcrete::EcOp(_) => Layout::new::<()>(),
+            CoreTypeConcrete::EcOp(_) => Layout::new::<u64>(),
             CoreTypeConcrete::EcPoint(_) => layout_repeat(&get_integer_layout(252), 2)?.0,
             CoreTypeConcrete::EcState(_) => layout_repeat(&get_integer_layout(252), 4)?.0,
             CoreTypeConcrete::Felt252(_) => get_integer_layout(252),
@@ -545,7 +549,7 @@ where
             CoreTypeConcrete::Uint128MulGuarantee(_) => Layout::new::<()>(),
             CoreTypeConcrete::NonZero(info) => registry.get_type(&info.ty)?.layout(registry)?,
             CoreTypeConcrete::Nullable(_) => Layout::new::<*mut ()>(),
-            CoreTypeConcrete::RangeCheck(_) => Layout::new::<()>(),
+            CoreTypeConcrete::RangeCheck(_) => Layout::new::<u64>(),
             CoreTypeConcrete::Uninitialized(info) => {
                 registry.get_type(&info.ty)?.layout(registry)?
             }
@@ -585,8 +589,8 @@ where
                     .0
             }
             CoreTypeConcrete::SquashedFelt252Dict(_) => Layout::new::<*mut std::ffi::c_void>(), // ptr
-            CoreTypeConcrete::Pedersen(_) => Layout::new::<()>(),
-            CoreTypeConcrete::Poseidon(_) => Layout::new::<()>(),
+            CoreTypeConcrete::Pedersen(_) => Layout::new::<u64>(),
+            CoreTypeConcrete::Poseidon(_) => Layout::new::<u64>(),
             CoreTypeConcrete::Span(_) => todo!(),
             CoreTypeConcrete::StarkNet(info) => match info {
                 StarkNetTypeConcrete::ClassHash(_) => get_integer_layout(252),
@@ -596,7 +600,7 @@ where
                 StarkNetTypeConcrete::System(_) => Layout::new::<*mut ()>(),
                 StarkNetTypeConcrete::Secp256Point(_) => todo!("implement Secp256Point type"),
             },
-            CoreTypeConcrete::SegmentArena(_) => Layout::new::<()>(),
+            CoreTypeConcrete::SegmentArena(_) => Layout::new::<u64>(),
             CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.layout(registry)?,
             CoreTypeConcrete::Sint8(_) => get_integer_layout(8),
             CoreTypeConcrete::Sint16(_) => get_integer_layout(16),

--- a/src/types/bitwise.rs
+++ b/src/types/bitwise.rs
@@ -13,7 +13,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -33,5 +32,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/types/ec_op.rs
+++ b/src/types/ec_op.rs
@@ -13,7 +13,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -33,5 +32,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/types/pedersen.rs
+++ b/src/types/pedersen.rs
@@ -12,7 +12,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -32,5 +31,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/types/poseidon.rs
+++ b/src/types/poseidon.rs
@@ -12,7 +12,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -32,5 +31,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/types/range_check.rs
+++ b/src/types/range_check.rs
@@ -13,7 +13,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -33,5 +32,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/types/segment_arena.rs
+++ b/src/types/segment_arena.rs
@@ -10,7 +10,6 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
     ir::{r#type::IntegerType, Module, Type},
     Context,
 };
@@ -30,5 +29,5 @@ where
     TLibfunc: GenericLibfunc,
     <TType as GenericType>::Concrete: TypeBuilder<TType, TLibfunc, Error = Error>,
 {
-    Ok(llvm::r#type::array(IntegerType::new(context, 8).into(), 0))
+    Ok(IntegerType::new(context, 64).into())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -731,10 +731,7 @@ pub mod test {
         let mut db = RootDatabase::default();
         init_dev_corelib(
             &mut db,
-            Path::new(&var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| {
-                "/Users/esteve/Documents/LambdaClass/cairo_native".to_string()
-            }))
-            .join("corelib/src"),
+            Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("corelib/src"),
         );
         let main_crate_ids = setup_project(&mut db, program_file.path()).unwrap();
         let program = compile_prepared_db(

--- a/tests/trampoline.rs
+++ b/tests/trampoline.rs
@@ -1,8 +1,12 @@
 use crate::common::load_cairo;
 use cairo_lang_sierra::program::Program;
 use cairo_native::{
-    context::NativeContext, execution_result::ExecutionResult, executor::JitNativeExecutor,
-    utils::find_function_id, values::JitValue, OptLevel,
+    context::NativeContext,
+    execution_result::{BuiltinStats, ExecutionResult},
+    executor::JitNativeExecutor,
+    utils::find_function_id,
+    values::JitValue,
+    OptLevel,
 };
 use starknet_types_core::felt::Felt;
 
@@ -35,6 +39,7 @@ fn invoke0() {
                 fields: Vec::new(),
                 debug_name: None,
             },
+            builtin_stats: BuiltinStats::default(),
         },
     );
 }
@@ -58,6 +63,7 @@ fn invoke1_felt252() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -87,6 +93,7 @@ fn invoke1_u8() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -116,6 +123,7 @@ fn invoke1_u16() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -145,6 +153,7 @@ fn invoke1_u32() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -174,6 +183,7 @@ fn invoke1_u64() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -203,6 +213,7 @@ fn invoke1_u128() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -235,6 +246,7 @@ fn invoke1_tuple1_felt252() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -267,6 +279,7 @@ fn invoke1_tuple1_u64() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -305,6 +318,7 @@ fn invoke1_tuple5_u8_u16_u32_u64_u128() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -334,6 +348,7 @@ fn invoke1_array_felt252() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -374,6 +389,7 @@ fn invoke1_enum1_unit() {
         ExecutionResult {
             remaining_gas: None,
             return_value: x,
+            builtin_stats: BuiltinStats::default(),
         },
     );
 }
@@ -405,6 +421,7 @@ fn invoke1_enum1_u64() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -442,6 +459,7 @@ fn invoke1_enum1_felt252() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };
@@ -492,6 +510,7 @@ fn invoke1_enum2_u8_u16() {
             ExecutionResult {
                 remaining_gas: None,
                 return_value: x,
+                builtin_stats: BuiltinStats::default(),
             },
         );
     };


### PR DESCRIPTION
# Add builtin usage stats

## Description

This PR makes it so that invokes return an extra structure containing the number of times a libfunc has been invoked that uses a specific builtin. In other words, how many times has each builtin been used.

It only implements the builtins we weren't using before, which are:
  - `Bitwise`
  - `EcOp`
  - `RangeCheck`
  - `Pedersen`
  - `Poseidon`
  - `SegmentArena`

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
