### PR TITLE
Remove std::mem::forget(arena) on invoke_dynamic

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -351,9 +351,6 @@ fn invoke_dynamic(
             })
         })?;
 
-    // FIXME: Arena deallocation.
-    std::mem::forget(arena);
-
     Ok(ExecutionResult {
         remaining_gas,
         return_value,


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
