### PR TITLE
Refactored enum libfuncs to use the BlockExt trait

### DIFF
--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -95,7 +95,7 @@ pub fn build_init<'ctx, 'this>(
                 false,
             );
 
-            let tag_val = entry.const_int(context, location, info.index as i64, 64)?;
+            let tag_val = entry.const_int_from_type(context, location, tag_ty, info.index)?;
 
             let payload_val = if payload_type_info.is_memory_allocated(registry) {
                 entry.load(context, location, entry.argument(0)?.into(), variant_tys[info.index].0, Some(variant_tys[info.index].1.align()))?
@@ -124,23 +124,14 @@ pub fn build_init<'ctx, 'this>(
             };
 
             if type_info.is_memory_allocated(registry) {
-                let k1: i64 = helper
-                    .init_block()
-                    .append_operation(arith::constant(
-                        context,
-                        IntegerAttribute::new(IntegerType::new(context, 64).into(), 1).into(),
-                        location,
-                    ))
-                    .result(0)?
-                    .into();
-            let stack_ptr = helper.init_block().alloca1(
-                context,
-                location,
-                type_info.build(
+                let stack_ptr = helper.init_block().alloca1(
                     context,
-                    helper,
-                    registry,
-                    metadata,
+                    location,
+                    type_info.build(
+                        context,
+                        helper,
+                        registry,
+                        metadata,
                     &info.branch_signatures()[0].vars[0].ty,
                 )?,
                 Some(layout.align()),
@@ -292,7 +283,7 @@ pub fn build_match<'ctx, 'this>(
                         ))
                         .result(0)?
                         .into();
-                    let stack_ptr = helper.init_block().alloca1(context, location, payload_layout, Some(payload_layout.align()))?;
+                    let stack_ptr = helper.init_block().alloca1(context, location, payload_ty, Some(payload_layout.align()))?;
 
                     block.store(context, location, stack_ptr, payload_val, Some(payload_layout.align()));
 

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -4,6 +4,7 @@
 
 use super::LibfuncHelper;
 use crate::{
+    block_ext::BlockExt,
     error::{Error, Result},
     metadata::{enum_snapshot_variants::EnumSnapshotVariantsMeta, MetadataStorage},
     types::TypeBuilder,
@@ -94,29 +95,10 @@ pub fn build_init<'ctx, 'this>(
                 false,
             );
 
-            let tag_val = entry
-                .append_operation(arith::constant(
-                    context,
-                    IntegerAttribute::new(tag_ty, info.index as i64).into(),
-                    location,
-                ))
-                .result(0)?
-                .into();
+            let tag_val = entry.const_int(context, location, info.index as i64, 64)?;
 
             let payload_val = if payload_type_info.is_memory_allocated(registry) {
-                entry
-                    .append_operation(llvm::load(
-                        context,
-                        entry.argument(0)?.into(),
-                        variant_tys[info.index].0,
-                        location,
-                        LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                            IntegerType::new(context, 64).into(),
-                            variant_tys[info.index].1.align() as i64,
-                        ))),
-                    ))
-                    .result(0)?
-                    .into()
+                entry.load(context, location, entry.argument(0)?.into(), variant_tys[info.index].0, Some(variant_tys[info.index].1.align()))?
             } else {
                 entry.argument(0)?.into()
             };
@@ -125,16 +107,7 @@ pub fn build_init<'ctx, 'this>(
                 .append_operation(llvm::undef(enum_ty, location))
                 .result(0)?
                 .into();
-            let val = entry
-                .append_operation(llvm::insert_value(
-                    context,
-                    val,
-                    DenseI64ArrayAttribute::new(context, &[0]),
-                    tag_val,
-                    location,
-                ))
-                .result(0)?
-                .into();
+            let val = entry.insert_value(context, location, val, tag_val, 0)?;
             let val = if payload_type_info.is_zst(registry) {
                 val
             } else {
@@ -160,39 +133,9 @@ pub fn build_init<'ctx, 'this>(
                     ))
                     .result(0)?
                     .into();
-                let stack_ptr = helper
-                    .init_block()
-                    .append_operation(llvm::alloca(
-                        context,
-                        k1,
-                        llvm::r#type::opaque_pointer(context),
-                        location,
-                        AllocaOptions::new()
-                            .align(Some(IntegerAttribute::new(
-                                IntegerType::new(context, 64).into(),
-                                layout.align() as i64,
-                            )))
-                            .elem_type(Some(TypeAttribute::new(type_info.build(
-                                context,
-                                helper,
-                                registry,
-                                metadata,
-                                &info.branch_signatures()[0].vars[0].ty,
-                            )?))),
-                    ))
-                    .result(0)?
-                    .into();
+            let stack_ptr = helper.alloca(context, location, k1, Some(layout.align()))?;
 
-                entry.append_operation(llvm::store(
-                    context,
-                    val,
-                    stack_ptr,
-                    location,
-                    LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                        IntegerType::new(context, 64).into(),
-                        layout.align() as i64,
-                    ))),
-                ));
+            entry.store(context, location, stack_ptr, val, Some(layout.align()));
 
                 entry.append_operation(helper.br(0, &[stack_ptr], location));
             } else {
@@ -232,30 +175,9 @@ pub fn build_match<'ctx, 'this>(
             )?;
 
             let tag_val = if type_info.is_memory_allocated(registry) {
-                entry
-                    .append_operation(llvm::load(
-                        context,
-                        entry.argument(0)?.into(),
-                        tag_ty,
-                        location,
-                        LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                            IntegerType::new(context, 64).into(),
-                            layout.align() as i64,
-                        ))),
-                    ))
-                    .result(0)?
-                    .into()
+                entry.load(context, location, entry.argument(0)?.into(), tag_ty, Some(layout.align()))?
             } else {
-                entry
-                    .append_operation(llvm::extract_value(
-                        context,
-                        entry.argument(0)?.into(),
-                        DenseI64ArrayAttribute::new(context, &[0]),
-                        tag_ty,
-                        location,
-                    ))
-                    .result(0)?
-                    .into()
+                entry.extract_value(context, location, entry.argument(0)?.into(), tag_ty, 0)?
             };
 
             let default_block = helper.append_block(Block::new(&[]));
@@ -359,33 +281,9 @@ pub fn build_match<'ctx, 'this>(
                         ))
                         .result(0)?
                         .into();
-                    let stack_ptr = helper
-                        .init_block()
-                        .append_operation(llvm::alloca(
-                            context,
-                            k1,
-                            llvm::r#type::opaque_pointer(context),
-                            location,
-                            AllocaOptions::new()
-                                .align(Some(IntegerAttribute::new(
-                                    IntegerType::new(context, 64).into(),
-                                    payload_layout.align() as i64,
-                                )))
-                                .elem_type(Some(TypeAttribute::new(payload_ty))),
-                        ))
-                        .result(0)?
-                        .into();
+                    let stack_ptr = helper.alloca(context, location, k1, Some(payload_layout.align()))?;
 
-                    block.append_operation(llvm::store(
-                        context,
-                        payload_val,
-                        stack_ptr,
-                        location,
-                        LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                            IntegerType::new(context, 64).into(),
-                            payload_layout.align() as i64,
-                        ))),
-                    ));
+                    block.store(context, location, stack_ptr, payload_val, Some(payload_layout.align()))?;
 
                     stack_ptr
                 } else {
@@ -428,30 +326,9 @@ pub fn build_snapshot_match<'ctx, 'this>(
     )?;
 
     let tag_val = if type_info.is_memory_allocated(registry) {
-        entry
-            .append_operation(llvm::load(
-                context,
-                entry.argument(0)?.into(),
-                tag_ty,
-                location,
-                LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                    IntegerType::new(context, 64).into(),
-                    layout.align() as i64,
-                ))),
-            ))
-            .result(0)?
-            .into()
+        entry.load(context, location, entry.argument(0)?.into(), tag_ty, Some(layout.align()))?
     } else {
-        entry
-            .append_operation(llvm::extract_value(
-                context,
-                entry.argument(0)?.into(),
-                DenseI64ArrayAttribute::new(context, &[0]),
-                tag_ty,
-                location,
-            ))
-            .result(0)?
-            .into()
+        entry.extract_value(context, location, entry.argument(0)?.into(), tag_ty, 0)?
     };
 
     let default_block = helper.append_block(Block::new(&[]));
@@ -498,19 +375,7 @@ pub fn build_snapshot_match<'ctx, 'this>(
         let enum_ty = llvm::r#type::r#struct(context, &[tag_ty, payload_ty], false);
 
         let val = if type_info.is_memory_allocated(registry) {
-            block
-                .append_operation(llvm::load(
-                    context,
-                    entry.argument(0)?.into(),
-                    enum_ty,
-                    location,
-                    LoadStoreOptions::new().align(Some(IntegerAttribute::new(
-                        IntegerType::new(context, 64).into(),
-                        layout.align() as i64,
-                    ))),
-                ))
-                .result(0)?
-                .into()
+            block.load(context, location, entry.argument(0)?.into(), enum_ty, Some(layout.align()))?
         } else {
             let val: Value = entry.argument(0)?.into();
 
@@ -525,16 +390,7 @@ pub fn build_snapshot_match<'ctx, 'this>(
             val
         };
 
-        let payload_val = block
-            .append_operation(llvm::extract_value(
-                context,
-                val,
-                DenseI64ArrayAttribute::new(context, &[1]),
-                payload_ty,
-                location,
-            ))
-            .result(0)?
-            .into();
+        let payload_val = block.extract_value(context, location, val, payload_ty, 1)?;
 
         block.append_operation(helper.br(i, &[payload_val], location));
     }

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -21,10 +21,10 @@ use cairo_lang_sierra::{
 use melior::{
     dialect::{
         arith, cf,
-        llvm::{self, AllocaOptions, LoadStoreOptions},
+        llvm::{self, LoadStoreOptions},
     },
     ir::{
-        attribute::{DenseI64ArrayAttribute, IntegerAttribute, TypeAttribute},
+        attribute::{DenseI64ArrayAttribute, IntegerAttribute},
         r#type::IntegerType,
         Block, Location, Value, ValueLike,
     },
@@ -124,7 +124,7 @@ pub fn build_init<'ctx, 'this>(
             };
 
             if type_info.is_memory_allocated(registry) {
-                let k1 = helper
+                let k1: i64 = helper
                     .init_block()
                     .append_operation(arith::constant(
                         context,
@@ -292,9 +292,9 @@ pub fn build_match<'ctx, 'this>(
                         ))
                         .result(0)?
                         .into();
-                    let stack_ptr = helper.init_block().alloca1(context, location, payload_layout.element_type(), Some(payload_layout.align()))?;
+                    let stack_ptr = helper.init_block().alloca1(context, location, payload_layout, Some(payload_layout.align()))?;
 
-                    block.store(context, location, stack_ptr, payload_val, Some(payload_layout.align()))?;
+                    block.store(context, location, stack_ptr, payload_val, Some(payload_layout.align()));
 
                     stack_ptr
                 } else {

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -133,7 +133,18 @@ pub fn build_init<'ctx, 'this>(
                     ))
                     .result(0)?
                     .into();
-            let stack_ptr = helper.alloca(context, location, k1, Some(layout.align()))?;
+            let stack_ptr = helper.init_block().alloca1(
+                context,
+                location,
+                type_info.build(
+                    context,
+                    helper,
+                    registry,
+                    metadata,
+                    &info.branch_signatures()[0].vars[0].ty,
+                )?,
+                Some(layout.align()),
+            )?;
 
             entry.store(context, location, stack_ptr, val, Some(layout.align()));
 
@@ -281,7 +292,7 @@ pub fn build_match<'ctx, 'this>(
                         ))
                         .result(0)?
                         .into();
-                    let stack_ptr = helper.alloca(context, location, k1, Some(payload_layout.align()))?;
+                    let stack_ptr = helper.init_block().alloca1(context, location, payload_layout.element_type(), Some(payload_layout.align()))?;
 
                     block.store(context, location, stack_ptr, payload_val, Some(payload_layout.align()))?;
 


### PR DESCRIPTION
## Checklist
- [ ] Linked to Github Issue: https://github.com/lambdaclass/cairo_native/issues/526
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
