### PR TITLE
Bump `starknet-types-core` to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
  "educe",
  "id-arena",
  "itertools 0.12.1",
- "lambdaworks-math",
+ "lambdaworks-math 0.5.0",
  "lazy_static",
  "libc",
  "libloading",
@@ -1837,6 +1837,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c74ce6f0d9cb672330b6ca59e85a6c3607a3329e0372ab0d3fe38c2d38e50f9"
 
 [[package]]
 name = "lazy_static"
@@ -3005,13 +3011,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d53160556d1f23425100f42b3230df747ea05763efee685a2cd939dfb640701"
+checksum = "1051b4f4af0bb9b546388a404873ee1e6b9787b9d5b0b3319ecbfadf315ef276"
 dependencies = [
  "bitvec",
- "lambdaworks-math",
- "lazy_static",
+ "lambdaworks-math 0.6.0",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
  "educe",
  "id-arena",
  "itertools 0.12.1",
- "lambdaworks-math 0.5.0",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "libloading",
@@ -1829,20 +1829,14 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee7dcab3968c71896b8ee4dc829147acc918cffe897af6265b1894527fe3add"
+checksum = "6c74ce6f0d9cb672330b6ca59e85a6c3607a3329e0372ab0d3fe38c2d38e50f9"
 dependencies = [
  "rayon",
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "lambdaworks-math"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c74ce6f0d9cb672330b6ca59e85a6c3607a3329e0372ab0d3fe38c2d38e50f9"
 
 [[package]]
 name = "lazy_static"
@@ -3016,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1051b4f4af0bb9b546388a404873ee1e6b9787b9d5b0b3319ecbfadf315ef276"
 dependencies = [
  "bitvec",
- "lambdaworks-math 0.6.0",
+ "lambdaworks-math",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ melior = { version = "0.17.0", features = ["ods-dialects"] }
 mlir-sys = "0.2.1"
 num-bigint = "0.4.4"
 num-traits = "0.2"
-starknet-types-core = { version = "0.0.9", default-features = false, features = [
+starknet-types-core = { version = "0.1.0", default-features = false, features = [
   "serde",
 ] }
 tempfile = "3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ cairo-felt = { version = "0.9.1", optional = true }
 cairo-felt = "0.9.1"
 cairo-lang-runner = "2.5.4"
 criterion = { version = "0.5.1", features = ["html_reports"] }
-lambdaworks-math = "0.5"
+lambdaworks-math = "0.6"
 pretty_assertions_sorted = "1.2.3"
 proptest = "1.4"
 test-case = "3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-starknet-types-core = { version = "0.0.9", default-features = false, features = [
+starknet-types-core = { version = "0.1.0", default-features = false, features = [
   "serde",
 ] }
 cairo-lang-runner = "2.5.4"


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

Bump `starknet-types-core` to v0.1.0


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
