### PR TITLE
Fix return value parsing for structs containing dicts

### DIFF
--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -281,8 +281,18 @@ fn jitvalue_to_felt(value: &JitValue) -> Vec<Felt> {
         JitValue::EcPoint(_, _)
         | JitValue::EcState(_, _, _, _)
         | JitValue::Secp256K1Point { .. }
-        | JitValue::Secp256R1Point { .. }
-        | JitValue::Felt252Dict { .. } => todo!(),
+        | JitValue::Secp256R1Point { .. } => todo!(),
+        JitValue::Felt252Dict {
+            value,
+            debug_name: _,
+        } => {
+            let mut res = Vec::new();
+            for (key, val) in value {
+                res.push(*key);
+                res.extend(jitvalue_to_felt(val))
+            }
+            res
+        }
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -834,7 +834,7 @@ fn parse_result(
         CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
         CoreTypeConcrete::SquashedFelt252Dict(_) => match return_ptr {
             Some(return_ptr) => Ok(JitValue::from_jit(
-                unsafe { *return_ptr.cast::<NonNull<()>>().as_ref() },
+                return_ptr,
                 type_id,
                 registry,
             )),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -833,11 +833,7 @@ fn parse_result(
         },
         CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
         CoreTypeConcrete::SquashedFelt252Dict(_) => match return_ptr {
-            Some(return_ptr) => Ok(JitValue::from_jit(
-                return_ptr,
-                type_id,
-                registry,
-            )),
+            Some(return_ptr) => Ok(JitValue::from_jit(return_ptr, type_id, registry)),
             None => Ok(JitValue::from_jit(
                 NonNull::new(ret_registers[0] as *mut ()).unwrap(),
                 type_id,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -820,11 +820,7 @@ fn parse_result(
             }
         }
         CoreTypeConcrete::Felt252Dict(_) => match return_ptr {
-            Some(return_ptr) => Ok(JitValue::from_jit(
-                unsafe { *return_ptr.cast::<NonNull<()>>().as_ref() },
-                type_id,
-                registry,
-            )),
+            Some(return_ptr) => Ok(JitValue::from_jit(return_ptr, type_id, registry)),
             None => Ok(JitValue::from_jit(
                 NonNull::new(ret_registers[0] as *mut ()).unwrap(),
                 type_id,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -833,7 +833,11 @@ fn parse_result(
         },
         CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
         CoreTypeConcrete::SquashedFelt252Dict(_) => match return_ptr {
-            Some(return_ptr) => Ok(JitValue::from_jit(return_ptr, type_id, registry)),
+            Some(return_ptr) => Ok(JitValue::from_jit(
+                unsafe { *return_ptr.cast::<NonNull<()>>().as_ref() },
+                type_id,
+                registry,
+            )),
             None => Ok(JitValue::from_jit(
                 NonNull::new(ret_registers[0] as *mut ()).unwrap(),
                 type_id,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -833,11 +833,7 @@ fn parse_result(
         },
         CoreTypeConcrete::Felt252DictEntry(_) => todo!(),
         CoreTypeConcrete::SquashedFelt252Dict(_) => match return_ptr {
-            Some(return_ptr) => Ok(JitValue::from_jit(
-                unsafe { *return_ptr.cast::<NonNull<()>>().as_ref() },
-                type_id,
-                registry,
-            )),
+            Some(return_ptr) => Ok(JitValue::from_jit(return_ptr, type_id, registry)),
             None => Ok(JitValue::from_jit(
                 NonNull::new(ret_registers[0] as *mut ()).unwrap(),
                 type_id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -450,14 +450,14 @@ impl TypeBuilder for CoreTypeConcrete {
             | CoreTypeConcrete::Sint32(_)
             | CoreTypeConcrete::Sint64(_)
             | CoreTypeConcrete::Sint128(_)
-            | CoreTypeConcrete::Nullable(_)
-            | CoreTypeConcrete::Felt252Dict(_)
-            | CoreTypeConcrete::SquashedFelt252Dict(_) => false,
+            | CoreTypeConcrete::Nullable(_) => false,
 
             CoreTypeConcrete::Array(_) => true,
             CoreTypeConcrete::EcPoint(_) => true,
             CoreTypeConcrete::EcState(_) => true,
-            CoreTypeConcrete::Felt252DictEntry(_) => true,
+            CoreTypeConcrete::Felt252DictEntry(_)
+            | CoreTypeConcrete::Felt252Dict(_)
+            | CoreTypeConcrete::SquashedFelt252Dict(_) => true,
 
             CoreTypeConcrete::Felt252(_)
             | CoreTypeConcrete::Bytes31(_)

--- a/src/types.rs
+++ b/src/types.rs
@@ -450,14 +450,14 @@ impl TypeBuilder for CoreTypeConcrete {
             | CoreTypeConcrete::Sint32(_)
             | CoreTypeConcrete::Sint64(_)
             | CoreTypeConcrete::Sint128(_)
-            | CoreTypeConcrete::Nullable(_) => false,
+            | CoreTypeConcrete::Nullable(_)
+            | CoreTypeConcrete::Felt252Dict(_)
+            | CoreTypeConcrete::SquashedFelt252Dict(_) => false,
 
             CoreTypeConcrete::Array(_) => true,
             CoreTypeConcrete::EcPoint(_) => true,
             CoreTypeConcrete::EcState(_) => true,
-            CoreTypeConcrete::Felt252DictEntry(_)
-            | CoreTypeConcrete::Felt252Dict(_)
-            | CoreTypeConcrete::SquashedFelt252Dict(_) => true,
+            CoreTypeConcrete::Felt252DictEntry(_) => true,
 
             CoreTypeConcrete::Felt252(_)
             | CoreTypeConcrete::Bytes31(_)

--- a/src/values.rs
+++ b/src/values.rs
@@ -690,13 +690,12 @@ impl JitValue {
                             None => (member_layout, 0),
                         };
                         layout = Some(new_layout);
-                        let mut ptr =
-                            NonNull::new(((ptr.as_ptr() as usize) + offset) as *mut ()).unwrap();
-                        if member.is_complex(registry) {
-                            // Dereference pointer
-                            ptr = *ptr.cast::<NonNull<()>>().as_ref();
-                        }
-                        members.push(Self::from_jit(ptr, member_ty, registry));
+
+                        members.push(Self::from_jit(
+                            NonNull::new(((ptr.as_ptr() as usize) + offset) as *mut ()).unwrap(),
+                            member_ty,
+                            registry,
+                        ));
                     }
 
                     JitValue::Struct {
@@ -706,6 +705,8 @@ impl JitValue {
                 }
                 CoreTypeConcrete::Felt252Dict(info)
                 | CoreTypeConcrete::SquashedFelt252Dict(info) => {
+                    // Dereference ptr
+                    let ptr = *ptr.cast::<NonNull<()>>().as_ref();
                     let map = Box::from_raw(
                         ptr.cast::<HashMap<[u8; 32], NonNull<std::ffi::c_void>>>()
                             .as_ptr(),

--- a/src/values.rs
+++ b/src/values.rs
@@ -706,7 +706,7 @@ impl JitValue {
                 CoreTypeConcrete::Felt252Dict(info)
                 | CoreTypeConcrete::SquashedFelt252Dict(info) => {
                     // Dereference ptr
-                    let ptr =  *ptr.cast::<NonNull<()>>().as_ref();
+                    let ptr = *ptr.cast::<NonNull<()>>().as_ref();
                     let map = Box::from_raw(
                         ptr.cast::<HashMap<[u8; 32], NonNull<std::ffi::c_void>>>()
                             .as_ptr(),

--- a/src/values.rs
+++ b/src/values.rs
@@ -705,6 +705,8 @@ impl JitValue {
                 }
                 CoreTypeConcrete::Felt252Dict(info)
                 | CoreTypeConcrete::SquashedFelt252Dict(info) => {
+                    // Dereference ptr
+                    let ptr =  *ptr.cast::<NonNull<()>>().as_ref();
                     let map = Box::from_raw(
                         ptr.cast::<HashMap<[u8; 32], NonNull<std::ffi::c_void>>>()
                             .as_ptr(),

--- a/src/values.rs
+++ b/src/values.rs
@@ -690,12 +690,13 @@ impl JitValue {
                             None => (member_layout, 0),
                         };
                         layout = Some(new_layout);
-
-                        members.push(Self::from_jit(
-                            NonNull::new(((ptr.as_ptr() as usize) + offset) as *mut ()).unwrap(),
-                            member_ty,
-                            registry,
-                        ));
+                        let mut ptr =
+                            NonNull::new(((ptr.as_ptr() as usize) + offset) as *mut ()).unwrap();
+                        if member.is_complex(registry) {
+                            // Dereference pointer
+                            ptr = *ptr.cast::<NonNull<()>>().as_ref();
+                        }
+                        members.push(Self::from_jit(ptr, member_ty, registry));
                     }
 
                     JitValue::Struct {
@@ -705,8 +706,6 @@ impl JitValue {
                 }
                 CoreTypeConcrete::Felt252Dict(info)
                 | CoreTypeConcrete::SquashedFelt252Dict(info) => {
-                    // Dereference ptr
-                    let ptr = *ptr.cast::<NonNull<()>>().as_ref();
                     let map = Box::from_raw(
                         ptr.cast::<HashMap<[u8; 32], NonNull<std::ffi::c_void>>>()
                             .as_ptr(),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -345,6 +345,10 @@ pub fn compare_outputs(
                     CoreTypeConcrete::Snapshot(info) => {
                         map_vm_sizes(size_cache, registry, &info.ty)
                     }
+                    CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => {
+                        2
+                    }
+                    CoreTypeConcrete::Box(_) => 1,
                     x => todo!("vm size not yet implemented: {:?}", x.info()),
                 };
                 size_cache.insert(ty.clone(), type_size);
@@ -538,6 +542,21 @@ pub fn compare_outputs(
             CoreTypeConcrete::Const(_) => todo!(),
             CoreTypeConcrete::BoundedInt(_) => todo!(),
             CoreTypeConcrete::Coupon(_) => todo!(),
+            CoreTypeConcrete::Box(info) => {
+                let ty_size = map_vm_sizes(size_cache, registry, &info.ty);
+                let ptr = values[0].to_usize().unwrap();
+                map_vm_values(
+                    size_cache,
+                    registry,
+                    memory,
+                    &memory[ptr..ptr + ty_size]
+                        .iter()
+                        .cloned()
+                        .collect::<Option<Vec<_>>>()
+                        .unwrap(),
+                    &info.ty,
+                )
+            }
             x => {
                 todo!("vm value not yet implemented: {:?}", x.info())
             }

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -123,7 +123,7 @@ use test_case::test_case;
 #[test_case("tests/cases/cairo_vm/hello.cairo")]
 #[test_case("tests/cases/cairo_vm/my_rectangle.cairo")]
 #[test_case("tests/cases/cairo_vm/null_ret.cairo")]
-// #[test_case("tests/cases/cairo_vm/nullable_box_vec.cairo")]
+#[test_case("tests/cases/cairo_vm/nullable_box_vec.cairo")]
 // #[test_case("tests/cases/cairo_vm/nullable_dict.cairo")]
 #[test_case("tests/cases/cairo_vm/ops.cairo")]
 #[test_case("tests/cases/cairo_vm/pedersen_example.cairo")]

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -122,7 +122,7 @@ use test_case::test_case;
 #[test_case("tests/cases/cairo_vm/fibonacci.cairo")]
 #[test_case("tests/cases/cairo_vm/hello.cairo")]
 #[test_case("tests/cases/cairo_vm/my_rectangle.cairo")]
-// #[test_case("tests/cases/cairo_vm/null_ret.cairo")]
+#[test_case("tests/cases/cairo_vm/null_ret.cairo")]
 // #[test_case("tests/cases/cairo_vm/nullable_box_vec.cairo")]
 // #[test_case("tests/cases/cairo_vm/nullable_dict.cairo")]
 #[test_case("tests/cases/cairo_vm/ops.cairo")]


### PR DESCRIPTION
Currently, when parsing a `SqushedFelt252Dict` or `Felt252Dict`, the pointer is dereferenced before calling `from_jit_value`, but when parsing a `Struct`, `from_jit` is called on its members, meaning that the pointers wont be dereferenced for dicts, leading to segmentation faults when trying to read from this non-dereferenced pointer.
This PR refactors this code a bit to dereference the pointer inside the `from_jit` impl for dict types instead of doing it before calling the method
