### PR TITLE
docs: fix mlir to binary section

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ sierra2mlir program.sierra -o program.mlir
 # compile natively
 "$MLIR_SYS_180_PREFIX"/bin/clang program.ll -Wno-override-module \
     -L "$MLIR_SYS_180_PREFIX"/lib -L"./target/release/" \
-    -lsierra2mlir_utils -lmlir_c_runner_utils \
+    -lcairo_native_runtime -lmlir_c_runner_utils \
     -Wl,-rpath "$MLIR_SYS_180_PREFIX"/lib \
     -Wl,-rpath ./target/release/ \
     -o program


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->

Fixes #708

Updates the command to compile from MLIR to binary in `README.md`. Might have been missed during name change to cairo native


## Checklist
- [x] Linked to Github Issue
- [ ] ~Unit tests added~
- [ ] ~Integration tests added.~
- [ ] ~This change requires new documentation.~
  - [ ] ~Documentation has been added/updated.~
