### PR TITLE
Fix casting libfuncs.

### DIFF
--- a/src/bin/cairo-native-test.rs
+++ b/src/bin/cairo-native-test.rs
@@ -318,6 +318,7 @@ fn jitvalue_to_felt(value: &JitValue) -> Vec<Felt> {
     let mut felts = Vec::new();
     match value {
         JitValue::Felt252(felt) => vec![felt.to_bigint().into()],
+        JitValue::Bytes31(_) => todo!(),
         JitValue::Array(values) => {
             for value in values {
                 let felt = jitvalue_to_felt(value);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -445,6 +445,12 @@ impl<'a> ArgumentMapper<'a> {
             ) => {
                 self.push_aligned(get_integer_layout(252).align(), &value.to_le_digits());
             }
+            (CoreTypeConcrete::Bytes31(_), JitValue::Bytes31(value)) => {
+                self.push_aligned(
+                    get_integer_layout(248).align(),
+                    &Felt::from_bytes_be_slice(value).to_le_digits(),
+                );
+            }
             (CoreTypeConcrete::Felt252Dict(_), JitValue::Felt252Dict { .. }) => {
                 #[cfg(not(feature = "with-runtime"))]
                 unimplemented!("enable the `with-runtime` feature to use felt252 dicts");

--- a/src/types.rs
+++ b/src/types.rs
@@ -722,6 +722,7 @@ impl TypeBuilder for CoreTypeConcrete {
             Self::Uint128(_) => Some(128),
 
             CoreTypeConcrete::BoundedInt(_) => todo!(),
+            CoreTypeConcrete::Bytes31(_) => Some(248),
             CoreTypeConcrete::Const(_) => todo!(),
 
             _ => None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ pub fn generate_function_name(function_id: &FunctionId) -> Cow<str> {
 /// with a size in bytes of a power of two has the same alignment as its size.
 pub fn get_integer_layout(width: u32) -> Layout {
     // TODO: Fix integer layouts properly.
-    if width == 252 || width == 256 {
+    if width == 248 || width == 252 || width == 256 {
         #[cfg(target_arch = "x86_64")]
         return Layout::from_size_align(32, 8).unwrap();
         #[cfg(not(target_arch = "x86_64"))]


### PR DESCRIPTION
Casting now works with `bytes31` too.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
