### PR TITLE
Refactored function call libfuncs to use the BlockExt trait

### DIFF
--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -124,15 +124,10 @@ pub fn build<'ctx, 'this>(
             let type_info = registry.get_type(&var_info.ty)?;
 
             if type_info.is_builtin() && type_info.is_zst(registry) {
-                results.push(
-                    cont_block
-                        .append_operation(llvm::undef(
-                            type_info.build(context, helper, registry, metadata, &var_info.ty)?,
-                            location,
-                        ))
-                        .result(0)?
-                        .into(),
-                );
+                results.push(cont_block.append_op_result(llvm::undef(
+                    type_info.build(context, helper, registry, metadata, &var_info.ty)?,
+                    location,
+                ))?);
             } else {
                 let val = cont_block.argument(count)?.into();
                 count += 1;
@@ -224,17 +219,14 @@ pub fn build<'ctx, 'this>(
                         let ret_layout = type_info.layout(registry)?;
                         (layout, offset) = layout.extend(ret_layout)?;
 
-                        let pointer_val = entry
-                            .append_operation(llvm::get_element_ptr(
-                                context,
-                                val,
-                                DenseI32ArrayAttribute::new(context, &[offset as i32]),
-                                IntegerType::new(context, 8).into(),
-                                llvm::r#type::pointer(context, 0),
-                                location,
-                            ))
-                            .result(0)?
-                            .into();
+                        let pointer_val = entry.append_op_result(llvm::get_element_ptr(
+                            context,
+                            val,
+                            DenseI32ArrayAttribute::new(context, &[offset as i32]),
+                            IntegerType::new(context, 8).into(),
+                            llvm::r#type::pointer(context, 0),
+                            location,
+                        ))?;
 
                         results.push(entry.load(
                             context,


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
