### PR TITLE
Fix Ignored Flag Bug

### DIFF
--- a/src/bin/cairo-native-test.rs
+++ b/src/bin/cairo-native-test.rs
@@ -229,6 +229,7 @@ pub fn filter_test_cases(
         .filter(|(name, _)| name.contains(&filter));
 
     let named_tests = if include_ignored {
+        // enable the ignored tests
         named_tests
             .into_iter()
             .map(|(name, mut test)| {
@@ -237,6 +238,7 @@ pub fn filter_test_cases(
             })
             .collect_vec()
     } else if ignored {
+        // filter not ignored tests and enable the remaining ones
         named_tests
             .into_iter()
             .map(|(name, mut test)| {

--- a/src/bin/cairo-native-test.rs
+++ b/src/bin/cairo-native-test.rs
@@ -226,8 +226,7 @@ pub fn filter_test_cases(
     let named_tests = compiled
         .named_tests
         .into_iter()
-        .filter(|(name, _)| name.contains(&filter))
-        .collect_vec();
+        .filter(|(name, _)| name.contains(&filter));
 
     let named_tests = if include_ignored {
         named_tests
@@ -247,7 +246,7 @@ pub fn filter_test_cases(
             .filter(|(_, test)| !test.ignored)
             .collect_vec()
     } else {
-        named_tests
+        named_tests.collect_vec()
     };
 
     let filtered_out = total_tests_count - named_tests.len();


### PR DESCRIPTION
The `--ignored` flag in `cairo-native-test` was not working as expected. It filtered out not ignored tests, but left the ignored tests as "ignored" (so no tests were executed in the end).

This PR fixes the issue by not only filtering out not ignored tests, but also changing the status of the remaining tests to "not ignored".

Also, the function now is separated in different iterator chains to improve legibility