### PR TITLE
refactor `Error` and increase test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
  "once_cell",
  "salsa",
  "smol_str",
+ "toml",
 ]
 
 [[package]]
@@ -873,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.5.4"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ab221aa0119b6e613992127687a1352a896d30a2e55a9295c52eb9598bcc78"
+checksum = "aa2891a07af4e55a029be8ad2ec88558fe6e78d6afd67f8c1308e99676586d3a"
 dependencies = [
  "cairo-lang-utils",
  "colored",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,10 @@
 //! Various error types used thorough the crate.
+use crate::metadata::gas::GasMetadataError;
 use cairo_lang_sierra::{
     edit_state::EditStateError, ids::ConcreteTypeId, program_registry::ProgramRegistryError,
 };
-
 use std::{alloc::LayoutError, num::TryFromIntError};
 use thiserror::Error;
-
-use crate::metadata::gas::GasMetadataError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -64,15 +62,43 @@ pub enum Error {
     ConstDataMismatch,
 }
 
-pub fn make_unexpected_value_error(expected: String) -> Error {
-    Error::UnexpectedValue(expected)
+impl Error {
+    pub fn make_missing_parameter(ty: &ConcreteTypeId) -> Self {
+        Self::MissingParameter(
+            ty.debug_name
+                .as_ref()
+                .map(|x| x.to_string())
+                .unwrap_or_default(),
+        )
+    }
 }
 
-pub fn make_missing_parameter(ty: &ConcreteTypeId) -> Error {
-    Error::MissingParameter(
-        ty.debug_name
-            .as_ref()
-            .map(|x| x.to_string())
-            .unwrap_or_default(),
-    )
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_make_missing_parameter() {
+        // Test with a type ID that has a debug name
+        let ty_with_debug_name = ConcreteTypeId {
+            debug_name: Some("u32".into()),
+            id: 10,
+        };
+
+        assert_eq!(
+            Error::make_missing_parameter(&ty_with_debug_name).to_string(),
+            "missing parameter of type 'u32'"
+        );
+
+        // Test with a type ID that does not have a debug name
+        let ty_without_debug_name = ConcreteTypeId {
+            debug_name: None,
+            id: 10,
+        };
+
+        assert_eq!(
+            Error::make_missing_parameter(&ty_without_debug_name).to_string(),
+            "missing parameter of type ''"
+        );
+    }
 }


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

- Useless `make_unexpected_value_error` function is removed.
- Unit test is provided for `make_missing_parameter` function.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
