### PR TITLE
Further enum init testing

### DIFF
--- a/tests/cases/enums/enum_init_c_style.cairo
+++ b/tests/cases/enums/enum_init_c_style.cairo
@@ -1,0 +1,13 @@
+enum CEnum {
+    A: (),
+    B: (),
+    C: (),
+}
+
+fn main() -> (CEnum, CEnum, CEnum) {
+    (
+        CEnum::A(()),
+        CEnum::B(()),
+        CEnum::C(()),
+    )
+}

--- a/tests/cases/enums/enum_init_empty.cairo
+++ b/tests/cases/enums/enum_init_empty.cairo
@@ -1,0 +1,7 @@
+enum EmptyEnum {
+    A: ()
+}
+
+fn main() -> EmptyEnum {
+    EmptyEnum::A(())
+}

--- a/tests/cases/enums/enum_init_multiple.cairo
+++ b/tests/cases/enums/enum_init_multiple.cairo
@@ -1,0 +1,8 @@
+enum MyEnum {
+    A: felt252,
+    B: (felt252, felt252),
+}
+
+fn main() -> (MyEnum, MyEnum) {
+    (MyEnum::A(10), MyEnum::B((20, 30)))
+}

--- a/tests/cases/enums/enum_init_nested_c_style.cairo
+++ b/tests/cases/enums/enum_init_nested_c_style.cairo
@@ -1,0 +1,21 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerCEnum,
+}
+
+enum InnerCEnum {
+    A: (),
+    B: (),
+    C: (),
+    D: (),
+}
+
+fn main() -> (OuterEnum, OuterEnum, OuterEnum, OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerCEnum::A(())),
+        OuterEnum::B(InnerCEnum::B(())),
+        OuterEnum::B(InnerCEnum::C(())),
+        OuterEnum::B(InnerCEnum::D(())),
+    )
+}

--- a/tests/cases/enums/enum_init_nested_empty.cairo
+++ b/tests/cases/enums/enum_init_nested_empty.cairo
@@ -1,0 +1,15 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerEmptyEnum,
+}
+
+enum InnerEmptyEnum {
+    A: ()
+}
+
+fn main() -> (OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerEmptyEnum::A(())),
+    )
+}

--- a/tests/cases/enums/enum_init_nested_multiple.cairo
+++ b/tests/cases/enums/enum_init_nested_multiple.cairo
@@ -1,0 +1,17 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerMultipleEnum,
+}
+
+enum InnerMultipleEnum {
+    A: felt252,
+    B: (u128, felt252),
+}
+
+fn main() -> (OuterEnum, OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerMultipleEnum::A(283947)),
+        OuterEnum::B(InnerMultipleEnum::B((1000, 10000))),
+    )
+}

--- a/tests/cases/enums/enum_init_nested_single_scalar.cairo
+++ b/tests/cases/enums/enum_init_nested_single_scalar.cairo
@@ -1,0 +1,15 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerScalarEnum,
+}
+
+enum InnerScalarEnum {
+    A: u16
+}
+
+fn main() -> (OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerScalarEnum::A(100)),
+    )
+}

--- a/tests/cases/enums/enum_init_nested_single_struct.cairo
+++ b/tests/cases/enums/enum_init_nested_single_struct.cairo
@@ -1,0 +1,23 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerStructEnum,
+}
+
+enum InnerStructEnum {
+    A: Payload
+}
+
+struct Payload {
+    first: u16,
+    second: u32,
+}
+
+fn main() -> (OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerStructEnum::A(Payload{
+            first: 10,
+            second: 100,
+        })),
+    )
+}

--- a/tests/cases/enums/enum_init_nested_single_tuple.cairo
+++ b/tests/cases/enums/enum_init_nested_single_tuple.cairo
@@ -1,0 +1,15 @@
+enum OuterEnum {
+    A: felt252,
+    B: InnerTupleEnum,
+}
+
+enum InnerTupleEnum {
+    A: (u16, u8)
+}
+
+fn main() -> (OuterEnum, OuterEnum) {
+    (
+        OuterEnum::A(1234),
+        OuterEnum::B(InnerTupleEnum::A((200, 190))),
+    )
+}

--- a/tests/cases/enums/enum_init_single_scalar.cairo
+++ b/tests/cases/enums/enum_init_single_scalar.cairo
@@ -1,0 +1,7 @@
+enum SingleScalarEnum {
+    A: felt252
+}
+
+fn main() -> SingleScalarEnum {
+    SingleScalarEnum::A(3874)
+}

--- a/tests/cases/enums/enum_init_single_struct.cairo
+++ b/tests/cases/enums/enum_init_single_struct.cairo
@@ -1,0 +1,15 @@
+enum SingleStructEnum {
+    A: Payload
+}
+
+struct Payload {
+    first: u8,
+    second: felt252,
+}
+
+fn main() -> SingleStructEnum {
+    SingleStructEnum::A(Payload {
+        first: 12,
+        second: 39845,
+    })
+}

--- a/tests/cases/enums/enum_init_single_tuple.cairo
+++ b/tests/cases/enums/enum_init_single_tuple.cairo
@@ -1,0 +1,7 @@
+enum SingleTupleEnum {
+    A: (felt252, felt252)
+}
+
+fn main() -> SingleTupleEnum {
+    SingleTupleEnum::A((1,2))
+}

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -20,7 +20,19 @@ use test_case::test_case;
 #[test_case("tests/cases/generic_fn_loop.cairo")]
 // enums
 // TODO: compare error: Fail(Reason("assertion failed: `(left == right)` \n  left: `0`,\n right: `10` at tests/common.rs:453"))
-#[test_case("tests/cases/enums/enum_init.cairo")]
+#[test_case("tests/cases/enums/enum_init_c_style.cairo")] // passes
+// #[test_case("tests/cases/enums/enum_init_empty.cairo")] // fails, invalid typing for empty enum
+#[test_case("tests/cases/enums/enum_init_multiple.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_nested_c_style.cairo")] // passes
+// #[test_case("tests/cases/enums/enum_init_nested_empty.cairo")] // fails, invalid typing for empty enum
+// #[test_case("tests/cases/enums/enum_init_nested_multiple.cairo")] // fails, incorrect content (likely incorrect result parsing)
+// #[test_case("tests/cases/enums/enum_init_nested_single_scalar.cairo")] // fails, as above
+// #[test_case("tests/cases/enums/enum_init_nested_single_struct.cairo")] // fails, as above
+// #[test_case("tests/cases/enums/enum_init_nested_single_tuple.cairo")] // fails, as above
+#[test_case("tests/cases/enums/enum_init_single_scalar.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_single_struct.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_single_tuple.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init.cairo")] // passes
 #[test_case("tests/cases/enums/single_value.cairo")]
 #[test_case("tests/cases/enums/enum_match.cairo")]
 #[test_case("tests/cases/enums/enum_snapshot_match_a.cairo")]

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -20,19 +20,19 @@ use test_case::test_case;
 #[test_case("tests/cases/generic_fn_loop.cairo")]
 // enums
 // TODO: compare error: Fail(Reason("assertion failed: `(left == right)` \n  left: `0`,\n right: `10` at tests/common.rs:453"))
-#[test_case("tests/cases/enums/enum_init_c_style.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_c_style.cairo")]
 // #[test_case("tests/cases/enums/enum_init_empty.cairo")] // fails, invalid typing for empty enum
-#[test_case("tests/cases/enums/enum_init_multiple.cairo")] // passes
-#[test_case("tests/cases/enums/enum_init_nested_c_style.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_multiple.cairo")]
+#[test_case("tests/cases/enums/enum_init_nested_c_style.cairo")]
 // #[test_case("tests/cases/enums/enum_init_nested_empty.cairo")] // fails, invalid typing for empty enum
 // #[test_case("tests/cases/enums/enum_init_nested_multiple.cairo")] // fails, incorrect content (likely incorrect result parsing)
 // #[test_case("tests/cases/enums/enum_init_nested_single_scalar.cairo")] // fails, as above
 // #[test_case("tests/cases/enums/enum_init_nested_single_struct.cairo")] // fails, as above
 // #[test_case("tests/cases/enums/enum_init_nested_single_tuple.cairo")] // fails, as above
-#[test_case("tests/cases/enums/enum_init_single_scalar.cairo")] // passes
-#[test_case("tests/cases/enums/enum_init_single_struct.cairo")] // passes
-#[test_case("tests/cases/enums/enum_init_single_tuple.cairo")] // passes
-#[test_case("tests/cases/enums/enum_init.cairo")] // passes
+#[test_case("tests/cases/enums/enum_init_single_scalar.cairo")]
+#[test_case("tests/cases/enums/enum_init_single_struct.cairo")]
+#[test_case("tests/cases/enums/enum_init_single_tuple.cairo")]
+#[test_case("tests/cases/enums/enum_init.cairo")]
 #[test_case("tests/cases/enums/single_value.cairo")]
 #[test_case("tests/cases/enums/enum_match.cairo")]
 #[test_case("tests/cases/enums/enum_snapshot_match_a.cairo")]


### PR DESCRIPTION
<!--
Adds enum tests aimed at covering every internal enum representation. These tests reveal two bugs:
- Zero sized enums fail at compile time, with different parts of the codebase assigning them different types (some parts do not use the zero length array representation)
- The payload of nested enums seems to either be incorrect, or to be loaded incorrectly when returned
The tests that fail because of these bugs are commented out so that fixes can be developed independent of this PR
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [X] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
