### PR TITLE
improve gas error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,9 +22,6 @@ pub enum Error {
     #[error("unexpected value, expected value of type '{0}'")]
     UnexpectedValue(String),
 
-    #[error("not enough gas to run")]
-    InsufficientGasError,
-
     #[error("a syscall handler was expected but was not provided")]
     MissingSyscallHandler,
 
@@ -52,7 +49,7 @@ pub enum Error {
     #[error(transparent)]
     EditStateError(#[from] EditStateError),
 
-    #[error("gas metadata error")]
+    #[error(transparent)]
     GasMetadataError(#[from] GasMetadataError),
 
     #[error("llvm error")]

--- a/src/executor/aot.rs
+++ b/src/executor/aot.rs
@@ -73,7 +73,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -95,7 +95,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -117,7 +117,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
 
         ContractExecutionResult::from_execution_result(super::invoke_dynamic(
             &self.registry,

--- a/src/executor/aot.rs
+++ b/src/executor/aot.rs
@@ -73,7 +73,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -95,7 +95,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -117,7 +117,7 @@ impl AotNativeExecutor {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
 
         ContractExecutionResult::from_execution_result(super::invoke_dynamic(
             &self.registry,

--- a/src/executor/jit.rs
+++ b/src/executor/jit.rs
@@ -73,7 +73,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -98,7 +98,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -120,7 +120,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
+            .map_err(crate::error::Error::GasMetadataError)?;
         // TODO: Check signature for contract interface.
         ContractExecutionResult::from_execution_result(super::invoke_dynamic(
             &self.registry,

--- a/src/executor/jit.rs
+++ b/src/executor/jit.rs
@@ -73,7 +73,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -98,7 +98,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
 
         super::invoke_dynamic(
             &self.registry,
@@ -120,7 +120,7 @@ impl<'m> JitNativeExecutor<'m> {
         let available_gas = self
             .gas_metadata
             .get_initial_available_gas(function_id, gas)
-            .map_err(|_| crate::error::Error::InsufficientGasError)?;
+            .map_err(|e| crate::error::Error::GasMetadataError(e))?;
         // TODO: Check signature for contract interface.
         ContractExecutionResult::from_execution_result(super::invoke_dynamic(
             &self.registry,

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -39,8 +39,11 @@ pub enum GasMetadataError {
     ApChangeError(#[from] ApChangeError),
     #[error(transparent)]
     CostError(#[from] CostError),
-    #[error("not enough gas to run")]
-    NotEnoughGas,
+    #[error("Not enough gas to run the operation. Required: {required_gas}, Available: {available_gas}.")]
+    NotEnoughGas {
+        required_gas: u128,
+        available_gas: u128,
+    },
 }
 
 impl Default for MetadataComputationConfig {
@@ -85,7 +88,10 @@ impl GasMetadata {
 
         available_gas
             .checked_sub(required_gas)
-            .ok_or(GasMetadataError::NotEnoughGas)
+            .ok_or(GasMetadataError::NotEnoughGas {
+                required_gas,
+                available_gas,
+            })
     }
 
     pub fn initial_required_gas(&self, func: &FunctionId) -> Option<u128> {

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -39,11 +39,8 @@ pub enum GasMetadataError {
     ApChangeError(#[from] ApChangeError),
     #[error(transparent)]
     CostError(#[from] CostError),
-    #[error("Not enough gas to run the operation. Required: {required_gas}, Available: {available_gas}.")]
-    NotEnoughGas {
-        required_gas: Box<u128>,
-        available_gas: Box<u128>,
-    },
+    #[error("Not enough gas to run the operation. Required: {:?}, Available: {:?}.", gas.0, gas.1)]
+    NotEnoughGas { gas: Box<(u128, u128)> },
 }
 
 impl Default for MetadataComputationConfig {
@@ -89,8 +86,7 @@ impl GasMetadata {
         available_gas
             .checked_sub(required_gas)
             .ok_or(GasMetadataError::NotEnoughGas {
-                required_gas: Box::new(required_gas),
-                available_gas: Box::new(available_gas),
+                gas: Box::new((required_gas, available_gas)),
             })
     }
 

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -41,8 +41,8 @@ pub enum GasMetadataError {
     CostError(#[from] CostError),
     #[error("Not enough gas to run the operation. Required: {required_gas}, Available: {available_gas}.")]
     NotEnoughGas {
-        required_gas: u128,
-        available_gas: u128,
+        required_gas: Box<u128>,
+        available_gas: Box<u128>,
     },
 }
 
@@ -89,8 +89,8 @@ impl GasMetadata {
         available_gas
             .checked_sub(required_gas)
             .ok_or(GasMetadataError::NotEnoughGas {
-                required_gas,
-                available_gas,
+                required_gas: Box::new(required_gas),
+                available_gas: Box::new(available_gas),
             })
     }
 


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

The `InsufficientGasError` inside the `Error` enum actually internally represents a `GasMetadataError` `NotEnoughGas` error.

It is therefore more practical and idiomatic to group these errors around `GasMetadataError` with a more explicit message on the `NotEnoughGas` error specifying the gases required and the gases available to give more information to the user.

Part of https://github.com/lambdaclass/cairo_native/issues/632


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
