### PR TITLE
Fix wrong upcast from unsigned to signed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2973,7 +2973,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.50",
+ "syn 2.0.61",
  "unicode-ident",
 ]
 

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -282,8 +282,6 @@ pub fn build_upcast<'ctx, 'this>(
 
     let is_signed = src_ty.is_integer_signed().ok_or_else(|| {
         Error::SierraAssert("casts always happen between numerical types".to_string())
-    })? || dst_ty.is_integer_signed().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
     })?;
 
     let is_felt = matches!(dst_ty, CoreTypeConcrete::Felt252(_));
@@ -292,7 +290,7 @@ pub fn build_upcast<'ctx, 'this>(
 
     let result = if src_width == dst_width {
         block.argument(0)?.into()
-    } else if is_signed {
+    } else if is_signed || is_felt {
         if is_felt {
             let result = block.append_op_result(arith::extsi(
                 block.argument(0)?.into(),


### PR DESCRIPTION
It used a sign extend when it should use a zero extend. The bug was that we checked whether to use sext if either src or dst type are signed when we should only care about src type


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
