### PR TITLE
Fix alloca, load and store operations on `BlockExt`.

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -326,13 +326,7 @@ pub fn build_append<'ctx, 'this>(
             location,
         ))?;
 
-        append_block.store(
-            context,
-            location,
-            ptr,
-            entry.argument(1)?.into(),
-            Some(elem_layout.align()),
-        )?;
+        append_block.store(context, location, ptr, entry.argument(1)?.into())?;
 
         let array_len = append_block.append_op_result(arith::addi(array_end, k1, location))?;
         let value = append_block.insert_value(
@@ -877,13 +871,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
 
     let container: Value = {
         // load box
-        entry.load(
-            context,
-            location,
-            entry.argument(0)?.into(),
-            struct_ty,
-            Some(struct_type_info.layout(registry)?.align()),
-        )?
+        entry.load(context, location, entry.argument(0)?.into(), struct_ty)?
     };
 
     let fields = struct_type_info.fields().expect("should have fields");
@@ -937,7 +925,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
             location,
         ))?;
 
-        entry.store(context, location, target_ptr, value, None)?;
+        entry.store(context, location, target_ptr, value)?;
     }
 
     let array_container = entry.insert_value(context, location, array_container, ptr, 0)?;

--- a/src/libfuncs/const.rs
+++ b/src/libfuncs/const.rs
@@ -91,7 +91,7 @@ pub fn build_const_as_box<'ctx, 'this>(
     ))?;
 
     // Store constant in box
-    entry.store(context, location, ptr, value, Some(inner_layout.align()))?;
+    entry.store(context, location, ptr, value)?;
 
     entry.append_operation(helper.br(0, &[ptr], location));
     Ok(())

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -193,13 +193,13 @@ pub fn build_point_from_x<'ctx, 'this>(
         context,
         location,
         ec_point_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
 
     let point = entry.append_op_result(llvm::undef(ec_point_ty, location))?;
     let point = entry.insert_value(context, location, point, entry.argument(1)?.into(), 0)?;
 
-    entry.store(context, location, point_ptr, point, None)?;
+    entry.store(context, location, point_ptr, point)?;
     let result = metadata
         .get_mut::<RuntimeBindingsMeta>()
         .ok_or(Error::MissingMetadata)?
@@ -207,7 +207,7 @@ pub fn build_point_from_x<'ctx, 'this>(
         .result(0)?
         .into();
 
-    let point = entry.load(context, location, point_ptr, ec_point_ty, None)?;
+    let point = entry.load(context, location, point_ptr, ec_point_ty)?;
 
     entry.append_operation(helper.cond_br(
         context,
@@ -244,37 +244,24 @@ pub fn build_state_add<'ctx, 'this>(
         context,
         location,
         ec_state_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
     let point_ptr = helper.init_block().alloca1(
         context,
         location,
         ec_state_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
 
-    entry.store(
-        context,
-        location,
-        state_ptr,
-        entry.argument(0)?.into(),
-        None,
-    )?;
-
-    entry.store(
-        context,
-        location,
-        point_ptr,
-        entry.argument(1)?.into(),
-        None,
-    )?;
+    entry.store(context, location, state_ptr, entry.argument(0)?.into())?;
+    entry.store(context, location, point_ptr, entry.argument(1)?.into())?;
 
     metadata
         .get_mut::<RuntimeBindingsMeta>()
         .ok_or(Error::MissingMetadata)?
         .libfunc_ec_state_add(context, helper, entry, state_ptr, point_ptr, location)?;
 
-    let state = entry.load(context, location, state_ptr, ec_state_ty, None)?;
+    let state = entry.load(context, location, state_ptr, ec_state_ty)?;
 
     entry.append_operation(helper.br(0, &[state], location));
     Ok(())
@@ -305,42 +292,24 @@ pub fn build_state_add_mul<'ctx, 'this>(
         context,
         location,
         ec_state_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
     let scalar_ptr = helper.init_block().alloca1(
         context,
         location,
         felt252_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
     let point_ptr = helper.init_block().alloca1(
         context,
         location,
         ec_point_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
 
-    entry.store(
-        context,
-        location,
-        state_ptr,
-        entry.argument(1)?.into(),
-        None,
-    )?;
-    entry.store(
-        context,
-        location,
-        scalar_ptr,
-        entry.argument(2)?.into(),
-        None,
-    )?;
-    entry.store(
-        context,
-        location,
-        point_ptr,
-        entry.argument(3)?.into(),
-        None,
-    )?;
+    entry.store(context, location, state_ptr, entry.argument(1)?.into())?;
+    entry.store(context, location, scalar_ptr, entry.argument(2)?.into())?;
+    entry.store(context, location, point_ptr, entry.argument(3)?.into())?;
 
     metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -349,7 +318,7 @@ pub fn build_state_add_mul<'ctx, 'this>(
             context, helper, entry, state_ptr, scalar_ptr, point_ptr, location,
         )?;
 
-    let state = entry.load(context, location, state_ptr, ec_state_ty, None)?;
+    let state = entry.load(context, location, state_ptr, ec_state_ty)?;
 
     entry.append_operation(helper.br(0, &[ec_op, state], location));
     Ok(())
@@ -377,22 +346,16 @@ pub fn build_state_finalize<'ctx, 'this>(
         context,
         location,
         ec_point_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
     let state_ptr = helper.init_block().alloca1(
         context,
         location,
         ec_state_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
 
-    entry.store(
-        context,
-        location,
-        state_ptr,
-        entry.argument(0)?.into(),
-        None,
-    )?;
+    entry.store(context, location, state_ptr, entry.argument(0)?.into())?;
 
     let is_zero = metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -401,7 +364,7 @@ pub fn build_state_finalize<'ctx, 'this>(
         .result(0)?
         .into();
 
-    let point = entry.load(context, location, point_ptr, ec_point_ty, None)?;
+    let point = entry.load(context, location, point_ptr, ec_point_ty)?;
 
     entry.append_operation(helper.cond_br(context, is_zero, [0, 1], [&[point], &[]], location));
     Ok(())
@@ -479,14 +442,14 @@ pub fn build_try_new<'ctx, 'this>(
         context,
         location,
         ec_point_ty,
-        Some(get_integer_layout(252).align()),
+        get_integer_layout(252).align(),
     )?;
 
     let point = entry.append_op_result(llvm::undef(ec_point_ty, location))?;
     let point = entry.insert_value(context, location, point, entry.argument(0)?.into(), 0)?;
     let point = entry.insert_value(context, location, point, entry.argument(1)?.into(), 1)?;
 
-    entry.store(context, location, point_ptr, point, None)?;
+    entry.store(context, location, point_ptr, point)?;
 
     let result = metadata
         .get_mut::<RuntimeBindingsMeta>()

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -153,17 +153,16 @@ pub fn build_enum_value<'ctx, 'this>(
                     context,
                     location,
                     type_info.build(context, helper, registry, metadata, enum_type)?,
-                    Some(layout.align()),
+                    layout.align(),
                 )?;
 
                 // Convert the enum from the concrete variant to the internal representation.
-                entry.store(context, location, stack_ptr, val, Some(layout.align()))?;
+                entry.store(context, location, stack_ptr, val)?;
                 val = entry.load(
                     context,
                     location,
                     stack_ptr,
                     type_info.build(context, helper, registry, metadata, enum_type)?,
-                    Some(layout.align()),
                 )?;
             };
 
@@ -283,17 +282,10 @@ pub fn build_match<'ctx, 'this>(
                         metadata,
                         &info.param_signatures()[0].ty,
                     )?,
-                    Some(layout.align()),
+                    layout.align(),
                 )?;
-                entry.store(
-                    context,
-                    location,
-                    stack_ptr,
-                    entry.argument(0)?.into(),
-                    Some(layout.align()),
-                )?;
-                let tag_val =
-                    entry.load(context, location, stack_ptr, tag_ty, Some(layout.align()))?;
+                entry.store(context, location, stack_ptr, entry.argument(0)?.into())?;
+                let tag_val = entry.load(context, location, stack_ptr, tag_ty)?;
 
                 (Some(stack_ptr), tag_val)
             } else {
@@ -363,13 +355,7 @@ pub fn build_match<'ctx, 'this>(
 
                 let payload_val = match stack_ptr {
                     Some(stack_ptr) => {
-                        let val = block.load(
-                            context,
-                            location,
-                            stack_ptr,
-                            enum_ty,
-                            Some(layout.align()),
-                        )?;
+                        let val = block.load(context, location, stack_ptr, enum_ty)?;
                         block.extract_value(context, location, val, payload_ty, 1)?
                     }
                     None => {
@@ -454,17 +440,10 @@ pub fn build_snapshot_match<'ctx, 'this>(
                         metadata,
                         &info.param_signatures()[0].ty,
                     )?,
-                    Some(layout.align()),
+                    layout.align(),
                 )?;
-                entry.store(
-                    context,
-                    location,
-                    stack_ptr,
-                    entry.argument(0)?.into(),
-                    Some(layout.align()),
-                )?;
-                let tag_val =
-                    entry.load(context, location, stack_ptr, tag_ty, Some(layout.align()))?;
+                entry.store(context, location, stack_ptr, entry.argument(0)?.into())?;
+                let tag_val = entry.load(context, location, stack_ptr, tag_ty)?;
 
                 (Some(stack_ptr), tag_val)
             } else {
@@ -519,13 +498,7 @@ pub fn build_snapshot_match<'ctx, 'this>(
 
                 let payload_val = match stack_ptr {
                     Some(stack_ptr) => {
-                        let val = block.load(
-                            context,
-                            location,
-                            stack_ptr,
-                            enum_ty,
-                            Some(layout.align()),
-                        )?;
+                        let val = block.load(context, location, stack_ptr, enum_ty)?;
                         block.extract_value(context, location, val, payload_ty, 1)?
                     }
                     None => {

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -89,18 +89,11 @@ pub fn build_get<'ctx, 'this>(
     let dict_ptr = entry.argument(0)?.into();
     let key_value = entry.argument(1)?.into();
 
-    let key_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, key_ty, Some(key_layout.align()))?;
+    let key_ptr = helper
+        .init_block()
+        .alloca1(context, location, key_ty, key_layout.align())?;
 
-    entry.store(
-        context,
-        location,
-        key_ptr,
-        key_value,
-        Some(key_layout.align()),
-    )?;
+    entry.store(context, location, key_ptr, key_value)?;
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -169,13 +162,7 @@ pub fn build_get<'ctx, 'this>(
 
     // found block
     {
-        let loaded_val_ptr = block_is_found.load(
-            context,
-            location,
-            result_ptr,
-            value_ty,
-            Some(value_layout.align()),
-        )?;
+        let loaded_val_ptr = block_is_found.load(context, location, result_ptr, value_ty)?;
         block_is_found.append_operation(cf::br(
             block_final,
             &[result_ptr, loaded_val_ptr],
@@ -203,16 +190,13 @@ pub fn build_get<'ctx, 'this>(
 
 pub fn build_finalize<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: &SignatureAndTypeConcreteLibfunc,
+    _info: &SignatureAndTypeConcreteLibfunc,
 ) -> Result<()> {
-    let value_type = registry.get_type(&info.param_signatures()[1].ty)?;
-    let value_layout = value_type.layout(registry)?;
-
     let key_ty = IntegerType::new(context, 252).into();
     let key_layout = get_integer_layout(252);
 
@@ -237,26 +221,13 @@ pub fn build_finalize<'ctx, 'this>(
         2,
     )?;
 
-    entry.store(
-        context,
-        location,
-        value_ptr,
-        new_value,
-        Some(value_layout.align()),
-    )?;
+    entry.store(context, location, value_ptr, new_value)?;
 
-    let key_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, key_ty, Some(key_layout.align()))?;
+    let key_ptr = helper
+        .init_block()
+        .alloca1(context, location, key_ty, key_layout.align())?;
 
-    entry.store(
-        context,
-        location,
-        key_ptr,
-        key_value,
-        Some(key_layout.align()),
-    )?;
+    entry.store(context, location, key_ptr, key_value)?;
 
     // call insert
 

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -53,16 +53,10 @@ pub fn build<'ctx, 'this>(
                         context,
                         location,
                         elem_ty,
-                        Some(type_info.layout(registry)?.align()),
+                        type_info.layout(registry)?.align(),
                     )?;
 
-                    entry.store(
-                        context,
-                        location,
-                        stack_ptr,
-                        entry.argument(idx)?.into(),
-                        Some(type_info.layout(registry)?.align()),
-                    )?;
+                    entry.store(context, location, stack_ptr, entry.argument(idx)?.into())?;
 
                     stack_ptr
                 } else {
@@ -178,7 +172,7 @@ pub fn build<'ctx, 'this>(
                 context,
                 location,
                 type_info.build(context, helper, registry, metadata, type_id)?,
-                Some(layout.align()),
+                layout.align(),
             )?;
 
             arguments.insert(0, stack_ptr);
@@ -233,7 +227,6 @@ pub fn build<'ctx, 'this>(
                             location,
                             pointer_val,
                             type_info.build(context, helper, registry, metadata, type_id)?,
-                            None,
                         )?);
                     }
                 }

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -72,42 +72,26 @@ pub fn build_pedersen<'ctx>(
 
     // We must extend to i256 because bswap must be an even number of bytes.
 
-    let lhs_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
-    let rhs_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
-    let dst_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
+    let lhs_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
+    let rhs_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
+    let dst_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
 
     let lhs_i256 = entry.append_op_result(arith::extui(lhs, i256_ty, location))?;
     let rhs_i256 = entry.append_op_result(arith::extui(rhs, i256_ty, location))?;
 
     let lhs_be =
         entry.append_op_result(ods::llvm::intr_bswap(context, lhs_i256, location).into())?;
-
     let rhs_be =
         entry.append_op_result(ods::llvm::intr_bswap(context, rhs_i256, location).into())?;
 
-    entry.store(
-        context,
-        location,
-        lhs_ptr,
-        lhs_be,
-        Some(layout_i256.align()),
-    )?;
-    entry.store(
-        context,
-        location,
-        rhs_ptr,
-        rhs_be,
-        Some(layout_i256.align()),
-    )?;
+    entry.store(context, location, lhs_ptr, lhs_be)?;
+    entry.store(context, location, rhs_ptr, rhs_be)?;
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -116,20 +100,11 @@ pub fn build_pedersen<'ctx>(
     runtime_bindings
         .libfunc_pedersen(context, helper, entry, dst_ptr, lhs_ptr, rhs_ptr, location)?;
 
-    let result_be = entry.load(
-        context,
-        location,
-        dst_ptr,
-        i256_ty,
-        Some(layout_i256.align()),
-    )?;
-
+    let result_be = entry.load(context, location, dst_ptr, i256_ty)?;
     let op = entry.append_op_result(ods::llvm::intr_bswap(context, result_be, location).into())?;
-
     let result = entry.append_op_result(arith::trunci(op, felt252_ty, location))?;
 
     entry.append_operation(helper.br(0, &[pedersen_builtin, result], location));
-
     Ok(())
 }
 

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -73,18 +73,15 @@ pub fn build_hades_permutation<'ctx>(
 
     // We must extend to i256 because bswap must be an even number of bytes.
 
-    let op0_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
-    let op1_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
-    let op2_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, i256_ty, Some(layout_i256.align()))?;
+    let op0_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
+    let op1_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
+    let op2_ptr = helper
+        .init_block()
+        .alloca1(context, location, i256_ty, layout_i256.align())?;
 
     let op0_i256 =
         entry.append_op_result(ods::arith::extui(context, i256_ty, op0, location).into())?;
@@ -98,27 +95,9 @@ pub fn build_hades_permutation<'ctx>(
     let op1_be = entry.append_op_result(llvm::intr_bswap(op1_i256, i256_ty, location))?;
     let op2_be = entry.append_op_result(llvm::intr_bswap(op2_i256, i256_ty, location))?;
 
-    entry.store(
-        context,
-        location,
-        op0_ptr,
-        op0_be,
-        Some(layout_i256.align()),
-    )?;
-    entry.store(
-        context,
-        location,
-        op1_ptr,
-        op1_be,
-        Some(layout_i256.align()),
-    )?;
-    entry.store(
-        context,
-        location,
-        op2_ptr,
-        op2_be,
-        Some(layout_i256.align()),
-    )?;
+    entry.store(context, location, op0_ptr, op0_be)?;
+    entry.store(context, location, op1_ptr, op1_be)?;
+    entry.store(context, location, op2_ptr, op2_be)?;
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -127,27 +106,9 @@ pub fn build_hades_permutation<'ctx>(
     runtime_bindings
         .libfunc_hades_permutation(context, helper, entry, op0_ptr, op1_ptr, op2_ptr, location)?;
 
-    let op0_be = entry.load(
-        context,
-        location,
-        op0_ptr,
-        i256_ty,
-        Some(layout_i256.align()),
-    )?;
-    let op1_be = entry.load(
-        context,
-        location,
-        op1_ptr,
-        i256_ty,
-        Some(layout_i256.align()),
-    )?;
-    let op2_be = entry.load(
-        context,
-        location,
-        op2_ptr,
-        i256_ty,
-        Some(layout_i256.align()),
-    )?;
+    let op0_be = entry.load(context, location, op0_ptr, i256_ty)?;
+    let op1_be = entry.load(context, location, op1_ptr, i256_ty)?;
+    let op2_be = entry.load(context, location, op2_ptr, i256_ty)?;
 
     let op0_i256 = entry.append_op_result(llvm::intr_bswap(op0_be, i256_ty, location))?;
     let op1_i256 = entry.append_op_result(llvm::intr_bswap(op1_be, i256_ty, location))?;

--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -236,7 +236,7 @@ pub fn build_call_contract<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -281,9 +281,12 @@ pub fn build_call_contract<'ctx, 'this>(
         )],
         false,
     );
-    let calldata_arg_ptr = helper
-        .init_block()
-        .alloca1(context, location, calldata_arg_ty, None)?;
+    let calldata_arg_ptr = helper.init_block().alloca1(
+        context,
+        location,
+        calldata_arg_ty,
+        get_integer_layout(64).align(),
+    )?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(4)?.into(),
@@ -716,7 +719,7 @@ pub fn build_storage_read<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -733,7 +736,6 @@ pub fn build_storage_read<'ctx, 'this>(
         location,
         address_arg_ptr,
         entry.argument(3)?.into(),
-        None,
     )?;
 
     // Extract function pointer.
@@ -989,7 +991,7 @@ pub fn build_storage_write<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -1006,18 +1008,11 @@ pub fn build_storage_write<'ctx, 'this>(
         location,
         address_arg_ptr,
         entry.argument(3)?.into(),
-        None,
     )?;
 
     // Allocate `value` argument and write the value.
     let value_arg_ptr = helper.init_block().alloca_int(context, location, 252)?;
-    entry.store(
-        context,
-        location,
-        value_arg_ptr,
-        entry.argument(4)?.into(),
-        None,
-    )?;
+    entry.store(context, location, value_arg_ptr, entry.argument(4)?.into())?;
 
     let fn_ptr = entry
         .append_operation(llvm::get_element_ptr(
@@ -1452,7 +1447,7 @@ pub fn build_emit_event<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -1480,15 +1475,9 @@ pub fn build_emit_event<'ctx, 'this>(
             )],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
-    entry.store(
-        context,
-        location,
-        keys_arg_ptr,
-        entry.argument(2)?.into(),
-        None,
-    )?;
+    entry.store(context, location, keys_arg_ptr, entry.argument(2)?.into())?;
 
     // Allocate `data` argument and write the value.
     let data_arg_ptr = helper.init_block().alloca1(
@@ -1508,15 +1497,9 @@ pub fn build_emit_event<'ctx, 'this>(
             )],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
-    entry.store(
-        context,
-        location,
-        data_arg_ptr,
-        entry.argument(3)?.into(),
-        None,
-    )?;
+    entry.store(context, location, data_arg_ptr, entry.argument(3)?.into())?;
 
     let fn_ptr = entry
         .append_operation(llvm::get_element_ptr(
@@ -1766,7 +1749,7 @@ pub fn build_get_block_hash<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2024,7 +2007,7 @@ pub fn build_get_execution_info<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2276,7 +2259,7 @@ pub fn build_get_execution_info_v2<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2571,7 +2554,7 @@ pub fn build_deploy<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2588,7 +2571,6 @@ pub fn build_deploy<'ctx, 'this>(
         location,
         class_hash_arg_ptr,
         entry.argument(2)?.into(),
-        None,
     )?;
 
     // Allocate `entry_point_selector` argument and write the value.
@@ -2598,7 +2580,6 @@ pub fn build_deploy<'ctx, 'this>(
         location,
         contract_address_salt_arg_ptr,
         entry.argument(3)?.into(),
-        None,
     )?;
 
     // Allocate `calldata` argument and write the value.
@@ -2619,14 +2600,13 @@ pub fn build_deploy<'ctx, 'this>(
             )],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
     entry.store(
         context,
         location,
         calldata_arg_ptr,
         entry.argument(4)?.into(),
-        None,
     )?;
 
     let fn_ptr = entry
@@ -2913,7 +2893,7 @@ pub fn build_keccak<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2937,15 +2917,9 @@ pub fn build_keccak<'ctx, 'this>(
             ],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
-    entry.store(
-        context,
-        location,
-        input_arg_ptr,
-        entry.argument(2)?.into(),
-        None,
-    )?;
+    entry.store(context, location, input_arg_ptr, entry.argument(2)?.into())?;
 
     let fn_ptr = entry
         .append_operation(llvm::get_element_ptr(
@@ -3188,7 +3162,7 @@ pub fn build_library_call<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -3236,7 +3210,7 @@ pub fn build_library_call<'ctx, 'this>(
             )],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -3499,7 +3473,7 @@ pub fn build_replace_class<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -3764,7 +3738,7 @@ pub fn build_send_message_to_l1<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -3798,7 +3772,7 @@ pub fn build_send_message_to_l1<'ctx, 'this>(
             ],
             false,
         ),
-        None,
+        get_integer_layout(64).align(),
     )?;
     entry.append_operation(llvm::store(
         context,

--- a/src/libfuncs/starknet/secp256.rs
+++ b/src/libfuncs/starknet/secp256.rs
@@ -164,7 +164,7 @@ pub fn build_k1_new<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -192,7 +192,7 @@ pub fn build_k1_new<'ctx, 'this>(
     // Allocate `x` argument and write the value.
     let x_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, x_ty, Some(x_layout.align()))?;
+        .alloca1(context, location, x_ty, x_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -204,7 +204,7 @@ pub fn build_k1_new<'ctx, 'this>(
     // Allocate `y` argument and write the value.
     let y_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, y_ty, Some(y_layout.align()))?;
+        .alloca1(context, location, y_ty, y_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(3)?.into(),
@@ -306,13 +306,7 @@ pub fn build_k1_new<'ctx, 'this>(
             )
             .result(0)?
             .into();
-        entry.load(
-            context,
-            location,
-            ptr,
-            variant_tys[0].0,
-            Some(variant_tys[0].1.align()),
-        )?
+        entry.load(context, location, ptr, variant_tys[0].0)?
     };
     let payload_err = {
         let ptr = entry
@@ -458,7 +452,7 @@ pub fn build_k1_add<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -484,10 +478,9 @@ pub fn build_k1_add<'ctx, 'this>(
     )?;
 
     // Allocate `p0` argument and write the value.
-    let p0_arg_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, p0_ty, Some(p0_layout.align()))?;
+    let p0_arg_ptr = helper
+        .init_block()
+        .alloca1(context, location, p0_ty, p0_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -497,10 +490,9 @@ pub fn build_k1_add<'ctx, 'this>(
     ));
 
     // Allocate `p1` argument and write the value.
-    let p1_arg_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, p1_ty, Some(p1_layout.align()))?;
+    let p1_arg_ptr = helper
+        .init_block()
+        .alloca1(context, location, p1_ty, p1_layout.align())?;
 
     entry.append_operation(llvm::store(
         context,
@@ -758,7 +750,7 @@ pub fn build_k1_mul<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -786,7 +778,7 @@ pub fn build_k1_mul<'ctx, 'this>(
     // Allocate `p` argument and write the value.
     let p_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, p_ty, Some(p_layout.align()))?;
+        .alloca1(context, location, p_ty, p_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -799,7 +791,7 @@ pub fn build_k1_mul<'ctx, 'this>(
     let scalar_arg_ptr =
         helper
             .init_block()
-            .alloca1(context, location, scalar_ty, Some(scalar_layout.align()))?;
+            .alloca1(context, location, scalar_ty, scalar_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(3)?.into(),
@@ -1056,7 +1048,7 @@ pub fn build_k1_get_point_from_x<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -1077,7 +1069,7 @@ pub fn build_k1_get_point_from_x<'ctx, 'this>(
     // Allocate `x` argument and write the value.
     let x_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, x_ty, Some(x_layout.align()))?;
+        .alloca1(context, location, x_ty, x_layout.align())?;
 
     entry.append_operation(llvm::store(
         context,
@@ -1191,13 +1183,7 @@ pub fn build_k1_get_point_from_x<'ctx, 'this>(
             )
             .result(0)?
             .into();
-        entry.load(
-            context,
-            location,
-            ptr,
-            variant_tys[0].0,
-            Some(variant_tys[0].1.align()),
-        )?
+        entry.load(context, location, ptr, variant_tys[0].0)?
     };
     let payload_err = {
         let ptr = entry
@@ -1372,7 +1358,7 @@ pub fn build_k1_get_xy<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -1393,7 +1379,7 @@ pub fn build_k1_get_xy<'ctx, 'this>(
     // Allocate `p` argument and write the value.
     let p_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, p_ty, Some(p_layout.align()))?;
+        .alloca1(context, location, p_ty, p_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -1685,7 +1671,7 @@ pub fn build_r1_new<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -1713,7 +1699,7 @@ pub fn build_r1_new<'ctx, 'this>(
     // Allocate `x` argument and write the value.
     let x_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, x_ty, Some(x_layout.align()))?;
+        .alloca1(context, location, x_ty, x_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -1725,7 +1711,7 @@ pub fn build_r1_new<'ctx, 'this>(
     // Allocate `y` argument and write the value.
     let y_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, y_ty, Some(y_layout.align()))?;
+        .alloca1(context, location, y_ty, y_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(3)?.into(),
@@ -1828,13 +1814,7 @@ pub fn build_r1_new<'ctx, 'this>(
             )
             .result(0)?
             .into();
-        entry.load(
-            context,
-            location,
-            ptr,
-            variant_tys[0].0,
-            Some(variant_tys[0].1.align()),
-        )?
+        entry.load(context, location, ptr, variant_tys[0].0)?
     };
     let payload_err = {
         let ptr = entry
@@ -1980,7 +1960,7 @@ pub fn build_r1_add<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2006,10 +1986,9 @@ pub fn build_r1_add<'ctx, 'this>(
     )?;
 
     // Allocate `p0` argument and write the value.
-    let p0_arg_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, p0_ty, Some(p0_layout.align()))?;
+    let p0_arg_ptr = helper
+        .init_block()
+        .alloca1(context, location, p0_ty, p0_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(2)?.into(),
@@ -2019,10 +1998,9 @@ pub fn build_r1_add<'ctx, 'this>(
     ));
 
     // Allocate `p1` argument and write the value.
-    let p1_arg_ptr =
-        helper
-            .init_block()
-            .alloca1(context, location, p1_ty, Some(p1_layout.align()))?;
+    let p1_arg_ptr = helper
+        .init_block()
+        .alloca1(context, location, p1_ty, p1_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(3)?.into(),
@@ -2280,7 +2258,7 @@ pub fn build_r1_mul<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2309,7 +2287,7 @@ pub fn build_r1_mul<'ctx, 'this>(
     // Allocate `p` argument and write the value.
     let p_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, p_ty, Some(p_layout.align()))?;
+        .alloca1(context, location, p_ty, p_layout.align())?;
 
     entry.append_operation(llvm::store(
         context,
@@ -2323,7 +2301,7 @@ pub fn build_r1_mul<'ctx, 'this>(
     let scalar_arg_ptr =
         helper
             .init_block()
-            .alloca1(context, location, scalar_ty, Some(scalar_layout.align()))?;
+            .alloca1(context, location, scalar_ty, scalar_layout.align())?;
     entry.append_operation(llvm::store(
         context,
         entry.argument(3)?.into(),
@@ -2581,7 +2559,7 @@ pub fn build_r1_get_point_from_x<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2603,7 +2581,7 @@ pub fn build_r1_get_point_from_x<'ctx, 'this>(
             ],
             false,
         ),
-        Some(16),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2717,13 +2695,7 @@ pub fn build_r1_get_point_from_x<'ctx, 'this>(
             )
             .result(0)?
             .into();
-        entry.load(
-            context,
-            location,
-            ptr,
-            variant_tys[0].0,
-            Some(variant_tys[0].1.align()),
-        )?
+        entry.load(context, location, ptr, variant_tys[0].0)?
     };
     let payload_err = {
         let ptr = entry
@@ -2898,7 +2870,7 @@ pub fn build_r1_get_xy<'ctx, 'this>(
         context,
         location,
         IntegerType::new(context, 128).into(),
-        Some(get_integer_layout(128).align()),
+        get_integer_layout(128).align(),
     )?;
     entry.append_operation(llvm::store(
         context,
@@ -2919,7 +2891,7 @@ pub fn build_r1_get_xy<'ctx, 'this>(
     // Allocate `p` argument and write the value.
     let p_arg_ptr = helper
         .init_block()
-        .alloca1(context, location, p_ty, Some(p_layout.align()))?;
+        .alloca1(context, location, p_ty, p_layout.align())?;
 
     entry.append_operation(llvm::store(
         context,

--- a/src/libfuncs/starknet/testing.rs
+++ b/src/libfuncs/starknet/testing.rs
@@ -21,7 +21,7 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
-    utils::ProgramRegistryExt,
+    utils::{get_integer_layout, ProgramRegistryExt},
 };
 
 pub fn build<'ctx, 'this>(
@@ -64,16 +64,11 @@ pub fn build<'ctx, 'this>(
     let selector = helper
         .init_block()
         .const_int(context, location, info.selector.clone(), 256)?;
-    let selector_ptr = helper.init_block().alloca1(
-        context,
-        location,
-        IntegerType::new(context, 256).into(),
-        None,
-    )?;
+    let selector_ptr = helper.init_block().alloca_int(context, location, 256)?;
 
     helper
         .init_block()
-        .store(context, location, selector_ptr, selector, None)?;
+        .store(context, location, selector_ptr, selector)?;
 
     // Allocate and store arguments. The cairo type is a Span<Felt252> (the outer struct),
     // which contains an Array<Felt252> (the inner struct)
@@ -91,10 +86,13 @@ pub fn build<'ctx, 'this>(
         )],
         false,
     );
-    let args_ptr = helper
-        .init_block()
-        .alloca1(context, location, span_felt252_type, None)?;
-    entry.store(context, location, args_ptr, entry.argument(0)?.into(), None)?;
+    let args_ptr = helper.init_block().alloca1(
+        context,
+        location,
+        span_felt252_type,
+        get_integer_layout(64).align(),
+    )?;
+    entry.store(context, location, args_ptr, entry.argument(0)?.into())?;
 
     // Call runtime cheatcode syscall wrapper
     metadata

--- a/src/metadata/debug_utils.rs
+++ b/src/metadata/debug_utils.rs
@@ -83,7 +83,7 @@
 
 #![cfg(feature = "with-debug-utils")]
 
-use crate::{block_ext::BlockExt, error::Result};
+use crate::{block_ext::BlockExt, error::Result, utils::get_integer_layout};
 use melior::{
     dialect::{
         arith, func,
@@ -194,7 +194,7 @@ impl DebugUtils {
             message.len().try_into().unwrap(),
         );
 
-        let ptr = block.alloca1(context, location, ty, None)?;
+        let ptr = block.alloca1(context, location, ty, get_integer_layout(8).align())?;
 
         let msg = block
             .append_operation(

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -199,13 +199,7 @@ fn snapshot_take<'ctx, 'this>(
 
         match elem_snapshot_take {
             Some(elem_snapshot_take) => {
-                let value = block_realloc.load(
-                    context,
-                    location,
-                    src_ptr,
-                    elem_ty,
-                    Some(elem_layout.align()),
-                )?;
+                let value = block_realloc.load(context, location, src_ptr, elem_ty)?;
 
                 let (block_relloc, value) = elem_snapshot_take(
                     context,
@@ -217,7 +211,7 @@ fn snapshot_take<'ctx, 'this>(
                     value,
                 )?;
 
-                block_relloc.store(context, location, dst_ptr, value, Some(elem_layout.align()))?;
+                block_relloc.store(context, location, dst_ptr, value)?;
                 block_relloc.append_operation(cf::br(block_finish, &[dst_ptr], location));
             }
             None => {

--- a/src/types/box.rs
+++ b/src/types/box.rs
@@ -95,24 +95,12 @@ fn snapshot_take<'ctx, 'this>(
 
     match inner_snapshot_take {
         Some(inner_snapshot_take) => {
-            let value = entry.load(
-                context,
-                location,
-                src_value,
-                inner_ty,
-                Some(inner_layout.align()),
-            )?;
+            let value = entry.load(context, location, src_value, inner_ty)?;
 
             let (entry, value) =
                 inner_snapshot_take(context, registry, entry, location, helper, metadata, value)?;
 
-            entry.store(
-                context,
-                location,
-                dst_ptr,
-                value,
-                Some(inner_layout.align()),
-            )?;
+            entry.store(context, location, dst_ptr, value)?;
         }
         None => {
             entry.append_operation(


### PR DESCRIPTION
All alloca operations need the target alignment. Load and store operations don't need it because the pointer is already aligned (or should be). This PR makes the alignment mandatory on allocas and removes it on load and store operations.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
