### PR TITLE
add `SierraAssertError` enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,10 +78,8 @@ impl Error {
 pub enum SierraAssertError {
     #[error("casts always happen between numerical types")]
     Cast,
-    #[error("range should always intersect, from {ranges.0:?} to {ranges.1:?}")]
-    Range {
-        ranges: Box<(Range, Range)>,
-    },
+    #[error("range should always intersect, from {:?} to {:?}", ranges.0, ranges.1)]
+    Range { ranges: Box<(Range, Range)> },
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,10 +78,9 @@ impl Error {
 pub enum SierraAssertError {
     #[error("casts always happen between numerical types")]
     Cast,
-    #[error("range should always intersect, from {from_range:?} to {to_range:?}")]
+    #[error("range should always intersect, from {ranges.0:?} to {ranges.1:?}")]
     Range {
-        from_range: Box<Range>,
-        to_range: Box<Range>,
+        ranges: Box<(Range, Range)>,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Various error types used thorough the crate.
 use crate::metadata::gas::GasMetadataError;
+use cairo_lang_sierra::extensions::modules::utils::Range;
 use cairo_lang_sierra::{
     edit_state::EditStateError, ids::ConcreteTypeId, program_registry::ProgramRegistryError,
 };
@@ -43,8 +44,8 @@ pub enum Error {
     #[error("missing metadata")]
     MissingMetadata,
 
-    #[error("a cairo-native sierra related assert failed: {0}")]
-    SierraAssert(String),
+    #[error(transparent)]
+    SierraAssert(SierraAssertError),
 
     #[error("a compiler related error happened: {0}")]
     Error(String),
@@ -71,6 +72,17 @@ impl Error {
                 .unwrap_or_default(),
         )
     }
+}
+
+#[derive(Error, Debug)]
+pub enum SierraAssertError {
+    #[error("casts always happen between numerical types")]
+    Cast,
+    #[error("range should always intersect, from {from_range:?} to {to_range:?}")]
+    Range {
+        from_range: Box<Range>,
+        to_range: Box<Range>,
+    },
 }
 
 #[cfg(test)]

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -5,7 +5,7 @@ use std::ops::Shr;
 use super::LibfuncHelper;
 use crate::{
     block_ext::BlockExt,
-    error::{Error, Result},
+    error::{Error, Result, SierraAssertError},
     metadata::{prime_modulo::PrimeModuloMeta, MetadataStorage},
     types::TypeBuilder,
 };
@@ -65,12 +65,12 @@ pub fn build_downcast<'ctx, 'this>(
 
     let src_type = registry.get_type(&info.from_ty)?;
     let dst_type = registry.get_type(&info.to_ty)?;
-    let src_width = src_type.integer_width().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
-    let dst_width = dst_type.integer_width().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
+    let src_width = src_type
+        .integer_width()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
+    let dst_width = dst_type
+        .integer_width()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
 
     let src_ty = src_type.build(context, helper, registry, metadata, &info.from_ty)?;
     let dst_ty = dst_type.build(context, helper, registry, metadata, &info.to_ty)?;
@@ -81,12 +81,12 @@ pub fn build_downcast<'ctx, 'this>(
         location,
     );
 
-    let src_is_signed = src_type.is_integer_signed().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
-    let dst_is_signed = dst_type.is_integer_signed().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
+    let src_is_signed = src_type
+        .is_integer_signed()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
+    let dst_is_signed = dst_type
+        .is_integer_signed()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
     let any_is_signed = src_is_signed | dst_is_signed;
     let src_is_felt = matches!(
         src_type,
@@ -188,18 +188,19 @@ pub fn build_downcast<'ctx, 'this>(
             (result, dst_ty)
         };
 
-        let mut int_max_value: BigInt = info
+        let info_range = info
             .to_range
             .intersection(&info.from_range)
-            .ok_or_else(|| Error::SierraAssert("range should always interesct".to_string()))?
-            .upper
-            - 1;
+            .ok_or_else(|| {
+                Error::SierraAssert(SierraAssertError::Range {
+                    from_range: info.from_range.clone().into(),
+                    to_range: info.to_range.clone().into(),
+                })
+            })?;
 
-        let mut int_min_value = info
-            .to_range
-            .intersection(&info.from_range)
-            .ok_or_else(|| Error::SierraAssert("range should always interesct".to_string()))?
-            .lower;
+        let mut int_max_value: BigInt = info_range.upper - 1;
+
+        let mut int_min_value = info_range.lower;
 
         if dst_is_felt {
             let prime = &metadata
@@ -290,17 +291,17 @@ pub fn build_upcast<'ctx, 'this>(
         location,
     );
 
-    let src_width = src_ty.integer_width().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
-    let dst_width = dst_ty.integer_width().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
+    let src_width = src_ty
+        .integer_width()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
+    let dst_width = dst_ty
+        .integer_width()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
     assert!(src_width <= dst_width);
 
-    let is_signed = src_ty.is_integer_signed().ok_or_else(|| {
-        Error::SierraAssert("casts always happen between numerical types".to_string())
-    })?;
+    let is_signed = src_ty
+        .is_integer_signed()
+        .ok_or_else(|| Error::SierraAssert(SierraAssertError::Cast))?;
 
     let is_felt = matches!(dst_ty, CoreTypeConcrete::Felt252(_));
 

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -193,8 +193,7 @@ pub fn build_downcast<'ctx, 'this>(
             .intersection(&info.from_range)
             .ok_or_else(|| {
                 Error::SierraAssert(SierraAssertError::Range {
-                    from_range: info.from_range.clone().into(),
-                    to_range: info.to_range.clone().into(),
+                    ranges: Box::new((info.from_range.clone(), info.to_range.clone())),
                 })
             })?;
 


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

`SierraAssert` errors are grouped into a `SierraAssertError` enum in order to avoid string errors and have clearer patterns.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
