### PR TITLE
make PR template less verbose

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,7 @@
-# TITLE
-
-## Description
-
+<!--
 Description of the pull request changes and motivation.
+-->
+
 
 ## Checklist
 - [ ] Linked to Github Issue


### PR DESCRIPTION
I feel that by default it adds too much text, this makes the text meant as an explanation for the write only visible in edit mode.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
