### PR TITLE
Refactor common operations into a block trait

### DIFF
--- a/src/block_ext.rs
+++ b/src/block_ext.rs
@@ -317,9 +317,7 @@ impl<'ctx> BlockExt<'ctx> for Block<'ctx> {
             ));
         }
 
-        self.append_op_result(
-            ods::llvm::alloca(context, opaque_pointer(context), num_elems, location).into(),
-        )
+        self.append_op_result(op.into())
     }
 
     fn alloca1(

--- a/src/block_ext.rs
+++ b/src/block_ext.rs
@@ -89,6 +89,16 @@ pub trait BlockExt<'ctx> {
         value: Value<'ctx, '_>,
         align: Option<usize>,
     );
+
+    /// Creates a memcpy operation.
+    fn memcpy(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        src: Value<'ctx, '_>,
+        dst: Value<'ctx, '_>,
+        len_bytes: Value<'ctx, '_>,
+    );
 }
 
 impl<'ctx> BlockExt<'ctx> for Block<'ctx> {
@@ -246,5 +256,26 @@ impl<'ctx> BlockExt<'ctx> for Block<'ctx> {
         }
 
         self.append_op_result(op.into())
+    }
+
+    fn memcpy(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        src: Value<'ctx, '_>,
+        dst: Value<'ctx, '_>,
+        len_bytes: Value<'ctx, '_>,
+    ) {
+        self.append_operation(
+            ods::llvm::intr_memcpy(
+                context,
+                dst,
+                src,
+                len_bytes,
+                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
+                location,
+            )
+            .into(),
+        );
     }
 }

--- a/src/block_ext.rs
+++ b/src/block_ext.rs
@@ -1,0 +1,250 @@
+//! Trait that extends the melior Block type to aid in codegen and consistency.
+
+use melior::{
+    dialect::ods,
+    ir::{
+        attribute::{DenseI64ArrayAttribute, IntegerAttribute},
+        r#type::IntegerType,
+        Attribute, Block, Location, Operation, Type, Value, ValueLike,
+    },
+    Context,
+};
+use num_bigint::BigInt;
+
+use crate::error::Error;
+
+pub trait BlockExt<'ctx> {
+    /// Appends the operation and returns the first result.
+    fn append_op_result(&self, operation: Operation<'ctx>) -> Result<Value<'ctx, '_>, Error>;
+
+    /// Creates a constant of the given integer bit width. Do not use for felt252.
+    fn const_int<T>(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        value: T,
+        bits: u32,
+    ) -> Result<Value<'ctx, '_>, Error>
+    where
+        T: Into<BigInt>;
+
+    /// Creates a constant of the given integer type. Do not use for felt252.
+    fn const_int_from_type<T>(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        value: T,
+        int_type: Type<'ctx>,
+    ) -> Result<Value<'ctx, '_>, Error>
+    where
+        T: Into<BigInt>;
+
+    /// Uses a llvm::extract_value operation to return the value at the given index of a container (e.g struct).
+    fn extract_value(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        container: Value<'ctx, '_>,
+        value_type: Type<'ctx>,
+        index: usize,
+    ) -> Result<Value<'ctx, '_>, Error>;
+
+    /// Uses a llvm::insert_value operation to insert the value at the given index of a container (e.g struct),
+    /// the result is the container with the value.
+    fn insert_value(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        container: Value<'ctx, '_>,
+        value: Value<'ctx, '_>,
+        index: usize,
+    ) -> Result<Value<'ctx, '_>, Error>;
+
+    /// Uses a llvm::insert_value operation to insert the values starting from index 0 into a container (e.g struct),
+    /// the result is the container with the values.
+    fn insert_values<'block>(
+        &'block self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        container: Value<'ctx, 'block>,
+        values: &[Value<'ctx, 'block>],
+    ) -> Result<Value<'ctx, 'block>, Error>;
+
+    /// Loads a value from the given addr.
+    fn load(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        addr: Value<'ctx, '_>,
+        value_type: Type<'ctx>,
+        align: Option<usize>,
+    ) -> Result<Value<'ctx, '_>, Error>;
+
+    /// Stores a value at the given addr.
+    fn store(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        addr: Value<'ctx, '_>,
+        value: Value<'ctx, '_>,
+        align: Option<usize>,
+    );
+}
+
+impl<'ctx> BlockExt<'ctx> for Block<'ctx> {
+    fn const_int<T>(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        value: T,
+        bits: u32,
+    ) -> Result<Value<'ctx, '_>, Error>
+    where
+        T: Into<BigInt>,
+    {
+        let ty = IntegerType::new(context, bits).into();
+        Ok(self
+            .append_operation(
+                ods::arith::constant(
+                    context,
+                    ty,
+                    Attribute::parse(context, &format!("{} : {}", value.into(), ty))
+                        .ok_or(Error::ParseAttributeError)?,
+                    location,
+                )
+                .into(),
+            )
+            .result(0)?
+            .into())
+    }
+
+    fn const_int_from_type<T>(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        value: T,
+        ty: Type<'ctx>,
+    ) -> Result<Value<'ctx, '_>, Error>
+    where
+        T: Into<BigInt>,
+    {
+        Ok(self
+            .append_operation(
+                ods::arith::constant(
+                    context,
+                    ty,
+                    Attribute::parse(context, &format!("{} : {}", value.into(), ty))
+                        .ok_or(Error::ParseAttributeError)?,
+                    location,
+                )
+                .into(),
+            )
+            .result(0)?
+            .into())
+    }
+
+    fn extract_value(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        container: Value<'ctx, '_>,
+        value_type: Type<'ctx>,
+        index: usize,
+    ) -> Result<Value<'ctx, '_>, Error> {
+        Ok(self
+            .append_operation(
+                ods::llvm::extractvalue(
+                    context,
+                    value_type,
+                    container,
+                    DenseI64ArrayAttribute::new(context, &[index.try_into().unwrap()]).into(),
+                    location,
+                )
+                .into(),
+            )
+            .result(0)?
+            .into())
+    }
+
+    fn insert_value(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        container: Value<'ctx, '_>,
+        value: Value<'ctx, '_>,
+        index: usize,
+    ) -> Result<Value<'ctx, '_>, Error> {
+        Ok(self
+            .append_operation(
+                ods::llvm::insertvalue(
+                    context,
+                    container.r#type(),
+                    container,
+                    value,
+                    DenseI64ArrayAttribute::new(context, &[index.try_into().unwrap()]).into(),
+                    location,
+                )
+                .into(),
+            )
+            .result(0)?
+            .into())
+    }
+
+    fn insert_values<'block>(
+        &'block self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        mut container: Value<'ctx, 'block>,
+        values: &[Value<'ctx, 'block>],
+    ) -> Result<Value<'ctx, 'block>, Error> {
+        for (i, value) in values.iter().enumerate() {
+            container = self.insert_value(context, location, container, *value, i)?;
+        }
+        Ok(container)
+    }
+
+    fn store(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        addr: Value<'ctx, '_>,
+        value: Value<'ctx, '_>,
+        align: Option<usize>,
+    ) {
+        let mut op = ods::llvm::store(context, value, addr, location);
+
+        if let Some(align) = align {
+            op.set_alignment(IntegerAttribute::new(
+                IntegerType::new(context, 64).into(),
+                align as i64,
+            ));
+        }
+
+        self.append_operation(op.into());
+    }
+
+    #[inline]
+    fn append_op_result(&self, operation: Operation<'ctx>) -> Result<Value<'ctx, '_>, Error> {
+        Ok(self.append_operation(operation).result(0)?.into())
+    }
+
+    fn load(
+        &self,
+        context: &'ctx Context,
+        location: Location<'ctx>,
+        addr: Value<'ctx, '_>,
+        value_type: Type<'ctx>,
+        align: Option<usize>,
+    ) -> Result<Value<'ctx, '_>, Error> {
+        let mut op = ods::llvm::load(context, value_type, addr, location);
+
+        if let Some(align) = align {
+            op.set_alignment(IntegerAttribute::new(
+                IntegerType::new(context, 64).into(),
+                align as i64,
+            ));
+        }
+
+        self.append_op_result(op.into())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub use self::{
     ffi::{module_to_object, object_to_shared_lib, LLVMCompileError, OptLevel},
 };
 
+pub(crate) mod block_ext;
 pub mod cache;
 mod compiler;
 pub mod context;

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -617,17 +617,7 @@ pub fn build_get<'ctx, 'this>(
         )?;
 
         // TODO: Support clone-only types (those that are not copy).
-        valid_block.append_operation(
-            ods::llvm::intr_memcpy(
-                context,
-                target_ptr,
-                elem_ptr,
-                elem_size,
-                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                location,
-            )
-            .into(),
-        );
+        valid_block.memcpy(context, location, elem_ptr, target_ptr, elem_size);
 
         valid_block.append_operation(helper.br(0, &[range_check, target_ptr], location));
     }
@@ -741,17 +731,7 @@ pub fn build_pop_front<'ctx, 'this>(
             "realloc returned nullptr",
         )?;
 
-        valid_block.append_operation(
-            ods::llvm::intr_memcpy(
-                context,
-                target_ptr,
-                ptr,
-                elem_size,
-                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                location,
-            )
-            .into(),
-        );
+        valid_block.memcpy(context, location, ptr, target_ptr, elem_size);
 
         let k1 = valid_block.const_int(context, location, 1, 32)?;
         let new_start = valid_block
@@ -904,17 +884,7 @@ pub fn build_snapshot_pop_back<'ctx, 'this>(
             "realloc returned nullptr",
         )?;
 
-        valid_block.append_operation(
-            ods::llvm::intr_memcpy(
-                context,
-                target_ptr,
-                ptr,
-                elem_size,
-                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                location,
-            )
-            .into(),
-        );
+        valid_block.memcpy(context, location, ptr, target_ptr, elem_size);
 
         let value = valid_block.insert_value(context, location, value, new_end, 2)?;
 
@@ -1062,17 +1032,7 @@ pub fn build_slice<'ctx, 'this>(
             location,
         ))?;
 
-        slice_block.append_operation(
-            ods::llvm::intr_memcpy(
-                context,
-                dst_ptr,
-                src_ptr,
-                dst_size,
-                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                location,
-            )
-            .into(),
-        );
+        slice_block.memcpy(context, location, src_ptr, dst_ptr, dst_size);
 
         let k0 = slice_block.const_int_from_type(context, location, 0, len_ty)?;
 

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -5,6 +5,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::Result,
     metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
     types::TypeBuilder,
@@ -23,12 +24,11 @@ use melior::{
     dialect::{
         arith::{self, CmpiPredicate},
         cf,
-        llvm::{self, r#type::opaque_pointer, LoadStoreOptions},
+        llvm::{self, r#type::opaque_pointer},
         ods,
     },
     ir::{
         attribute::{DenseI32ArrayAttribute, DenseI64ArrayAttribute, IntegerAttribute},
-        operation::OperationBuilder,
         r#type::IntegerType,
         Block, Location, Value, ValueLike,
     },
@@ -197,44 +197,13 @@ pub fn build_append<'ctx, 'this>(
     let elem_layout = elem_ty.layout(registry)?;
     let elem_stride = elem_layout.pad_to_align().size();
 
-    let k1 = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(IntegerType::new(context, 32).into(), 1).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let k1 = entry.const_int(context, location, 1, 32)?;
 
-    let elem_stride = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(IntegerType::new(context, 64).into(), elem_stride as i64).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let elem_stride = entry.const_int(context, location, elem_stride, 64)?;
 
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(0)?.into(),
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_capacity = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(0)?.into(),
-            DenseI64ArrayAttribute::new(context, &[3]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_end = entry.extract_value(context, location, entry.argument(0)?.into(), len_ty, 2)?;
+    let array_capacity =
+        entry.extract_value(context, location, entry.argument(0)?.into(), len_ty, 3)?;
 
     let has_tail_space = entry
         .append_operation(arith::cmpi(
@@ -263,24 +232,9 @@ pub fn build_append<'ctx, 'this>(
     ));
 
     {
-        let k0 = handle_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 32).into(), 0).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let array_start = handle_block
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[1]),
-                len_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k0 = handle_block.const_int(context, location, 0, 32)?;
+        let array_start =
+            handle_block.extract_value(context, location, entry.argument(0)?.into(), len_ty, 1)?;
 
         let has_head_space = handle_block
             .append_operation(arith::cmpi(
@@ -304,16 +258,8 @@ pub fn build_append<'ctx, 'this>(
     }
 
     {
-        let array_start = memmove_block
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[1]),
-                len_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let array_start =
+            memmove_block.extract_value(context, location, entry.argument(0)?.into(), len_ty, 1)?;
 
         let start_offset = memmove_block
             .append_operation(arith::extui(
@@ -328,16 +274,8 @@ pub fn build_append<'ctx, 'this>(
             .result(0)?
             .into();
 
-        let dst_ptr = memmove_block
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let dst_ptr =
+            memmove_block.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
         let src_ptr = memmove_block
             .append_operation(llvm::get_element_ptr_dynamic(
                 context,
@@ -379,55 +317,17 @@ pub fn build_append<'ctx, 'this>(
             .into(),
         );
 
-        let k0 = memmove_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(len_ty, 0).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = memmove_block
-            .append_operation(llvm::insert_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[1]),
-                k0,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = memmove_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[2]),
-                array_len,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k0 = memmove_block.const_int_from_type(context, location, 0, len_ty)?;
+        let value =
+            memmove_block.insert_value(context, location, entry.argument(0)?.into(), k0, 1)?;
+        let value = memmove_block.insert_value(context, location, value, array_len, 2)?;
 
         memmove_block.append_operation(cf::br(append_block, &[value], location));
     }
 
     {
-        let k8 = realloc_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 32).into(), 8).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let k1024 = realloc_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 32).into(), 1024).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k8 = realloc_block.const_int(context, location, 8, 32)?;
+        let k1024 = realloc_block.const_int(context, location, 1024, 32)?;
 
         // Array allocation growth formula:
         //   new_len = max(8, old_len + min(1024, 2 * old_len));
@@ -463,16 +363,8 @@ pub fn build_append<'ctx, 'this>(
                 .into()
         };
 
-        let ptr = realloc_block
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let ptr =
+            realloc_block.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
         let ptr = realloc_block
             .append_operation(ReallocBindingsMeta::realloc(
                 context,
@@ -486,51 +378,28 @@ pub fn build_append<'ctx, 'this>(
         // No need to memmove, guaranteed by the fact that if we needed to memmove we'd have gone
         // through the memmove block instead of reallocating.
 
-        let value = realloc_block
-            .append_operation(llvm::insert_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = realloc_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[3]),
-                new_capacity,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value =
+            realloc_block.insert_value(context, location, entry.argument(0)?.into(), ptr, 0)?;
+        let value = realloc_block.insert_value(context, location, value, new_capacity, 3)?;
 
         realloc_block.append_operation(cf::br(append_block, &[value], location));
     }
 
     {
-        let ptr = append_block
-            .append_operation(llvm::extract_value(
-                context,
-                append_block.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let array_end = append_block
-            .append_operation(llvm::extract_value(
-                context,
-                append_block.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[2]),
-                len_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let ptr = append_block.extract_value(
+            context,
+            location,
+            append_block.argument(0)?.into(),
+            ptr_ty,
+            0,
+        )?;
+        let array_end = append_block.extract_value(
+            context,
+            location,
+            append_block.argument(0)?.into(),
+            len_ty,
+            2,
+        )?;
 
         let offset = append_block
             .append_operation(arith::extui(
@@ -556,31 +425,25 @@ pub fn build_append<'ctx, 'this>(
             .result(0)?
             .into();
 
-        append_block.append_operation(llvm::store(
+        append_block.store(
             context,
-            entry.argument(1)?.into(),
-            ptr,
             location,
-            LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                IntegerType::new(context, 64).into(),
-                elem_layout.align() as i64,
-            ))),
-        ));
+            ptr,
+            entry.argument(1)?.into(),
+            Some(elem_layout.align()),
+        );
 
         let array_len = append_block
             .append_operation(arith::addi(array_end, k1, location))
             .result(0)?
             .into();
-        let value = append_block
-            .append_operation(llvm::insert_value(
-                context,
-                append_block.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[2]),
-                array_len,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value = append_block.insert_value(
+            context,
+            location,
+            append_block.argument(0)?.into(),
+            array_len,
+            2,
+        )?;
 
         append_block.append_operation(helper.br(0, &[value], location));
     }
@@ -607,27 +470,10 @@ pub fn build_len<'ctx, 'this>(
     )?;
 
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
+    let array_value = entry.argument(0)?.into();
 
-    let array_start = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(0)?.into(),
-            DenseI64ArrayAttribute::new(context, &[1]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(0)?.into(),
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_start = entry.extract_value(context, location, array_value, len_ty, 1)?;
+    let array_end = entry.extract_value(context, location, array_value, len_ty, 2)?;
 
     let array_len = entry
         .append_operation(arith::subi(array_end, array_start, location))
@@ -673,26 +519,8 @@ pub fn build_get<'ctx, 'this>(
     let value = entry.argument(1)?.into();
     let index = entry.argument(2)?.into();
 
-    let array_start = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[1]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_start = entry.extract_value(context, location, value, len_ty, 1)?;
+    let array_end = entry.extract_value(context, location, value, len_ty, 2)?;
 
     let array_len = entry
         .append_operation(arith::subi(array_end, array_start, location))
@@ -722,16 +550,7 @@ pub fn build_get<'ctx, 'this>(
     ));
 
     {
-        let ptr = valid_block
-            .append_operation(llvm::extract_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let ptr = valid_block.extract_value(context, location, value, ptr_ty, 0)?;
 
         let index = {
             let array_start = valid_block
@@ -756,15 +575,7 @@ pub fn build_get<'ctx, 'this>(
                 .into()
         };
 
-        let elem_stride = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 64).into(), elem_stride as i64)
-                    .into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let elem_stride = valid_block.const_int(context, location, elem_stride, 64)?;
         let elem_offset = valid_block
             .append_operation(arith::muli(elem_stride, index, location))
             .result(0)?
@@ -782,18 +593,7 @@ pub fn build_get<'ctx, 'this>(
             .result(0)?
             .into();
 
-        let elem_size = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    elem_layout.size() as i64,
-                )
-                .into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let elem_size = valid_block.const_int(context, location, elem_layout.size(), 64)?;
 
         let target_ptr = valid_block
             .append_operation(llvm::nullptr(
@@ -866,26 +666,9 @@ pub fn build_pop_front<'ctx, 'this>(
 
     let value = entry.argument(0)?.into();
 
-    let array_start = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[1]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_start = entry.extract_value(context, location, value, len_ty, 1)?;
+    let array_end = entry.extract_value(context, location, value, len_ty, 2)?;
+
     let is_empty = entry
         .append_operation(arith::cmpi(
             context,
@@ -910,29 +693,9 @@ pub fn build_pop_front<'ctx, 'this>(
     ));
 
     {
-        let ptr = valid_block
-            .append_operation(llvm::extract_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let ptr = valid_block.extract_value(context, location, value, ptr_ty, 0)?;
 
-        let elem_size = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    elem_layout.size() as i64,
-                )
-                .into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let elem_size = valid_block.const_int(context, location, elem_layout.size(), 64)?;
         let elem_offset = valid_block
             .append_operation(arith::extui(
                 array_start,
@@ -990,28 +753,12 @@ pub fn build_pop_front<'ctx, 'this>(
             .into(),
         );
 
-        let k1 = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 32).into(), 1).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k1 = valid_block.const_int(context, location, 1, 32)?;
         let new_start = valid_block
             .append_operation(arith::addi(array_start, k1, location))
             .result(0)?
             .into();
-        let value = valid_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[1]),
-                new_start,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value = valid_block.insert_value(context, location, value, new_start, 1)?;
 
         valid_block.append_operation(helper.br(0, &[value, target_ptr], location));
     }
@@ -1077,26 +824,8 @@ pub fn build_snapshot_pop_back<'ctx, 'this>(
 
     let value = entry.argument(0)?.into();
 
-    let array_start = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[1]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            value,
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_start = entry.extract_value(context, location, value, len_ty, 1)?;
+    let array_end = entry.extract_value(context, location, value, len_ty, 2)?;
     let is_empty = entry
         .append_operation(arith::cmpi(
             context,
@@ -1121,42 +850,15 @@ pub fn build_snapshot_pop_back<'ctx, 'this>(
     ));
 
     {
-        let k1 = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 32).into(), 1).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k1 = valid_block.const_int(context, location, 1, 32)?;
         let new_end = valid_block
             .append_operation(arith::subi(array_end, k1, location))
             .result(0)?
             .into();
 
-        let ptr = valid_block
-            .append_operation(llvm::extract_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[0]),
-                ptr_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let ptr = valid_block.extract_value(context, location, value, ptr_ty, 0)?;
 
-        let elem_size = valid_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    elem_layout.size() as i64,
-                )
-                .into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let elem_size = valid_block.const_int(context, location, elem_layout.size(), 64)?;
         let elem_offset = valid_block
             .append_operation(arith::extui(
                 new_end,
@@ -1214,16 +916,7 @@ pub fn build_snapshot_pop_back<'ctx, 'this>(
             .into(),
         );
 
-        let value = valid_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[2]),
-                new_end,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value = valid_block.insert_value(context, location, value, new_end, 2)?;
 
         valid_block.append_operation(helper.br(0, &[value, target_ptr], location));
     }
@@ -1270,26 +963,9 @@ pub fn build_slice<'ctx, 'this>(
         .result(0)?
         .into();
 
-    let array_start = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(1)?.into(),
-            DenseI64ArrayAttribute::new(context, &[1]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_end = entry
-        .append_operation(llvm::extract_value(
-            context,
-            entry.argument(1)?.into(),
-            DenseI64ArrayAttribute::new(context, &[2]),
-            len_ty,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_start =
+        entry.extract_value(context, location, entry.argument(1)?.into(), len_ty, 1)?;
+    let array_end = entry.extract_value(context, location, entry.argument(1)?.into(), len_ty, 2)?;
 
     let slice_since = entry
         .append_operation(arith::addi(slice_since, array_start, location))
@@ -1339,18 +1015,8 @@ pub fn build_slice<'ctx, 'this>(
     ));
 
     {
-        let elem_size = slice_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    elem_layout.pad_to_align().size() as i64,
-                )
-                .into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let elem_size =
+            slice_block.const_int(context, location, elem_layout.pad_to_align().size(), 64)?;
         let dst_size = slice_block
             .append_operation(arith::extui(
                 slice_length,
@@ -1359,63 +1025,42 @@ pub fn build_slice<'ctx, 'this>(
             ))
             .result(0)?
             .into();
-        let dst_size = slice_block
-            .append_operation(arith::muli(dst_size, elem_size, location))
-            .result(0)?
-            .into();
+        let dst_size = slice_block.append_op_result(arith::muli(dst_size, elem_size, location))?;
 
-        let dst_ptr = slice_block
-            .append_operation(llvm::nullptr(
-                llvm::r#type::opaque_pointer(context),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let dst_ptr = slice_block
-            .append_operation(ReallocBindingsMeta::realloc(
-                context, dst_ptr, dst_size, location,
-            ))
-            .result(0)?
-            .into();
+        let dst_ptr = slice_block.append_op_result(llvm::nullptr(
+            llvm::r#type::opaque_pointer(context),
+            location,
+        ))?;
+        let dst_ptr = slice_block.append_op_result(ReallocBindingsMeta::realloc(
+            context, dst_ptr, dst_size, location,
+        ))?;
 
         // TODO: Find out if we need to clone stuff using the snapshot clone meta.
         let src_offset = {
-            let slice_since = slice_block
-                .append_operation(arith::extui(
-                    slice_since,
-                    IntegerType::new(context, 64).into(),
-                    location,
-                ))
-                .result(0)?
-                .into();
+            let slice_since = slice_block.append_op_result(arith::extui(
+                slice_since,
+                IntegerType::new(context, 64).into(),
+                location,
+            ))?;
 
-            slice_block
-                .append_operation(arith::muli(slice_since, elem_size, location))
-                .result(0)?
-                .into()
+            slice_block.append_op_result(arith::muli(slice_since, elem_size, location))?
         };
 
-        let src_ptr = slice_block
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(1)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                llvm::r#type::opaque_pointer(context),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let src_ptr = slice_block
-            .append_operation(llvm::get_element_ptr_dynamic(
-                context,
-                src_ptr,
-                &[src_offset],
-                IntegerType::new(context, 8).into(),
-                llvm::r#type::opaque_pointer(context),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let src_ptr = slice_block.extract_value(
+            context,
+            location,
+            entry.argument(1)?.into(),
+            opaque_pointer(context),
+            0,
+        )?;
+        let src_ptr = slice_block.append_op_result(llvm::get_element_ptr_dynamic(
+            context,
+            src_ptr,
+            &[src_offset],
+            IntegerType::new(context, 8).into(),
+            llvm::r#type::opaque_pointer(context),
+            location,
+        ))?;
 
         slice_block.append_operation(
             ods::llvm::intr_memcpy(
@@ -1429,59 +1074,15 @@ pub fn build_slice<'ctx, 'this>(
             .into(),
         );
 
-        let k0 = slice_block
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(len_ty, 0).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
+        let k0 = slice_block.const_int_from_type(context, location, 0, len_ty)?;
 
-        let value = slice_block
-            .append_operation(llvm::undef(array_ty, location))
-            .result(0)?
-            .into();
-        let value = slice_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[0]),
-                dst_ptr,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = slice_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[1]),
-                k0,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = slice_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[2]),
-                slice_length,
-                location,
-            ))
-            .result(0)?
-            .into();
-        let value = slice_block
-            .append_operation(llvm::insert_value(
-                context,
-                value,
-                DenseI64ArrayAttribute::new(context, &[3]),
-                slice_length,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value = slice_block.append_op_result(llvm::undef(array_ty, location))?;
+        let value = slice_block.insert_values(
+            context,
+            location,
+            value,
+            &[dst_ptr, k0, slice_length, slice_length],
+        )?;
 
         slice_block.append_operation(helper.br(0, &[range_check, value], location));
     }
@@ -1512,19 +1113,13 @@ pub fn build_span_from_tuple<'ctx, 'this>(
 
     let container: Value = {
         // load box
-        entry
-            .append_operation(llvm::load(
-                context,
-                entry.argument(0)?.into(),
-                struct_ty,
-                location,
-                LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    struct_type_info.layout(registry)?.align() as i64,
-                ))),
-            ))
-            .result(0)?
-            .into()
+        entry.load(
+            context,
+            location,
+            entry.argument(0)?.into(),
+            struct_ty,
+            Some(struct_type_info.layout(registry)?.align()),
+        )?
     };
 
     let fields = struct_type_info.fields().expect("should have fields");
@@ -1541,59 +1136,17 @@ pub fn build_span_from_tuple<'ctx, 'this>(
     )?;
     let len_ty = crate::ffi::get_struct_field_type_at(&array_ty, 1);
 
-    let array_len_value = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(len_ty, fields.len().try_into().unwrap()).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_len_value = entry.const_int_from_type(context, location, fields.len(), len_ty)?;
 
-    let array_container = entry
-        .append_operation(llvm::undef(array_ty, location))
-        .result(0)?
-        .into();
+    let array_container = entry.append_op_result(llvm::undef(array_ty, location))?;
 
-    let k0 = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(len_ty, 0).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let k0 = entry.const_int_from_type(context, location, 0, len_ty)?;
 
-    let array_container = entry
-        .append_operation(llvm::insert_value(
-            context,
-            array_container,
-            DenseI64ArrayAttribute::new(context, &[1]),
-            k0,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_container = entry
-        .append_operation(llvm::insert_value(
-            context,
-            array_container,
-            DenseI64ArrayAttribute::new(context, &[2]),
-            array_len_value,
-            location,
-        ))
-        .result(0)?
-        .into();
-    let array_container = entry
-        .append_operation(llvm::insert_value(
-            context,
-            array_container,
-            DenseI64ArrayAttribute::new(context, &[3]),
-            array_len_value,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_container = entry.insert_value(context, location, array_container, k0, 1)?;
+    let array_container =
+        entry.insert_value(context, location, array_container, array_len_value, 2)?;
+    let array_container =
+        entry.insert_value(context, location, array_container, array_len_value, 3)?;
 
     let opaque_ptr_ty = opaque_pointer(context);
 
@@ -1602,18 +1155,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
         .result(0)?
         .into();
 
-    let field_size: Value = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(
-                IntegerType::new(context, 64).into(),
-                field_stride.try_into().unwrap(),
-            )
-            .into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let field_size: Value = entry.const_int(context, location, field_stride, 64)?;
     let array_len_value_i64 = entry
         .append_operation(arith::extui(array_len_value, field_size.r#type(), location))
         .result(0)?
@@ -1631,16 +1173,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
         .into();
 
     for (i, _) in fields.iter().enumerate() {
-        let value: Value = entry
-            .append_operation(llvm::extract_value(
-                context,
-                container,
-                DenseI64ArrayAttribute::new(context, &[i.try_into()?]),
-                field_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let value: Value = entry.extract_value(context, location, container, field_ty, i)?;
 
         let target_ptr = entry
             .append_operation(llvm::get_element_ptr(
@@ -1654,25 +1187,10 @@ pub fn build_span_from_tuple<'ctx, 'this>(
             .result(0)?
             .into();
 
-        entry.append_operation(llvm::store(
-            context,
-            value,
-            target_ptr,
-            location,
-            LoadStoreOptions::default(),
-        ));
+        entry.store(context, location, target_ptr, value, None);
     }
 
-    let array_container = entry
-        .append_operation(llvm::insert_value(
-            context,
-            array_container,
-            DenseI64ArrayAttribute::new(context, &[0]),
-            ptr,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let array_container = entry.insert_value(context, location, array_container, ptr, 0)?;
 
     entry.append_operation(helper.br(0, &[array_container], location));
 
@@ -1686,23 +1204,10 @@ fn assert_nonnull<'ctx, 'this>(
     ptr: Value<'ctx, 'this>,
     msg: &str,
 ) -> Result<()> {
-    let k0 = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
-    let ptr_value = entry
-        .append_operation(
-            OperationBuilder::new("llvm.ptrtoint", location)
-                .add_operands(&[ptr])
-                .add_results(&[IntegerType::new(context, 64).into()])
-                .build()?,
-        )
-        .result(0)?
-        .into();
+    let k0 = entry.const_int(context, location, 0, 64)?;
+    let ptr_value = entry.append_op_result(
+        ods::llvm::ptrtoint(context, IntegerType::new(context, 64).into(), ptr, location).into(),
+    )?;
 
     let ptr_is_not_null = entry
         .append_operation(arith::cmpi(

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -21,7 +21,7 @@ use cairo_lang_sierra::{
 use melior::{
     dialect::{
         cf, func, index,
-        llvm::{self, LoadStoreOptions},
+        llvm::{self},
         memref,
     },
     ir::{

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -20,14 +20,12 @@ use cairo_lang_sierra::{
 };
 use melior::{
     dialect::{
-        arith, cf, func, index,
-        llvm::{self, AllocaOptions, LoadStoreOptions},
+        cf, func, index,
+        llvm::{self, LoadStoreOptions},
         memref,
     },
     ir::{
-        attribute::{
-            DenseI32ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute, TypeAttribute,
-        },
+        attribute::{DenseI32ArrayAttribute, FlatSymbolRefAttribute, IntegerAttribute},
         r#type::IntegerType,
         Block, Location, Type, Value,
     },
@@ -183,7 +181,7 @@ pub fn build<'ctx, 'this>(
 
         cont_block.append_operation(helper.br(0, &results, location));
     } else {
-        let op0 = entry.append_operation(func::call(
+        let function_call_result = entry.append_operation(func::call(
             context,
             FlatSymbolRefAttribute::new(context, &generate_function_name(&info.function.id)),
             &arguments,
@@ -224,17 +222,13 @@ pub fn build<'ctx, 'this>(
                         results.push(if type_info.is_memory_allocated(registry) {
                             pointer_val
                         } else {
-                            entry
-                                .append_operation(llvm::load(
-                                    context,
-                                    pointer_val,
-                                    type_info
-                                        .build(context, helper, registry, metadata, type_id)?,
-                                    location,
-                                    LoadStoreOptions::new(),
-                                ))
-                                .result(0)?
-                                .into()
+                            entry.load(
+                                context,
+                                location,
+                                pointer_val,
+                                type_info.build(context, helper, registry, metadata, type_id)?,
+                                None,
+                            )?
                         });
                     }
                 }
@@ -250,7 +244,7 @@ pub fn build<'ctx, 'this>(
                     if type_info.is_builtin() && type_info.is_zst(registry) {
                         results.push(entry.argument(idx)?.into());
                     } else {
-                        let val = op0.result(count)?.into();
+                        let val = function_call_result.result(count)?.into();
                         count += 1;
 
                         results.push(if type_info.is_memory_allocated(registry) {
@@ -258,43 +252,14 @@ pub fn build<'ctx, 'this>(
                                 type_info.build(context, helper, registry, metadata, type_id)?;
                             let layout = type_info.layout(registry)?;
 
-                            let k1 = helper
-                                .init_block()
-                                .append_operation(arith::constant(
-                                    context,
-                                    IntegerAttribute::new(IntegerType::new(context, 64).into(), 1)
-                                        .into(),
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-                            let stack_ptr = helper
-                                .init_block()
-                                .append_operation(llvm::alloca(
-                                    context,
-                                    k1,
-                                    llvm::r#type::opaque_pointer(context),
-                                    location,
-                                    AllocaOptions::new()
-                                        .align(Some(IntegerAttribute::new(
-                                            IntegerType::new(context, 64).into(),
-                                            layout.align() as i64,
-                                        )))
-                                        .elem_type(Some(TypeAttribute::new(ty))),
-                                ))
-                                .result(0)?
-                                .into();
-
-                            entry.append_operation(llvm::store(
+                            let stack_ptr = helper.init_block().alloca1(
                                 context,
-                                val,
-                                stack_ptr,
                                 location,
-                                LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                                    IntegerType::new(context, 64).into(),
-                                    layout.align() as i64,
-                                ))),
-                            ));
+                                ty,
+                                Some(layout.align()),
+                            )?;
+
+                            entry.store(context, location, stack_ptr, val, Some(layout.align()));
 
                             stack_ptr
                         } else {
@@ -314,7 +279,7 @@ pub fn build<'ctx, 'this>(
                     if type_info.is_builtin() && type_info.is_zst(registry) {
                         results.push(entry.argument(idx)?.into());
                     } else {
-                        let value = op0.result(count)?.into();
+                        let value = function_call_result.result(count)?.into();
                         count += 1;
 
                         results.push(value);

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -5,6 +5,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::Result,
     metadata::{tail_recursion::TailRecursionMeta, MetadataStorage},
     types::TypeBuilder,
@@ -87,33 +88,12 @@ pub fn build<'ctx, 'this>(
         let (type_id, type_info) = return_types[0];
         let layout = type_info.layout(registry)?;
 
-        let k1 = helper
-            .init_block()
-            .append_operation(arith::constant(
-                context,
-                IntegerAttribute::new(IntegerType::new(context, 64).into(), 1).into(),
-                location,
-            ))
-            .result(0)?
-            .into();
-        let stack_ptr = helper
-            .init_block()
-            .append_operation(llvm::alloca(
-                context,
-                k1,
-                llvm::r#type::opaque_pointer(context),
-                location,
-                AllocaOptions::new()
-                    .align(Some(IntegerAttribute::new(
-                        IntegerType::new(context, 64).into(),
-                        layout.align() as i64,
-                    )))
-                    .elem_type(Some(TypeAttribute::new(
-                        type_info.build(context, helper, registry, metadata, type_id)?,
-                    ))),
-            ))
-            .result(0)?
-            .into();
+        let stack_ptr = helper.init_block().alloca1(
+            context,
+            location,
+            type_info.build(context, helper, registry, metadata, type_id)?,
+            Some(layout.align()),
+        )?;
 
         arguments.insert(0, stack_ptr);
 
@@ -126,19 +106,20 @@ pub fn build<'ctx, 'this>(
     };
 
     if let Some(tailrec_meta) = metadata.get_mut::<TailRecursionMeta>() {
-        let op0 = entry.append_operation(memref::load(tailrec_meta.depth_counter(), &[], location));
-        let op1 = entry.append_operation(index::constant(
+        let depth_counter =
+            entry.append_op_result(memref::load(tailrec_meta.depth_counter(), &[], location))?;
+
+        let index1 = entry.append_op_result(index::constant(
             context,
             IntegerAttribute::new(Type::index(context), 1),
             location,
-        ));
-        let op2 = entry.append_operation(index::add(
-            op0.result(0)?.into(),
-            op1.result(0)?.into(),
-            location,
-        ));
+        ))?;
+
+        let depth_counter_plus_1 =
+            entry.append_op_result(index::add(depth_counter, index1, location))?;
+
         entry.append_operation(memref::store(
-            op2.result(0)?.into(),
+            depth_counter_plus_1,
             tailrec_meta.depth_counter(),
             &[],
             location,
@@ -186,42 +167,12 @@ pub fn build<'ctx, 'this>(
                     let ty = type_info.build(context, helper, registry, metadata, &var_info.ty)?;
                     let layout = type_info.layout(registry)?;
 
-                    let k1 = helper
-                        .init_block()
-                        .append_operation(arith::constant(
-                            context,
-                            IntegerAttribute::new(IntegerType::new(context, 64).into(), 1).into(),
-                            location,
-                        ))
-                        .result(0)?
-                        .into();
-                    let stack_ptr = helper
-                        .init_block()
-                        .append_operation(llvm::alloca(
-                            context,
-                            k1,
-                            llvm::r#type::opaque_pointer(context),
-                            location,
-                            AllocaOptions::new()
-                                .align(Some(IntegerAttribute::new(
-                                    IntegerType::new(context, 64).into(),
-                                    layout.align() as i64,
-                                )))
-                                .elem_type(Some(TypeAttribute::new(ty))),
-                        ))
-                        .result(0)?
-                        .into();
+                    let stack_ptr =
+                        helper
+                            .init_block()
+                            .alloca1(context, location, ty, Some(layout.align()))?;
 
-                    cont_block.append_operation(llvm::store(
-                        context,
-                        val,
-                        stack_ptr,
-                        location,
-                        LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                            IntegerType::new(context, 64).into(),
-                            layout.align() as i64,
-                        ))),
-                    ));
+                    cont_block.store(context, location, stack_ptr, val, Some(layout.align()));
 
                     stack_ptr
                 } else {

--- a/src/libfuncs/sint128.rs
+++ b/src/libfuncs/sint128.rs
@@ -3,6 +3,7 @@ use super::LibfuncHelper;
 use std::ops::Shr;
 
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     utils::ProgramRegistryExt,
@@ -86,13 +87,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/sint16.rs
+++ b/src/libfuncs/sint16.rs
@@ -3,6 +3,7 @@ use super::LibfuncHelper;
 use std::ops::Shr;
 
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     utils::ProgramRegistryExt,
@@ -87,13 +88,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/sint32.rs
+++ b/src/libfuncs/sint32.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     utils::ProgramRegistryExt,
@@ -87,13 +88,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/sint64.rs
+++ b/src/libfuncs/sint64.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     utils::ProgramRegistryExt,
@@ -87,13 +88,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/sint8.rs
+++ b/src/libfuncs/sint8.rs
@@ -3,6 +3,7 @@ use super::LibfuncHelper;
 use std::ops::Shr;
 
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     utils::ProgramRegistryExt,
@@ -87,13 +88,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/uint16.rs
+++ b/src/libfuncs/uint16.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::MetadataStorage,
     utils::ProgramRegistryExt,
@@ -93,13 +94,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/uint32.rs
+++ b/src/libfuncs/uint32.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::MetadataStorage,
     utils::ProgramRegistryExt,
@@ -93,13 +94,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/uint64.rs
+++ b/src/libfuncs/uint64.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::MetadataStorage,
     utils::ProgramRegistryExt,
@@ -93,13 +94,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }

--- a/src/libfuncs/uint8.rs
+++ b/src/libfuncs/uint8.rs
@@ -2,6 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::MetadataStorage,
     utils::ProgramRegistryExt,
@@ -93,13 +94,9 @@ pub fn build_const<'ctx, 'this>(
         &info.signature.branch_signatures[0].vars[0].ty,
     )?;
 
-    let op0 = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{value} : {value_ty}"))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    entry.append_operation(helper.br(0, &[op0.result(0)?.into()], location));
+    let value = entry.const_int_from_type(context, location, value, value_ty)?;
+
+    entry.append_operation(helper.br(0, &[value], location));
 
     Ok(())
 }


### PR DESCRIPTION
We have a lot of repeated places in codegen where we use complicated or repetitive operations, this refactors some common complexity so we can avoid mistakes.

For now I only use the methods in a few places like the array libfuncs, but it could be used in all libfuncs, It's just quite some more work to do replacing those.

Operations that are in BlockExt that can be replaced

- llvm.alloca
- arith.constant
- llvm.extract_value
- llvm.insert_value
- llvm.alloca
- llvm.load
- llvm.store
- llvm.memcpy


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
