### PR TITLE
fix: builtin gas

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -61,7 +61,6 @@ use cairo_lang_sierra::{
     edit_state,
     extensions::{
         core::{CoreLibfunc, CoreType},
-        gas::CostTokenType,
         ConcreteLibfunc,
     },
     ids::{ConcreteTypeId, VarId},
@@ -288,8 +287,7 @@ fn compile_func(
         (initial_state, BTreeMap::<usize, usize>::new()),
         |statement_idx, (mut state, mut tailrec_state)| {
             if let Some(gas_metadata) = metadata.get::<GasMetadata>() {
-                let gas_cost =
-                    gas_metadata.get_gas_cost_for_statement(statement_idx, CostTokenType::Const);
+                let gas_cost = gas_metadata.get_gas_cost_for_statement(statement_idx);
                 metadata.remove::<GasCost>();
                 metadata.insert(GasCost(gas_cost));
             }

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -100,7 +100,19 @@ impl GasMetadata {
         )
     }
 
-    pub fn get_gas_cost_for_statement(
+    pub fn get_gas_cost_for_statement(&self, idx: StatementIdx) -> Option<u128> {
+        let mut cost = None;
+        for cost_type in CostTokenType::iter() {
+            if let Some(amount) =
+                self.get_gas_cost_for_statement_and_cost_token_type(idx, *cost_type)
+            {
+                *cost.get_or_insert(0) += amount * token_gas_cost(*cost_type) as u128;
+            }
+        }
+        cost
+    }
+
+    pub fn get_gas_cost_for_statement_and_cost_token_type(
         &self,
         idx: StatementIdx,
         cost_type: CostTokenType,

--- a/tests/alexandria/src/lib.cairo
+++ b/tests/alexandria/src/lib.cairo
@@ -2,7 +2,7 @@ mod alexandria {
     // Alexandria Math
 
     use core::option::OptionTrait;
-fn fib() -> felt252 {
+    fn fib() -> felt252 {
         alexandria_math::fibonacci::fib(16, 10, 1)
     }
 

--- a/tests/tests/alexandria.rs
+++ b/tests/tests/alexandria.rs
@@ -55,7 +55,7 @@ fn compare_inputless_function(function_name: &str) {
 #[test_case("queue")]
 #[test_case("bit_array")]
 // alexandria_encoding
-#[test_case("base64_encode" => ignore["Gas mismatch"])]
+#[test_case("base64_encode")]
 #[test_case("reverse_bits")]
 #[test_case("reverse_bytes")]
 fn test_cases(function_name: &str) {


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->
Fixes the last gas mismatch test left in Alexandria test suite. The builtins gas cost was not added to the `GasCost` metadata, which caused the mismatch. As shown [here](https://github.com/starkware-libs/cairo/blob/v2.5.4/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs#L150), builtins cost should be accounted for when calling the `withdraw_all_gas` libfunc.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
