### PR TITLE
add a `Compiler` instance to hold context

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -900,18 +900,10 @@ impl<'c> Compiler<'c> {
         type_ids: &'c [ConcreteTypeId],
     ) -> impl 'c + Iterator<Item = Result<Type<'c>, Error>> {
         type_ids.iter().filter_map(|id| {
-            let type_info = self.get_type(id).ok()?;
-
-            if type_info.is_builtin() && type_info.is_zst(self.registry) {
+            if self.type_is_zst_builtin(id) {
                 None
             } else {
-                Some(type_info.build(
-                    self.context,
-                    self.module,
-                    self.registry,
-                    *self.metadata.borrow_mut(),
-                    id,
-                ))
+                Some(self.build_type(id))
             }
         })
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -120,14 +120,15 @@ impl NativeContext {
         // Create the Sierra program registry
         let registry = ProgramRegistry::<CoreType, CoreLibfunc>::new(program)?;
 
-        crate::compile(
+        let compiler = crate::Compiler::new(
             &self.context,
             &module,
             program,
             &registry,
             &mut metadata,
             debug_locations.as_ref(),
-        )?;
+        );
+        compiler.compile()?;
 
         if let Ok(x) = std::env::var("NATIVE_DEBUG_DUMP_PREPASS") {
             if x == "1" || x == "true" {
@@ -191,14 +192,15 @@ impl NativeContext {
         // Create the Sierra program registry
         let registry = ProgramRegistry::<CoreType, CoreLibfunc>::new(program)?;
 
-        crate::compile(
+        let compiler = crate::Compiler::new(
             &self.context,
             &module,
             program,
             &registry,
             &mut metadata,
             None,
-        )?;
+        );
+        compiler.compile()?;
 
         run_pass_manager(&self.context, &mut module)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub use self::{
-    compiler::compile,
+    compiler::Compiler,
     ffi::{module_to_object, object_to_shared_lib, LLVMCompileError, OptLevel},
 };
 

--- a/tests/tests/compile_library.rs
+++ b/tests/tests/compile_library.rs
@@ -42,14 +42,15 @@ pub fn compile_library() -> Result<(), Box<dyn Error>> {
     // Make the runtime library available.
     metadata.insert(RuntimeBindingsMeta::default()).unwrap();
 
-    cairo_native::compile(
+    let compiler = cairo_native::Compiler::new(
         &context,
         &module,
         &program.1,
         &registry,
         &mut metadata,
         None,
-    )?;
+    );
+    compiler.compile()?;
 
     // lower to llvm dialect
     let pass_manager = PassManager::new(&context);


### PR DESCRIPTION
Add a `Compiler` structure which holds the MLIR context and module during compilation. Starts a refactor of the `compile` function in order to break it down into smaller functions.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
