### PR TITLE
Fix memcpy with dynamic length

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1065,7 +1065,7 @@ pub fn build_slice<'ctx, 'this>(
 
     block_not_oob.append_operation(llvm::call_intrinsic(
         context,
-        StringAttribute::new(context, "llvm.memcpy.inline"),
+        StringAttribute::new(context, "llvm.memcpy"),
         &[new_ptr, elem_ptr, bytes_val, is_volatile],
         &[],
         location,


### PR DESCRIPTION
There is an inline memcpy with a dynamic length, which is invalid.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
