### PR TITLE
Dont call realloc on snapshot_take if array is empty, add some tests

### DIFF
--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -247,7 +247,7 @@ fn jitvalue_to_felt(value: &JitValue) -> Vec<Felt> {
             felts
         }
         JitValue::Enum {
-            value: _,
+            value,
             tag,
             debug_name,
         } => {
@@ -255,7 +255,10 @@ fn jitvalue_to_felt(value: &JitValue) -> Vec<Felt> {
                 if debug_name == "core::bool" {
                     vec![(*tag == 1).into()]
                 } else {
-                    todo!()
+                    felts.push((*tag).into());
+                    let felt = jitvalue_to_felt(value);
+                    felts.extend(felt);
+                    felts
                 }
             } else {
                 todo!()

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -607,7 +607,6 @@ pub fn build_len<'ctx, 'this>(
     )?;
 
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
-    dbg!(&info.param_signatures()[0].ty.debug_name);
 
     let array_start = entry
         .append_operation(llvm::extract_value(

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -588,7 +588,7 @@ pub fn build_append<'ctx, 'this>(
     Ok(())
 }
 
-/// Generate MLIR operations for the `array_append` libfunc.
+/// Generate MLIR operations for the `array_len` libfunc.
 pub fn build_len<'ctx, 'this>(
     context: &'ctx Context,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
@@ -607,6 +607,7 @@ pub fn build_len<'ctx, 'this>(
     )?;
 
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
+    dbg!(&info.param_signatures()[0].ty.debug_name);
 
     let array_start = entry
         .append_operation(llvm::extract_value(
@@ -2338,6 +2339,7 @@ mod test {
             },
         );
     }
+
     #[test]
     fn array_pop_back_state() {
         let program = load_cairo!(
@@ -2357,5 +2359,67 @@ mod test {
         let result = run_program(&program, "run_test", &[]).return_value;
 
         assert_eq!(result, jit_struct!([1u32, 2u32].into()));
+    }
+
+    #[test]
+    fn array_empty_span() {
+        // Tests snapshot_take on a empty array.
+        let program = load_cairo!(
+            fn run_test() -> Span<u32> {
+                let x = ArrayTrait::new();
+                x.span()
+            }
+        );
+
+        assert_eq!(
+            run_program(&program, "run_test", &[]).return_value,
+            jit_struct!(JitValue::Array(vec![])),
+        );
+    }
+
+    #[test]
+    fn array_span_modify_span() {
+        // Tests pop_back on a span.
+        let program = load_cairo!(
+            use core::array::SpanTrait;
+            fn pop_elem(mut self: Span<u64>) -> Option<@u64> {
+                let x = self.pop_back();
+                x
+            }
+
+            fn run_test() -> Option<@u64> {
+                let mut data = array![2].span();
+                let x = pop_elem(data);
+                x
+            }
+        );
+
+        assert_eq!(
+            run_program(&program, "run_test", &[]).return_value,
+            jit_enum!(0, 2u64.into()),
+        );
+    }
+
+    #[test]
+    fn array_span_check_array() {
+        // Tests pop back on a span not modifying the original array.
+        let program = load_cairo!(
+            use core::array::SpanTrait;
+            fn pop_elem(mut self: Span<u64>) -> Option<@u64> {
+                let x = self.pop_back();
+                x
+            }
+
+            fn run_test() -> Array<u64> {
+                let mut data = array![1, 2];
+                let _x = pop_elem(data.span());
+                data
+            }
+        );
+
+        assert_eq!(
+            run_program(&program, "run_test", &[]).return_value,
+            JitValue::Array(vec![1u64.into(), 2u64.into()]),
+        );
     }
 }

--- a/src/libfuncs/snapshot_take.rs
+++ b/src/libfuncs/snapshot_take.rs
@@ -30,7 +30,7 @@ pub fn build<'ctx, 'this>(
     // Handle non-trivially-copyable types (ex. arrays) by invoking their override or just copy the
     // original value otherwise.
     let original_value = entry.argument(0)?.into();
-    let cloned_value = match metadata
+    let (entry, cloned_value) = match metadata
         .get_mut::<SnapshotClonesMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
     {
@@ -43,7 +43,7 @@ pub fn build<'ctx, 'this>(
             metadata,
             original_value,
         )?,
-        None => original_value,
+        None => (entry, original_value),
     };
 
     entry.append_operation(helper.br(0, &[original_value, cloned_value], location));

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -20,7 +20,7 @@ pub type CloneFn<P> = for<'ctx, 'this> fn(
     &mut MetadataStorage,
     WithSelf<P>,
     Value<'ctx, 'this>,
-) -> Result<Value<'ctx, 'this>>;
+) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>;
 
 type CloneFnWrapper = Arc<
     dyn for<'ctx, 'this> Fn(
@@ -31,7 +31,7 @@ type CloneFnWrapper = Arc<
         &LibfuncHelper<'ctx, 'this>,
         &mut MetadataStorage,
         Value<'this, 'ctx>,
-    ) -> Result<Value<'ctx, 'this>>,
+    ) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>,
 >;
 
 #[derive(Default)]

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -35,14 +35,14 @@ use cairo_lang_sierra::{
 };
 use melior::{
     dialect::{
-        arith,
-        llvm::{self, LoadStoreOptions},
+        arith, cf,
+        llvm::{self, r#type::opaque_pointer, LoadStoreOptions},
         ods,
     },
     ir::{
         attribute::{DenseI64ArrayAttribute, IntegerAttribute},
         r#type::IntegerType,
-        Block, Location, Module, Type, Value,
+        Block, Location, Module, Type, Value, ValueLike,
     },
     Context,
 };
@@ -88,7 +88,7 @@ fn snapshot_take<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
     src_value: Value<'ctx, 'this>,
-) -> Result<Value<'ctx, 'this>> {
+) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
     if metadata.get::<ReallocBindingsMeta>().is_none() {
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
@@ -148,124 +148,172 @@ fn snapshot_take<'ctx, 'this>(
 
     let array_ty = registry.build_type(context, helper, registry, metadata, info.self_ty())?;
 
-    let array_len = entry
+    let array_len: Value = entry
         .append_operation(arith::subi(array_end, array_start, location))
         .result(0)?
         .into();
-    let dst_len_bytes = {
-        let array_len = entry
-            .append_operation(arith::extui(
-                array_len,
-                IntegerType::new(context, 64).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
 
-        entry
-            .append_operation(arith::muli(array_len, elem_stride, location))
-            .result(0)?
-            .into()
-    };
-
-    let dst_ptr = {
-        let dst_ptr = entry
-            .append_operation(llvm::nullptr(
-                llvm::r#type::opaque_pointer(context),
-                location,
-            ))
-            .result(0)?
-            .into();
-
-        entry
-            .append_operation(ReallocBindingsMeta::realloc(
-                context,
-                dst_ptr,
-                dst_len_bytes,
-                location,
-            ))
-            .result(0)?
-            .into()
-    };
-
-    let src_ptr_offset = {
-        let array_start = entry
-            .append_operation(arith::extui(
-                array_start,
-                IntegerType::new(context, 64).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
-
-        entry
-            .append_operation(arith::muli(array_start, elem_stride, location))
-            .result(0)?
-            .into()
-    };
-    let src_ptr = entry
-        .append_operation(llvm::get_element_ptr_dynamic(
+    let k0 = entry
+        .append_operation(arith::constant(
             context,
-            src_ptr,
-            &[src_ptr_offset],
-            IntegerType::new(context, 8).into(),
+            IntegerAttribute::new(array_len.r#type(), 0).into(),
+            location,
+        ))
+        .result(0)?
+        .into();
+    let is_len_zero = entry
+        .append_operation(arith::cmpi(
+            context,
+            arith::CmpiPredicate::Eq,
+            array_len,
+            k0,
+            location,
+        ))
+        .result(0)?
+        .into();
+
+    let null_ptr = entry
+        .append_operation(llvm::nullptr(
             llvm::r#type::opaque_pointer(context),
             location,
         ))
         .result(0)?
         .into();
 
-    match elem_snapshot_take {
-        Some(elem_snapshot_take) => {
-            let value = entry
-                .append_operation(llvm::load(
+    let block_realloc = helper.append_block(Block::new(&[]));
+    let block_finish = helper.append_block(Block::new(&[(opaque_pointer(context), location)]));
+
+    entry.append_operation(cf::cond_br(
+        context,
+        is_len_zero,
+        block_finish,
+        block_realloc,
+        &[null_ptr],
+        &[],
+        location,
+    ));
+
+    {
+        // realloc
+        let dst_len_bytes: Value = {
+            let array_len = block_realloc
+                .append_operation(arith::extui(
+                    array_len,
+                    IntegerType::new(context, 64).into(),
+                    location,
+                ))
+                .result(0)?
+                .into();
+
+            block_realloc
+                .append_operation(arith::muli(array_len, elem_stride, location))
+                .result(0)?
+                .into()
+        };
+
+        let dst_ptr = {
+            let dst_ptr = null_ptr;
+
+            block_realloc
+                .append_operation(ReallocBindingsMeta::realloc(
                     context,
-                    src_ptr,
-                    elem_ty,
+                    dst_ptr,
+                    dst_len_bytes,
+                    location,
+                ))
+                .result(0)?
+                .into()
+        };
+
+        let src_ptr_offset = {
+            let array_start = block_realloc
+                .append_operation(arith::extui(
+                    array_start,
+                    IntegerType::new(context, 64).into(),
+                    location,
+                ))
+                .result(0)?
+                .into();
+
+            block_realloc
+                .append_operation(arith::muli(array_start, elem_stride, location))
+                .result(0)?
+                .into()
+        };
+        let src_ptr = block_realloc
+            .append_operation(llvm::get_element_ptr_dynamic(
+                context,
+                src_ptr,
+                &[src_ptr_offset],
+                IntegerType::new(context, 8).into(),
+                llvm::r#type::opaque_pointer(context),
+                location,
+            ))
+            .result(0)?
+            .into();
+
+        match elem_snapshot_take {
+            Some(elem_snapshot_take) => {
+                let value = block_realloc
+                    .append_operation(llvm::load(
+                        context,
+                        src_ptr,
+                        elem_ty,
+                        location,
+                        LoadStoreOptions::new().align(Some(IntegerAttribute::new(
+                            IntegerType::new(context, 64).into(),
+                            elem_layout.align() as i64,
+                        ))),
+                    ))
+                    .result(0)?
+                    .into();
+
+                let (block_relloc, value) = elem_snapshot_take(
+                    context,
+                    registry,
+                    block_realloc,
+                    location,
+                    helper,
+                    metadata,
+                    value,
+                )?;
+
+                block_relloc.append_operation(llvm::store(
+                    context,
+                    value,
+                    dst_ptr,
                     location,
                     LoadStoreOptions::new().align(Some(IntegerAttribute::new(
                         IntegerType::new(context, 64).into(),
                         elem_layout.align() as i64,
                     ))),
-                ))
-                .result(0)?
-                .into();
-
-            let value =
-                elem_snapshot_take(context, registry, entry, location, helper, metadata, value)?;
-
-            entry.append_operation(llvm::store(
-                context,
-                value,
-                dst_ptr,
-                location,
-                LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    elem_layout.align() as i64,
-                ))),
-            ));
-        }
-        None => {
-            entry.append_operation(
-                ods::llvm::intr_memcpy(
-                    context,
-                    dst_ptr,
-                    src_ptr,
-                    dst_len_bytes,
-                    IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                    location,
-                )
-                .into(),
-            );
+                ));
+                block_relloc.append_operation(cf::br(block_finish, &[dst_ptr], location));
+            }
+            None => {
+                block_realloc.append_operation(
+                    ods::llvm::intr_memcpy(
+                        context,
+                        dst_ptr,
+                        src_ptr,
+                        dst_len_bytes,
+                        IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
+                        location,
+                    )
+                    .into(),
+                );
+                block_realloc.append_operation(cf::br(block_finish, &[dst_ptr], location));
+            }
         }
     }
 
-    let dst_value = entry
+    let dst_value = block_finish
         .append_operation(llvm::undef(array_ty, location))
         .result(0)?
         .into();
+    let dst_ptr = block_finish.argument(0)?.into();
 
-    let k0 = entry
+    let k0 = block_finish
         .append_operation(arith::constant(
             context,
             IntegerAttribute::new(IntegerType::new(context, 32).into(), 0).into(),
@@ -273,7 +321,7 @@ fn snapshot_take<'ctx, 'this>(
         ))
         .result(0)?
         .into();
-    let dst_value = entry
+    let dst_value = block_finish
         .append_operation(llvm::insert_value(
             context,
             dst_value,
@@ -283,7 +331,7 @@ fn snapshot_take<'ctx, 'this>(
         ))
         .result(0)?
         .into();
-    let dst_value = entry
+    let dst_value = block_finish
         .append_operation(llvm::insert_value(
             context,
             dst_value,
@@ -293,7 +341,7 @@ fn snapshot_take<'ctx, 'this>(
         ))
         .result(0)?
         .into();
-    let dst_value = entry
+    let dst_value = block_finish
         .append_operation(llvm::insert_value(
             context,
             dst_value,
@@ -303,7 +351,7 @@ fn snapshot_take<'ctx, 'this>(
         ))
         .result(0)?
         .into();
-    let dst_value = entry
+    let dst_value = block_finish
         .append_operation(llvm::insert_value(
             context,
             dst_value,
@@ -314,5 +362,5 @@ fn snapshot_take<'ctx, 'this>(
         .result(0)?
         .into();
 
-    Ok(dst_value)
+    Ok((block_finish, dst_value))
 }

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -67,7 +67,7 @@ fn snapshot_take<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
     src_value: Value<'ctx, 'this>,
-) -> Result<Value<'ctx, 'this>> {
+) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
     if metadata.get::<ReallocBindingsMeta>().is_none() {
         metadata.insert(ReallocBindingsMeta::new(context, helper));
     }
@@ -114,7 +114,8 @@ fn snapshot_take<'ctx, 'this>(
         ))
         .result(0)?
         .into();
-    Ok(entry
+
+    let value = entry
         .append_operation(scf::r#if(
             is_null,
             &[llvm::r#type::opaque_pointer(context)],
@@ -167,5 +168,7 @@ fn snapshot_take<'ctx, 'this>(
             location,
         ))
         .result(0)?
-        .into())
+        .into();
+
+    Ok((entry, value))
 }


### PR DESCRIPTION
realloc was called with a size of 0 if the array was empty, which is implementation defined before C23 and UB from C23 onwards


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
