### PR TITLE
Implement new array libfuncs.

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -729,8 +729,13 @@ pub fn build_snapshot_multi_pop_front<'ctx, 'this>(
     _location: Location<'ctx>,
     _helper: &LibfuncHelper<'ctx, 'this>,
     _metadata: &mut MetadataStorage,
-    _info: &ConcreteMultiPopLibfunc,
+    info: &ConcreteMultiPopLibfunc,
 ) -> Result<()> {
+    use itertools::Itertools;
+    dbg!(&info.popped_ty);
+    dbg!(&info.param_signatures().iter().map(|p| &p.ty).collect_vec());
+    dbg!(&info.branch_signatures());
+
     Ok(())
 }
 
@@ -1903,5 +1908,21 @@ mod test {
                 debug_name: None
             }
         );
+    }
+
+    #[test]
+    fn snapshot_multi_pop_front() {
+        let program = load_cairo!(
+            use array::ArrayTrait;
+
+            fn run_test() -> @Box<[u32; 2]> {
+                let mut numbers = array![1, 2, 3, 4].span();
+
+                numbers.multi_pop_front::<2>().unwrap()
+            }
+        );
+        let result = run_program(&program, "run_test", &[]).return_value;
+
+        assert_eq!(result, jit_struct!());
     }
 }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -2024,4 +2024,42 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn snapshot_failed_multi_pop_front() {
+        let program = load_cairo!(
+            use array::ArrayTrait;
+
+            fn run_test() -> Span<felt252> {
+                let mut numbers = array![1, 2].span();
+
+                // should fail (return none)
+                if numbers.multi_pop_front::<3>().is_some() {
+                    panic!();
+                }
+
+                numbers
+            }
+        );
+
+        let result = run_program(&program, "run_test", &[]).return_value;
+
+        assert_eq!(
+            result,
+            // Panic result
+            jit_enum!(
+                0,
+                jit_struct!(
+                    // Tuple
+                    jit_struct!(
+                        // Span of original array
+                        jit_struct!(JitValue::Array(vec![
+                            JitValue::Felt252(1.into()),
+                            JitValue::Felt252(2.into()),
+                        ])),
+                    )
+                )
+            )
+        );
+    }
 }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1873,10 +1873,21 @@ mod test {
                 ])],
             )
             .return_value,
-            JitValue::Struct {
-                fields: vec![],
-                debug_name: None,
-            },
+            JitValue::Enum {
+                tag: 0,
+                value: Box::new(JitValue::Struct {
+                    fields: vec![JitValue::Struct {
+                        fields: vec![
+                            JitValue::Felt252(1.into()),
+                            JitValue::Felt252(2.into()),
+                            JitValue::Felt252(3.into()),
+                        ],
+                        debug_name: None
+                    }],
+                    debug_name: None
+                }),
+                debug_name: None
+            }
         );
     }
 }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -929,13 +929,13 @@ pub fn build_snapshot_multi_pop_back<'ctx, 'this>(
         valid_block.memcpy(context, location, popped_ptr, return_ptr, popped_size_value);
 
         let array = {
-            let new_array_start = valid_block.append_op_result(arith::addi(
-                array_start,
+            let new_array_end = valid_block.append_op_result(arith::subi(
+                array_end,
                 popped_amount_value,
                 location,
             ))?;
 
-            valid_block.insert_value(context, location, array, new_array_start, 1)?
+            valid_block.insert_value(context, location, array, new_array_end, 2)?
         };
 
         valid_block.append_operation(helper.br(0, &[range_check, array, return_ptr], location));

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -2268,4 +2268,42 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn snapshot_multi_pop_back_front() {
+        let program = load_cairo!(
+            use array::ArrayTrait;
+
+            fn run_test() -> (Span<felt252>, @Box<[felt252; 2]>, @Box<[felt252; 2]>) {
+                let mut numbers = array![1, 2, 3, 4, 5, 6].span();
+                let popped_front = numbers.multi_pop_front::<2>().unwrap();
+                let popped_back = numbers.multi_pop_back::<2>().unwrap();
+
+                (numbers, popped_front, popped_back)
+            }
+        );
+        let result = run_program(&program, "run_test", &[]).return_value;
+
+        assert_eq!(
+            result,
+            // Panic result
+            jit_enum!(
+                0,
+                jit_struct!(
+                    // Tuple
+                    jit_struct!(
+                        // Span of original array
+                        jit_struct!(JitValue::Array(vec![
+                            JitValue::Felt252(3.into()),
+                            JitValue::Felt252(4.into()),
+                        ])),
+                        // Box of fixed array
+                        jit_struct!(JitValue::Felt252(1.into()), JitValue::Felt252(2.into()),),
+                        // Box of fixed array
+                        jit_struct!(JitValue::Felt252(5.into()), JitValue::Felt252(6.into())),
+                    )
+                )
+            )
+        );
+    }
 }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1206,10 +1206,14 @@ pub fn build_tuple_from_span<'ctx, 'this>(
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    _metadata: &mut MetadataStorage,
+    metadata: &mut MetadataStorage,
     info: &SignatureAndTypeConcreteLibfunc,
 ) -> Result<()> {
     // (Snapshot<Array<felt252>>) -> Box<Tuple<felt252, felt252, felt252>>
+
+    if metadata.get::<ReallocBindingsMeta>().is_none() {
+        metadata.insert(ReallocBindingsMeta::new(context, helper));
+    }
 
     // if arg0.end - arg0.start != tuple_len {
     //     return err;

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -2124,6 +2124,30 @@ mod test {
     }
 
     #[test]
+    fn tuple_from_span_failed() {
+        let program = load_cairo! {
+            use core::array::{tuple_from_span, FixedSizedArrayInfoImpl};
+
+            fn run_test(x: Array<felt252>) -> Option<@Box<[core::felt252; 3]>> {
+                tuple_from_span::<[felt252; 3], FixedSizedArrayInfoImpl<felt252, 3>>(@x)
+            }
+        };
+
+        assert_eq!(
+            run_program(
+                &program,
+                "run_test",
+                &[JitValue::Array(vec![
+                    JitValue::Felt252(1.into()),
+                    JitValue::Felt252(2.into()),
+                ])],
+            )
+            .return_value,
+            jit_enum!(1, jit_struct!())
+        );
+    }
+
+    #[test]
     fn snapshot_multi_pop_front() {
         let program = load_cairo!(
             use array::ArrayTrait;

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -768,7 +768,7 @@ pub fn build_snapshot_multi_pop_front<'ctx, 'this>(
     let array_len = entry.append_op_result(arith::subi(array_end, array_start, location))?;
     let popped_amount_value = entry.const_int(context, location, popped_amount, 32)?;
     let is_valid = entry.append_op_result(arith::cmpi(
-        &context,
+        context,
         CmpiPredicate::Uge,
         array_len,
         popped_amount_value,
@@ -879,7 +879,7 @@ pub fn build_snapshot_multi_pop_back<'ctx, 'this>(
     let array_len = entry.append_op_result(arith::subi(array_end, array_start, location))?;
     let popped_amount_value = entry.const_int(context, location, popped_amount, 32)?;
     let is_valid = entry.append_op_result(arith::cmpi(
-        &context,
+        context,
         CmpiPredicate::Uge,
         array_len,
         popped_amount_value,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -2034,9 +2034,7 @@ mod test {
                 let mut numbers = array![1, 2].span();
 
                 // should fail (return none)
-                if numbers.multi_pop_front::<3>().is_some() {
-                    panic!();
-                }
+                assert!(numbers.multi_pop_front::<3>().is_none());
 
                 numbers
             }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -2229,4 +2229,37 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn snapshot_failed_multi_pop_back() {
+        let program = load_cairo!(
+            use array::ArrayTrait;
+
+            fn run_test() -> Span<felt252> {
+                let mut numbers = array![1, 2].span();
+
+                // should fail (return none)
+                assert!(numbers.multi_pop_back::<3>().is_none());
+
+                numbers
+            }
+        );
+
+        let result = run_program(&program, "run_test", &[]).return_value;
+
+        assert_eq!(
+            result,
+            // Panic result
+            jit_enum!(
+                0,
+                jit_struct!(
+                    // Span of original array
+                    jit_struct!(JitValue::Array(vec![
+                        JitValue::Felt252(1.into()),
+                        JitValue::Felt252(2.into()),
+                    ]),)
+                )
+            )
+        );
+    }
 }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use cairo_lang_sierra::{
     extensions::{
-        array::ArrayConcreteLibfunc,
+        array::{ArrayConcreteLibfunc, ConcreteMultiPopLibfunc},
         core::{CoreLibfunc, CoreType, CoreTypeConcrete},
         lib_func::{SignatureAndTypeConcreteLibfunc, SignatureOnlyConcreteLibfunc},
         ConcreteLibfunc,
@@ -79,8 +79,10 @@ pub fn build<'ctx, 'this>(
         ArrayConcreteLibfunc::TupleFromSpan(info) => {
             build_tuple_from_span(context, registry, entry, location, helper, metadata, info)
         }
-        ArrayConcreteLibfunc::SnapshotMultiPopFront(_)
-        | ArrayConcreteLibfunc::SnapshotMultiPopBack(_) => todo!(),
+        ArrayConcreteLibfunc::SnapshotMultiPopFront(info) => build_snapshot_multi_pop_front(
+            context, registry, entry, location, helper, metadata, info,
+        ),
+        ArrayConcreteLibfunc::SnapshotMultiPopBack(_) => todo!(),
     }
 }
 
@@ -717,6 +719,18 @@ pub fn build_snapshot_pop_back<'ctx, 'this>(
     }
 
     empty_block.append_operation(helper.br(1, &[value], location));
+    Ok(())
+}
+
+pub fn build_snapshot_multi_pop_front<'ctx, 'this>(
+    _context: &'ctx Context,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _entry: &'this Block<'ctx>,
+    _location: Location<'ctx>,
+    _helper: &LibfuncHelper<'ctx, 'this>,
+    _metadata: &mut MetadataStorage,
+    _info: &ConcreteMultiPopLibfunc,
+) -> Result<()> {
     Ok(())
 }
 

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -904,10 +904,16 @@ pub fn build_snapshot_multi_pop_back<'ctx, 'this>(
             let single_popped_ty =
                 registry.build_type(context, helper, registry, metadata, &popped_ctys[0])?;
 
+            let popped_start = valid_block.append_op_result(arith::subi(
+                array_end,
+                popped_amount_value,
+                location,
+            ))?;
+
             valid_block.append_op_result(llvm::get_element_ptr_dynamic(
                 context,
                 array_ptr,
-                &[array_start],
+                &[popped_start],
                 single_popped_ty,
                 llvm::r#type::pointer(context, 0),
                 location,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -972,7 +972,7 @@ pub fn build_tuple_from_span<'ctx, 'this>(
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
+    _metadata: &mut MetadataStorage,
     info: &SignatureAndTypeConcreteLibfunc,
 ) -> Result<()> {
     // (Snapshot<Array<felt252>>) -> Box<Tuple<felt252, felt252, felt252>>


### PR DESCRIPTION
Implements new array libfuncs from cairo lang 2.7.0:
- `tuple_from_span`: converts a span to a fixed size tuple if the size matches
- `snapshot_multi_pop_front`: pops elements from the front of a span and returns them as a fixed array
- `snapshot_multi_pop_back`: pops elements from the back of a span and returns them as a fixed array


## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
