### PR TITLE
Fix `test_ecdsa_recover_public_key` test

### DIFF
--- a/cairo-tests/src/ec_test.cairo
+++ b/cairo-tests/src/ec_test.cairo
@@ -111,9 +111,7 @@ fn test_ecdsa() {
     );
 }
 
-// TODO: fails  recover_ecdsa_public_key failed
 #[test]
-#[ignore]
 fn test_ecdsa_recover_public_key() {
     let message_hash = 0x503f4bea29baee10b22a7f10bdc82dda071c977c1f25b8f3973d34e6b03b2c;
     let signature_r = 0xbe96d72eb4f94078192c2e84d5230cde2a70f4b45c8797e2c907acff5060bb;


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

Should close https://github.com/lambdaclass/cairo_native/issues/468

The modular inverse should be obtained roughly via the pseudo code:

```
function inverse(a, n)
    t := 0;     newt := 1
    r := n;     newr := a

    while newr ≠ 0 do
        quotient := r div newr
        (t, newt) := (newt, t − quotient × newt) 
        (r, newr) := (newr, r − quotient × newr)

    if r > 1 then
        return "a is not invertible"
    if t < 0 then
        t := t + n

    return t
```

In the `build_u256_guarantee_inv_mod_n` construction, we missed the `t < 0` condition, causing this operation https://github.com/starkware-libs/cairo/blob/afeeed29b37bd394535fcf3e8d7d16db047381fb/corelib/src/ecdsa.cairo#L143 to fail in the ECDSA `recover_public_key` procedure. This issue is fixed and another unit test is added in the `u256_inv_mod_n` suite to cover this scenario.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
