### PR TITLE
Fix bug in cairo tests (test_u256_div_mod_n)

### DIFF
--- a/cairo-tests/src/math_test.cairo
+++ b/cairo-tests/src/math_test.cairo
@@ -1,9 +1,15 @@
 use core::option::OptionTrait;
 use core::math;
+use core::fmt::{Display, Debug};
 
 /// Helper for making a non-zero value.
-fn nz<N, +TryInto<N, NonZero<N>>>(n: N) -> NonZero<N> {
-    n.try_into().unwrap()
+fn nz<N, +TryInto<N, NonZero<N>>, +Display<N>, +Copy<N>, +Drop<N>, +Debug<N>>(n: N) -> NonZero<N>{
+    let nz_value: NonZero<N> = match n.try_into() {
+        Option::Some(nz2) => nz2,
+        Option::None => { panic!("Failed to create NonZero") },
+    };
+
+    nz_value
 }
 
 #[test]
@@ -55,9 +61,7 @@ fn test_inv_mod() {
     assert(math::inv_mod(nz(7), nz(1)) == Option::Some(0_usize), 'inv_mov(7, 1) != 0');
 }
 
-// TODO: Panicked with 0x36202f203220213d203320283729 ('6 / 2 != 3 (7)').
 #[test]
-#[ignore]
 fn test_u256_div_mod_n() {
     assert(math::u256_div_mod_n(6, 2, nz(7)) == Option::Some(3), '6 / 2 != 3 (7)');
     assert(math::u256_div_mod_n(5, 1, nz(7)) == Option::Some(5), '5 / 1 != 5 (7)');

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -1234,5 +1234,10 @@ mod test {
             (5, 0),
             jit_enum!(0, jit_struct!(1u128.into(), 0u128.into())),
         );
+        run(
+            (2, 0),
+            (7, 0),
+            jit_enum!(0, jit_struct!(4u128.into(), 0u128.into())),
+        );
     }
 }


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/lambdaclass/cairo_native/issues/472

The issue was a problem with the `nz` function.
It was an issue with the usage of `.unwrap()` in cases where it failed and with the Display and Debug traits on that function.

I did modify the implementation of that function and seems to be working now.


## Checklist
- [X] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

Screenshots
![image](https://github.com/lambdaclass/cairo_native/assets/11419017/13cbbd56-320e-4928-b990-0f6d282fa2ec)
![image](https://github.com/lambdaclass/cairo_native/assets/11419017/13aed2bf-199f-43f1-9686-5b6cb981383e)
