### PR TITLE
Basic Stress Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cairo-*.tar
 *.a
 *.mlir
 /*.info
+.aot-cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
+ "stats_alloc",
  "tempfile",
  "test-case",
  "thiserror",
@@ -3480,6 +3481,12 @@ dependencies = [
  "num-traits 0.2.19",
  "serde",
 ]
+
+[[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ scarb-metadata = { git = "https://github.com/software-mansion/scarb.git", rev = 
 scarb-ui = { git = "https://github.com/software-mansion/scarb.git", rev = "v2.6.3", optional = true }
 sec1 = { version = "0.7.3", optional = true }
 serde_json = { version = "1.0.117", optional = true }
+stats_alloc = "0.1.10"
 
 [dev-dependencies]
 cairo-vm = { version = "1.0.0-rc3", features = ["cairo-1-hints"] }

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -109,7 +109,7 @@ fn main() {
             };
 
             assert!(
-                execution_result.failure_flag == false,
+                !execution_result.failure_flag,
                 "contract execution had failure flag set"
             );
         }
@@ -138,8 +138,7 @@ fn main() {
 /// We should modify the program returned from this to obtain
 /// different unique programs without recompiling each time
 fn generate_starknet_contract() -> (FunctionId, cairo_lang_sierra::program::Program) {
-    let program_str = format!(
-        "\
+    let program_str = "\
 #[starknet::contract]
 mod Contract {{
     #[storage]
@@ -150,8 +149,7 @@ mod Contract {{
         return 252;
     }}
 }}
-"
-    );
+";
 
     let mut program_file = tempfile::Builder::new()
         .prefix("test_")
@@ -239,13 +237,13 @@ where
             .expect("module should have gas metadata");
 
         let shared_library = {
-            let object_data = module_to_object(&native_module.module(), opt_level)
+            let object_data = module_to_object(native_module.module(), opt_level)
                 .expect("failed to convert MLIR to object");
 
             let shared_library_dir = Path::new(AOT_CACHE_DIR);
             create_dir_all(shared_library_dir).expect("failed to create shared library directory");
             let shared_library_name = format!("lib{key}{SHARED_LIBRARY_EXT}");
-            let shared_library_path = shared_library_dir.join(&shared_library_name);
+            let shared_library_path = shared_library_dir.join(shared_library_name);
 
             object_to_shared_lib(&object_data, &shared_library_path)
                 .expect("failed to link object into shared library");
@@ -276,7 +274,7 @@ fn directory_get_size(path: impl AsRef<Path>) -> io::Result<u64> {
             data => data.len(),
         };
 
-        return Ok(total_size + size);
+        Ok(total_size + size)
     })
 }
 

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -41,7 +41,7 @@ const UNIQUE_CONTRACT_VALUE: u32 = 835;
 
 /// A stress tester for Cairo Native
 ///
-/// It Sierra programs compiles with Cairo Native, caches, and executes them with AOT runner.
+/// It compiles Sierra programs with Cairo Native, caches, and executes them with AOT runner.
 /// The compiled dynamic libraries are stored in `AOT_CACHE_DIR` relative to the current working directory.
 #[derive(Parser, Debug)]
 struct StressTestCommand {

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -113,7 +113,8 @@ fn main() {
                 .invoke_contract_dynamic(&entry_point, &[], Some(u128::MAX), DummySyscallHandler)
                 .expect("failed to execute contract");
             let elapsed = now.elapsed().as_millis();
-            debug!(time = elapsed, "executed test program");
+            let result = execution_result.return_values[0];
+            debug!(time = elapsed, result = %result, "executed test program");
             execution_result
         };
 

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -70,6 +70,9 @@ fn main() {
             execution_result.return_values[0]
         );
     }
+
+    let elapsed = now.elapsed().as_millis();
+    trace!("finished stress test, took {elapsed}ms");
 }
 
 fn generate_initial_program() -> (FunctionId, cairo_lang_sierra::program::Program) {

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -190,7 +190,7 @@ mod Contract {{
     (entry_point, program)
 }
 
-/// Modifies the given contract by replacing the `anchor_value` with `new_value`
+/// Modifies the given contract by replacing the `anchor_value` with `new_value` in any type declaration
 ///
 /// The contract must only contain the value `anchor_value` once
 fn modify_starknet_contract(mut program: Program, anchor_value: u32, new_value: u32) -> Program {

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -224,7 +224,7 @@ fn modify_starknet_contract(mut program: Program, anchor_value: u32, new_value: 
 /// dynamic shared library loaded.
 ///
 /// Possible improvements include:
-/// - Keeping only some executores on memory, while storing the remaianing compiled shared libraries on disk.
+/// - Keeping only some executors on memory, while storing the remaining compiled shared libraries on disk.
 /// - When restarting the program, reutilize already compiled programs from `AOT_CACHE_DIR`
 struct NaiveAotCache<'a, K>
 where

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -31,7 +31,7 @@ fn main() {
 
         let execution_result = executor
             .invoke_contract_dynamic(&entry_point_id, &[], Some(u128::MAX), DummySyscallHandler)
-            .unwrap();
+            .expect("contract execution failed");
 
         assert!(
             execution_result.failure_flag == false,
@@ -65,14 +65,20 @@ mod {name} {{
         .prefix("test_")
         .suffix(".cairo")
         .tempfile()
-        .unwrap();
-    fs::write(&mut program_file, program_str).unwrap();
+        .expect("temporary file creation failed");
+    fs::write(&mut program_file, program_str).expect("writing to temporary file failed");
 
-    let contract_class = compile_path(program_file.path(), None, Default::default()).unwrap();
+    let contract_class = compile_path(program_file.path(), None, Default::default())
+        .expect("compiling contract failed");
 
-    let program = contract_class.extract_sierra_program().unwrap();
+    let program = contract_class
+        .extract_sierra_program()
+        .expect("extracting sierra failed");
 
-    let entry_point_id = find_entry_point_by_idx(&program, 0).unwrap().id.clone();
+    let entry_point_id = find_entry_point_by_idx(&program, 0)
+        .expect("cairo file should have an entry point")
+        .id
+        .clone();
 
     (entry_point_id, program)
 }

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -37,7 +37,7 @@ const AOT_CACHE_DIR: &str = ".aot-cache";
 /// An unique value hardcoded into the initial contract that it's
 /// used as an anchor point to safely modify it.
 /// It can be any value as long as it's unique in the contract.
-const CONTRACT_MODIFICATION_ANCHOR: u32 = 835;
+const UNIQUE_CONTRACT_VALUE: u32 = 835;
 
 /// A stress tester for Cairo Native
 ///
@@ -66,7 +66,7 @@ fn main() {
     // Generate initial program
     let (entry_point, program) = {
         let before_generate = Instant::now();
-        let initial_program = generate_starknet_contract(CONTRACT_MODIFICATION_ANCHOR);
+        let initial_program = generate_starknet_contract(UNIQUE_CONTRACT_VALUE);
         let elapsed = before_generate.elapsed().as_millis();
         debug!(time = elapsed, "generated test program");
         initial_program
@@ -86,8 +86,7 @@ fn main() {
 
         let before_round = Instant::now();
 
-        let program =
-            modify_starknet_contract(program.clone(), CONTRACT_MODIFICATION_ANCHOR, round);
+        let program = modify_starknet_contract(program.clone(), UNIQUE_CONTRACT_VALUE, round);
         // TODO: use the program hash instead of round number.
         let hash = round;
 
@@ -191,20 +190,20 @@ mod Contract {{
     (entry_point, program)
 }
 
-/// Modifies the given contract by replacing the `anchor_value` with `new_value` in any type declaration
+/// Modifies the given contract by replacing the `old_value` with `new_value` in any type declaration
 ///
-/// The contract must only contain the value `anchor_value` once
-fn modify_starknet_contract(mut program: Program, anchor_value: u32, new_value: u32) -> Program {
-    let mut anchor_counter = 0;
+/// The contract must only contain the value `old_value` once
+fn modify_starknet_contract(mut program: Program, old_value: u32, new_value: u32) -> Program {
+    let mut old_value_counter = 0;
 
     for type_declaration in &mut program.type_declarations {
         for generic_arg in &mut type_declaration.long_id.generic_args {
-            let anchor = BigInt::from(anchor_value);
+            let anchor = BigInt::from(old_value);
 
             match generic_arg {
                 GenericArg::Value(return_value) if *return_value == anchor => {
                     *return_value = BigInt::from(new_value);
-                    anchor_counter += 1;
+                    old_value_counter += 1;
                 }
                 _ => {}
             };
@@ -212,8 +211,8 @@ fn modify_starknet_contract(mut program: Program, anchor_value: u32, new_value: 
     }
 
     assert!(
-        anchor_counter == 1,
-        "CONTRACT_MODIFICATION_ANCHOR was not found exactly once"
+        old_value_counter == 1,
+        "old_value was not found exactly once"
     );
 
     program

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -33,7 +33,7 @@ fn main() {
         let _enter_span = info_span!("round");
 
         let now = Instant::now();
-        let (entry_point, program) = generate_program("Name", round);
+        let (entry_point, program) = generate_program_from_scratch("Name", round);
         let elapsed = now.elapsed().as_millis();
         trace!("generated test program, took {elapsed}ms");
 
@@ -65,7 +65,10 @@ fn main() {
     }
 }
 
-fn generate_program(name: &str, output: u32) -> (FunctionId, cairo_lang_sierra::program::Program) {
+fn generate_program_from_scratch(
+    name: &str,
+    output: u32,
+) -> (FunctionId, cairo_lang_sierra::program::Program) {
     let program_str = format!(
         "\
 #[starknet::contract]

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -140,15 +140,15 @@ fn main() {
 fn generate_starknet_contract() -> (FunctionId, cairo_lang_sierra::program::Program) {
     let program_str = "\
 #[starknet::contract]
-mod Contract {{
+mod Contract {
     #[storage]
-    struct Storage {{}}
+    struct Storage {}
 
     #[external(v0)]
-    fn main(self: @ContractState) -> felt252 {{
+    fn main(self: @ContractState) -> felt252 {
         return 252;
-    }}
-}}
+    }
+}
 ";
 
     let mut program_file = tempfile::Builder::new()

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -1,0 +1,85 @@
+use std::fs;
+
+use cairo_lang_sierra::program_registry::ProgramRegistry;
+use cairo_lang_starknet::compile::compile_path;
+use cairo_native::{
+    context::NativeContext,
+    executor::AotNativeExecutor,
+    metadata::gas::GasMetadata,
+    module_to_object, object_to_shared_lib,
+    starknet::DummySyscallHandler,
+    utils::{find_entry_point_by_idx, SHARED_LIBRARY_EXT},
+};
+use libloading::Library;
+
+fn main() {
+    let program = generate_program("Name", 252);
+
+    let native_context = NativeContext::new();
+    let native_module = native_context
+        .compile(&program, None)
+        .expect("should compile");
+
+    let object_data =
+        module_to_object(native_module.module(), cairo_native::OptLevel::None).unwrap();
+    let shared_library_path = tempfile::Builder::new()
+        .prefix("lib")
+        .suffix(SHARED_LIBRARY_EXT)
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+    object_to_shared_lib(&object_data, &shared_library_path).unwrap();
+    let shared_library = unsafe { Library::new(shared_library_path).unwrap() };
+
+    let registry = ProgramRegistry::new(&program).unwrap();
+
+    let executor = AotNativeExecutor::new(
+        shared_library,
+        registry,
+        native_module
+            .metadata()
+            .get::<GasMetadata>()
+            .cloned()
+            .unwrap(),
+    );
+
+    let entry_point_id = &find_entry_point_by_idx(&program, 0).unwrap().id;
+    let execution_result = executor
+        .invoke_contract_dynamic(entry_point_id, &[], Some(u128::MAX), DummySyscallHandler)
+        .unwrap();
+
+    assert!(
+        execution_result.failure_flag == false,
+        "contract execution failed"
+    )
+}
+
+fn generate_program(name: &str, output: u32) -> cairo_lang_sierra::program::Program {
+    let program_str = format!(
+        "\
+#[starknet::contract]
+mod {name} {{
+    #[storage]
+    struct Storage {{}}
+
+    #[external(v0)]
+    fn main(self: @ContractState) -> felt252 {{
+        return {output};
+    }}
+}}
+"
+    );
+
+    let mut program_file = tempfile::Builder::new()
+        .prefix("test_")
+        .suffix(".cairo")
+        .tempfile()
+        .unwrap();
+    fs::write(&mut program_file, program_str).unwrap();
+
+    let contract_class = compile_path(program_file.path(), None, Default::default()).unwrap();
+
+    let program = contract_class.extract_sierra_program().unwrap();
+
+    program
+}

--- a/src/bin/cairo-native-stress.rs
+++ b/src/bin/cairo-native-stress.rs
@@ -29,16 +29,16 @@ fn main() {
     let native_context = NativeContext::new();
     let mut cache = AotProgramCache::new(&native_context);
 
+    let now = Instant::now();
+    let (entry_point, program) = generate_initial_program();
+    let elapsed = now.elapsed().as_millis();
+    trace!("generated test program, took {elapsed}ms");
+
     for round in 0..cli_args.iterations {
         let _enter_span = info_span!("round");
 
-        let now = Instant::now();
-        let (entry_point, program) = generate_program_from_scratch("Name", round);
-        let elapsed = now.elapsed().as_millis();
-        trace!("generated test program, took {elapsed}ms");
-
         if cache.get(&round).is_some() {
-            panic!("all contracts should be different")
+            panic!("all keys should be different")
         }
 
         let now = Instant::now();
@@ -65,20 +65,17 @@ fn main() {
     }
 }
 
-fn generate_program_from_scratch(
-    name: &str,
-    output: u32,
-) -> (FunctionId, cairo_lang_sierra::program::Program) {
+fn generate_initial_program() -> (FunctionId, cairo_lang_sierra::program::Program) {
     let program_str = format!(
         "\
 #[starknet::contract]
-mod {name} {{
+mod Contract {{
     #[storage]
     struct Storage {{}}
 
     #[external(v0)]
     fn main(self: @ContractState) -> felt252 {{
-        return {output};
+        return 252;
     }}
 }}
 "

--- a/src/libfuncs/uint64.rs
+++ b/src/libfuncs/uint64.rs
@@ -2,10 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    block_ext::BlockExt,
-    error::{Error, Result},
-    metadata::MetadataStorage,
-    utils::ProgramRegistryExt,
+    block_ext::BlockExt, error::Result, metadata::MetadataStorage, utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -25,10 +22,8 @@ use melior::{
         cf, llvm, ods, scf,
     },
     ir::{
-        attribute::{DenseI64ArrayAttribute, IntegerAttribute},
-        operation::OperationBuilder,
-        r#type::IntegerType,
-        Attribute, Block, Location, Region, Value, ValueLike,
+        attribute::IntegerAttribute, operation::OperationBuilder, r#type::IntegerType, Block,
+        Location, Region, Value, ValueLike,
     },
     Context,
 };
@@ -129,31 +124,22 @@ pub fn build_operation<'ctx, 'this>(
         false,
     );
 
-    let op = entry.append_operation(
+    let result = entry.append_op_result(
         OperationBuilder::new(op_name, location)
             .add_operands(&[lhs, rhs])
             .add_results(&[result_type])
             .build()?,
-    );
-    let result = op.result(0)?.into();
+    )?;
 
-    let op = entry.append_operation(llvm::extract_value(
+    let op_result = entry.extract_value(context, location, result, values_type, 0)?;
+
+    let op_overflow = entry.extract_value(
         context,
-        result,
-        DenseI64ArrayAttribute::new(context, &[0]),
-        values_type,
         location,
-    ));
-    let op_result = op.result(0)?.into();
-
-    let op = entry.append_operation(llvm::extract_value(
-        context,
         result,
-        DenseI64ArrayAttribute::new(context, &[1]),
         IntegerType::new(context, 1).into(),
-        location,
-    ));
-    let op_overflow = op.result(0)?.into();
+        1,
+    )?;
 
     entry.append_operation(helper.cond_br(
         context,
@@ -207,21 +193,15 @@ pub fn build_is_zero<'ctx, 'this>(
 ) -> Result<()> {
     let arg0: Value = entry.argument(0)?.into();
 
-    let op = entry.append_operation(arith::constant(
-        context,
-        IntegerAttribute::new(arg0.r#type(), 0).into(),
-        location,
-    ));
-    let const_0 = op.result(0)?.into();
+    let const_0 = entry.const_int_from_type(context, location, 0, arg0.r#type())?;
 
-    let op = entry.append_operation(arith::cmpi(
+    let condition = entry.append_op_result(arith::cmpi(
         context,
         CmpiPredicate::Eq,
         arg0,
         const_0,
         location,
-    ));
-    let condition = op.result(0)?.into();
+    ))?;
 
     entry.append_operation(helper.cond_br(context, condition, [0, 1], [&[], &[arg0]], location));
 
@@ -243,11 +223,8 @@ pub fn build_divmod<'ctx, 'this>(
     let lhs: Value = entry.argument(1)?.into();
     let rhs: Value = entry.argument(2)?.into();
 
-    let op = entry.append_operation(arith::divui(lhs, rhs, location));
-
-    let result_div = op.result(0)?.into();
-    let op = entry.append_operation(arith::remui(lhs, rhs, location));
-    let result_rem = op.result(0)?.into();
+    let result_div = entry.append_op_result(arith::divui(lhs, rhs, location))?;
+    let result_rem = entry.append_op_result(arith::remui(lhs, rhs, location))?;
 
     entry.append_operation(helper.br(0, &[range_check, result_div, result_rem], location));
     Ok(())
@@ -273,14 +250,9 @@ pub fn build_widemul<'ctx, 'this>(
     let lhs: Value = entry.argument(0)?.into();
     let rhs: Value = entry.argument(1)?.into();
 
-    let op = entry.append_operation(arith::extui(lhs, target_type, location));
-    let lhs = op.result(0)?.into();
-
-    let op = entry.append_operation(arith::extui(rhs, target_type, location));
-    let rhs = op.result(0)?.into();
-
-    let op = entry.append_operation(arith::muli(lhs, rhs, location));
-    let result = op.result(0)?.into();
+    let lhs = entry.append_op_result(arith::extui(lhs, target_type, location))?;
+    let rhs = entry.append_op_result(arith::extui(rhs, target_type, location))?;
+    let result = entry.append_op_result(arith::muli(lhs, rhs, location))?;
 
     entry.append_operation(helper.br(0, &[result], location));
     Ok(())
@@ -305,9 +277,7 @@ pub fn build_to_felt252<'ctx, 'this>(
     )?;
     let value: Value = entry.argument(0)?.into();
 
-    let op = entry.append_operation(arith::extui(value, felt252_ty, location));
-
-    let result = op.result(0)?.into();
+    let result = entry.append_op_result(arith::extui(value, felt252_ty, location))?;
 
     entry.append_operation(helper.br(0, &[result], location));
 
@@ -330,246 +300,155 @@ pub fn build_square_root<'ctx, 'this>(
     let i32_ty = IntegerType::new(context, 32).into();
     let i64_ty = IntegerType::new(context, 64).into();
 
-    let k1 = entry
-        .append_operation(arith::constant(
-            context,
-            IntegerAttribute::new(i64_ty, 1).into(),
-            location,
-        ))
-        .result(0)?
-        .into();
+    let k1 = entry.const_int_from_type(context, location, 1, i64_ty)?;
 
-    let is_small = entry
-        .append_operation(arith::cmpi(
-            context,
-            CmpiPredicate::Ule,
-            entry.argument(1)?.into(),
-            k1,
-            location,
-        ))
-        .result(0)?
-        .into();
+    let is_small = entry.append_op_result(arith::cmpi(
+        context,
+        CmpiPredicate::Ule,
+        entry.argument(1)?.into(),
+        k1,
+        location,
+    ))?;
 
-    let result = entry
-        .append_operation(scf::r#if(
-            is_small,
-            &[i64_ty],
-            {
-                let region = Region::new();
-                let block = region.append_block(Block::new(&[]));
+    let result = entry.append_op_result(scf::r#if(
+        is_small,
+        &[i64_ty],
+        {
+            let region = Region::new();
+            let block = region.append_block(Block::new(&[]));
 
-                block.append_operation(scf::r#yield(&[entry.argument(1)?.into()], location));
+            block.append_operation(scf::r#yield(&[entry.argument(1)?.into()], location));
 
-                region
-            },
-            {
-                let region = Region::new();
-                let block = region.append_block(Block::new(&[]));
+            region
+        },
+        {
+            let region = Region::new();
+            let block = region.append_block(Block::new(&[]));
 
-                let k64 = entry
-                    .append_operation(arith::constant(
+            let k64 = entry.const_int_from_type(context, location, 64, i64_ty)?;
+
+            let leading_zeros = block.append_op_result(
+                ods::llvm::intr_ctlz(
+                    context,
+                    i64_ty,
+                    entry.argument(1)?.into(),
+                    IntegerAttribute::new(IntegerType::new(context, 1).into(), 1),
+                    location,
+                )
+                .into(),
+            )?;
+
+            let num_bits = block.append_op_result(arith::subi(k64, leading_zeros, location))?;
+
+            let shift_amount = block.append_op_result(arith::addi(num_bits, k1, location))?;
+
+            let parity_mask = block.const_int_from_type(context, location, -2, i64_ty)?;
+            let shift_amount =
+                block.append_op_result(arith::andi(shift_amount, parity_mask, location))?;
+
+            let k0 = block.const_int_from_type(context, location, 0, i64_ty)?;
+            let result = block.append_op_result(scf::r#while(
+                &[k0, shift_amount],
+                &[i64_ty, i64_ty],
+                {
+                    let region = Region::new();
+                    let block =
+                        region.append_block(Block::new(&[(i64_ty, location), (i64_ty, location)]));
+
+                    let result = block.append_op_result(arith::shli(
+                        block.argument(0)?.into(),
+                        k1,
+                        location,
+                    ))?;
+                    let large_candidate =
+                        block.append_op_result(arith::xori(result, k1, location))?;
+
+                    let large_candidate_squared = block.append_op_result(arith::muli(
+                        large_candidate,
+                        large_candidate,
+                        location,
+                    ))?;
+
+                    let threshold = block.append_op_result(arith::shrui(
+                        entry.argument(1)?.into(),
+                        block.argument(1)?.into(),
+                        location,
+                    ))?;
+                    let threshold_is_poison = block.append_op_result(arith::cmpi(
                         context,
-                        IntegerAttribute::new(i64_ty, 64).into(),
+                        CmpiPredicate::Eq,
+                        block.argument(1)?.into(),
+                        k64,
                         location,
-                    ))
-                    .result(0)?
-                    .into();
+                    ))?;
+                    let threshold = block.append_op_result(
+                        OperationBuilder::new("arith.select", location)
+                            .add_operands(&[threshold_is_poison, k0, threshold])
+                            .add_results(&[i64_ty])
+                            .build()?,
+                    )?;
 
-                let leading_zeros = block
-                    .append_operation(
-                        ods::llvm::intr_ctlz(
-                            context,
-                            i64_ty,
-                            entry.argument(1)?.into(),
-                            IntegerAttribute::new(IntegerType::new(context, 1).into(), 1),
-                            location,
-                        )
-                        .into(),
-                    )
-                    .result(0)?
-                    .into();
-
-                let num_bits = block
-                    .append_operation(arith::subi(k64, leading_zeros, location))
-                    .result(0)?
-                    .into();
-
-                let shift_amount = block
-                    .append_operation(arith::addi(num_bits, k1, location))
-                    .result(0)?
-                    .into();
-
-                let parity_mask = block
-                    .append_operation(arith::constant(
+                    let is_in_range = block.append_op_result(arith::cmpi(
                         context,
-                        IntegerAttribute::new(i64_ty, -2).into(),
+                        CmpiPredicate::Ule,
+                        large_candidate_squared,
+                        threshold,
                         location,
-                    ))
-                    .result(0)?
-                    .into();
-                let shift_amount = block
-                    .append_operation(arith::andi(shift_amount, parity_mask, location))
-                    .result(0)?
-                    .into();
+                    ))?;
 
-                let k0 = block
-                    .append_operation(arith::constant(
+                    let result = block.append_op_result(
+                        OperationBuilder::new("arith.select", location)
+                            .add_operands(&[is_in_range, large_candidate, result])
+                            .add_results(&[i64_ty])
+                            .build()?,
+                    )?;
+
+                    let k2 = block.const_int_from_type(context, location, 2, i64_ty)?;
+
+                    let shift_amount = block.append_op_result(arith::subi(
+                        block.argument(1)?.into(),
+                        k2,
+                        location,
+                    ))?;
+
+                    let should_continue = block.append_op_result(arith::cmpi(
                         context,
-                        IntegerAttribute::new(i64_ty, 0).into(),
+                        CmpiPredicate::Sge,
+                        shift_amount,
+                        k0,
                         location,
-                    ))
-                    .result(0)?
-                    .into();
-                let result = block
-                    .append_operation(scf::r#while(
-                        &[k0, shift_amount],
-                        &[i64_ty, i64_ty],
-                        {
-                            let region = Region::new();
-                            let block = region.append_block(Block::new(&[
-                                (i64_ty, location),
-                                (i64_ty, location),
-                            ]));
-
-                            let result = block
-                                .append_operation(arith::shli(
-                                    block.argument(0)?.into(),
-                                    k1,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-                            let large_candidate = block
-                                .append_operation(arith::xori(result, k1, location))
-                                .result(0)?
-                                .into();
-
-                            let large_candidate_squared = block
-                                .append_operation(arith::muli(
-                                    large_candidate,
-                                    large_candidate,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-
-                            let threshold = block
-                                .append_operation(arith::shrui(
-                                    entry.argument(1)?.into(),
-                                    block.argument(1)?.into(),
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-                            let threshold_is_poison = block
-                                .append_operation(arith::cmpi(
-                                    context,
-                                    CmpiPredicate::Eq,
-                                    block.argument(1)?.into(),
-                                    k64,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-                            let threshold = block
-                                .append_operation(
-                                    OperationBuilder::new("arith.select", location)
-                                        .add_operands(&[threshold_is_poison, k0, threshold])
-                                        .add_results(&[i64_ty])
-                                        .build()?,
-                                )
-                                .result(0)?
-                                .into();
-
-                            let is_in_range = block
-                                .append_operation(arith::cmpi(
-                                    context,
-                                    CmpiPredicate::Ule,
-                                    large_candidate_squared,
-                                    threshold,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-
-                            let result = block
-                                .append_operation(
-                                    OperationBuilder::new("arith.select", location)
-                                        .add_operands(&[is_in_range, large_candidate, result])
-                                        .add_results(&[i64_ty])
-                                        .build()?,
-                                )
-                                .result(0)?
-                                .into();
-
-                            let k2 = block
-                                .append_operation(arith::constant(
-                                    context,
-                                    IntegerAttribute::new(i64_ty, 2).into(),
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-
-                            let shift_amount = block
-                                .append_operation(arith::subi(
-                                    block.argument(1)?.into(),
-                                    k2,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-
-                            let should_continue = block
-                                .append_operation(arith::cmpi(
-                                    context,
-                                    CmpiPredicate::Sge,
-                                    shift_amount,
-                                    k0,
-                                    location,
-                                ))
-                                .result(0)?
-                                .into();
-                            block.append_operation(scf::condition(
-                                should_continue,
-                                &[result, shift_amount],
-                                location,
-                            ));
-
-                            region
-                        },
-                        {
-                            let region = Region::new();
-                            let block = region.append_block(Block::new(&[
-                                (i64_ty, location),
-                                (i64_ty, location),
-                            ]));
-
-                            block.append_operation(scf::r#yield(
-                                &[block.argument(0)?.into(), block.argument(1)?.into()],
-                                location,
-                            ));
-
-                            region
-                        },
+                    ))?;
+                    block.append_operation(scf::condition(
+                        should_continue,
+                        &[result, shift_amount],
                         location,
-                    ))
-                    .result(0)?
-                    .into();
+                    ));
 
-                block.append_operation(scf::r#yield(&[result], location));
+                    region
+                },
+                {
+                    let region = Region::new();
+                    let block =
+                        region.append_block(Block::new(&[(i64_ty, location), (i64_ty, location)]));
 
-                region
-            },
-            location,
-        ))
-        .result(0)?
-        .into();
+                    block.append_operation(scf::r#yield(
+                        &[block.argument(0)?.into(), block.argument(1)?.into()],
+                        location,
+                    ));
 
-    let result = entry
-        .append_operation(arith::trunci(result, i32_ty, location))
-        .result(0)?
-        .into();
+                    region
+                },
+                location,
+            ))?;
+
+            block.append_operation(scf::r#yield(&[result], location));
+
+            region
+        },
+        location,
+    ))?;
+
+    let result = entry.append_op_result(arith::trunci(result, i32_ty, location))?;
 
     entry.append_operation(helper.br(0, &[range_check, result], location));
     Ok(())
@@ -605,22 +484,15 @@ pub fn build_from_felt252<'ctx, 'this>(
         &info.branch_signatures()[0].vars[1].ty,
     )?;
 
-    let op = entry.append_operation(arith::constant(
-        context,
-        Attribute::parse(context, &format!("{} : {}", u64::MAX, felt252_ty))
-            .ok_or(Error::ParseAttributeError)?,
-        location,
-    ));
-    let const_max = op.result(0)?.into();
+    let const_max = entry.const_int_from_type(context, location, u64::MAX, felt252_ty)?;
 
-    let op = entry.append_operation(arith::cmpi(
+    let is_ule = entry.append_op_result(arith::cmpi(
         context,
         CmpiPredicate::Ule,
         value,
         const_max,
         location,
-    ));
-    let is_ule = op.result(0)?.into();
+    ))?;
 
     let block_success = helper.append_block(Block::new(&[]));
     let block_failure = helper.append_block(Block::new(&[]));
@@ -635,8 +507,7 @@ pub fn build_from_felt252<'ctx, 'this>(
         location,
     ));
 
-    let op = block_success.append_operation(arith::trunci(value, result_ty, location));
-    let value = op.result(0)?.into();
+    let value = block_success.append_op_result(arith::trunci(value, result_ty, location))?;
 
     block_success.append_operation(helper.br(0, &[range_check, value], location));
     block_failure.append_operation(helper.br(1, &[range_check], location));


### PR DESCRIPTION
related to #682

Adds `cairo-native-stress` that generates, compiles, caches, and runs contracts in order to stress test cairo native.
- Receives by argument the amount rounds to execute.
- In each round it generates, compiles, caches, and runs a new contract
- The compiled dynamic shared libraries are stored on disk
- The cache keeps in memory every executor for every compiled contract
- After each round, it prints a report

## Program Generation

At the start of the program, a dummy program is generated with a hardcoded value (835 in this case) in the return value:
```cairo
#[starknet::contract]
mod Contract {
    #[storage]
    struct Storage {}

    #[external(v0)]
    fn main(self: @ContractState) -> felt252 {
        return 835;
    }
}
```

At the start of each round, the program is traversed to find the hardcoded value and is replaced with a new one. This allows to generate a new valid program with a different return value each round

## Examples

With info logging (20 rounds):
<img width="1393" alt="image" src="https://github.com/lambdaclass/cairo_native/assets/60768809/e8eef67d-906e-49f4-bfed-f844e4d12732">
With debug logging (5 rounds):
<img width="1377" alt="image" src="https://github.com/lambdaclass/cairo_native/assets/60768809/7141790f-36b6-4c74-86eb-48f8f3603179">

## Next Steps

- Export the logs to a JSON or a CSV and plot it
- Try different implementations of the Cache

## Checklist
- [x] Linked to Github Issue
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.