### PR TITLE
Fix `dup` implementation for `Box<T>` and other non-copy types.

### DIFF
--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -175,7 +175,7 @@ fn test_program_cases(program_path: &str) {
 #[test_case("tests/cases/cairo_vm/contracts/widemul128.cairo", &[100, 100])]
 #[test_case("tests/cases/cairo_vm/contracts/field_sqrt.cairo", &[])]
 #[test_case("tests/cases/cairo_vm/contracts/random_ec_point.cairo", &[])]
-// #[test_case("tests/cases/cairo_vm/contracts/alloc_constant_size.cairo", &[10, 10, 10])]
+#[test_case("tests/cases/cairo_vm/contracts/alloc_constant_size.cairo", &[10, 10, 10])]
 fn test_contract_cases(program_path: &str, args: &[u128]) {
     let args = args.iter().map(|&arg| arg.into()).collect_vec();
 


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
