### PR TITLE
Add release and publish to the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,5 +37,7 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install llvm-17 llvm-17-dev llvm-17-runtime clang-17 clang-tools-17 lld-17 libpolly-17-dev libmlir-17-dev mlir-17-tools
-      - name: publish the crates
-        run: cargo publish --token ${CRATES_TOKEN} --all-features
+      - name: publish the runtime
+        run: cargo publish --token ${CRATES_TOKEN} --all-features -p cairo-native-runtime
+      - name: publish the crate
+        run: cargo publish --token ${CRATES_TOKEN} --all-features -p cairo-native

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Release
+
+permissions:
+  contents: write
+  discussions: write
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+        MLIR_SYS_170_PREFIX: /usr/lib/llvm-17/
+        LLVM_SYS_170_PREFIX: /usr/lib/llvm-17/
+        TABLEGEN_170_PREFIX: /usr/lib/llvm-17/
+        CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: free HDD space
+        run: |
+          # deleting space
+          sudo rm -rf /usr/share/dotnet/
+          sudo rm -rf /usr/local/lib/android
+      - name: Setup rust env
+        uses: dtolnay/rust-toolchain@1.76.0
+      - name: Retreive cached dependecies
+        uses: Swatinem/rust-cache@v2
+      - name: add llvm deb repository
+        uses: myci-actions/add-deb-repo@10
+        with:
+          repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
+          repo-name: llvm-repo
+          keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - name: Install LLVM
+        run: sudo apt-get install llvm-17 llvm-17-dev llvm-17-runtime clang-17 clang-tools-17 lld-17 libpolly-17-dev libmlir-17-dev mlir-17-tools
+      - name: publish the crates
+        run: cargo publish --token ${CRATES_TOKEN} --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+permissions:
+  contents: write
+  discussions: write
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+        MLIR_SYS_170_PREFIX: /usr/lib/llvm-17/
+        LLVM_SYS_170_PREFIX: /usr/lib/llvm-17/
+        TABLEGEN_170_PREFIX: /usr/lib/llvm-17/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: free HDD space
+        run: |
+          # deleting space
+          sudo rm -rf /usr/share/dotnet/
+          sudo rm -rf /usr/local/lib/android
+      - name: Setup rust env
+        uses: dtolnay/rust-toolchain@1.76.0
+      - name: Retreive cached dependecies
+        uses: Swatinem/rust-cache@v2
+      - name: add llvm deb repository
+        uses: myci-actions/add-deb-repo@10
+        with:
+          repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
+          repo-name: llvm-repo
+          keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - name: Install LLVM
+        run: sudo apt-get install llvm-17 llvm-17-dev llvm-17-runtime clang-17 clang-tools-17 lld-17 libpolly-17-dev libmlir-17-dev mlir-17-tools
+      - name: build release
+        run: make build
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            target/release/cairo-native-test
+            target/release/cairo-native-compile
+            target/release/cairo-native-dump
+            target/release/cairo-native-run
+            target/release/libcairo_native_runtime.a

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -13,12 +13,12 @@ jobs:
     name: GitHub Pages
     runs-on: ubuntu-latest
     env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       MLIR_SYS_170_PREFIX: /usr/lib/llvm-17/
+      LLVM_SYS_170_PREFIX: /usr/lib/llvm-17/
       TABLEGEN_170_PREFIX: /usr/lib/llvm-17/
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.76
+      - uses: dtolnay/rust-toolchain@1.76.0
       - uses: Swatinem/rust-cache@v2
       - name: add llvm deb repository
         uses: myci-actions/add-deb-repo@11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ cairo-lang-sierra-ap-change = "2.5.4"
 cairo-lang-sierra-gas = "2.5.4"
 cairo-lang-starknet = "2.5.4"
 cairo-lang-utils = "2.5.4"
-cairo-native-runtime = { path = "runtime", optional = true }
+cairo-native-runtime = { version = "0.1.0", path = "runtime", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 libloading = "0.8.1"
 tracing-subscriber = { version = "0.3", features = [

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ To read more in-depth documentation, visit [this page](https://lambdaclass.notio
 - [API usage example](#api--usage-example)
 - [From MLIR to native binary](#from-mlir-to-native-binary)
 
+## ⚠️ Disclaimer
+
+🚧 `cairo-native` is still being built therefore API breaking changes might happen often so use it at your own risk. 🚧
+
+For versions under `1.0` `cargo` doesn't comply with [semver](https://semver.org/), so we advise to pin the version the version you use. This can be done by adding `cairo-native = "0.1.0"` to your Cargo.toml
+
 ## Implemented Library Functions
 
 Cairo Native works by leveraging the intermediate representation of Cairo called Sierra.
@@ -758,6 +764,8 @@ sierra2mlir program.sierra -o program.mlir
 
 This tool mimics the `cairo-test` [tool](https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-test-runner) and is identical to it, the only feature it doesn't have is the profiler.
 
+You can download it on our [releases](https://github.com/lambdaclass/cairo_native/releases) page.
+
 ```bash
 $ cairo-native-test --help
 Compiles a Cairo project and runs all the functions marked as `#[test]`.
@@ -780,3 +788,16 @@ Options:
   -h, --help                   Print help
   -V, --version                Print version
 ```
+
+For single files, you can use the `-s, --single-file` option.
+
+For a project, it needs to have a `cairo_project.toml` specifying the crate_roots. You can find an
+example under the `cairo-tests/` folder, which is a cairo project that works with this tool.
+
+```
+cairo-native-test -s myfile.cairo
+
+cairo-native-test ./cairo-tests/
+```
+
+This will run all the tests (functions marked with the `#[test]` attribute).


### PR DESCRIPTION
This allows so that when we make a tag matching `v*.*.*` a release page will be created and the artifacts uploaded.

It will also upload the crates to the crates.io registry using the `CARGO_REGISTRY_TOKEN` secret configured on this repository