### PR TITLE
Update version of `starknet-types-core` and remove unused dependencies  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,6 @@ dependencies = [
 name = "cairo-native-runtime"
 version = "0.2.0"
 dependencies = [
- "cairo-lang-runner",
  "cairo-lang-sierra-gas",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4098ac4ad57621cc7ec133b80fe72814d2cc4bee63ca8e7be4450ba6f42a07e8"
+checksum = "ce6bacf0ba19bc721e518bc4bf389ff13daa8a7c5db5fd320600473b8aa9fcbd"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,7 @@ dependencies = [
 name = "cairo-native-runtime"
 version = "0.2.0"
 dependencies = [
+ "cairo-lang-runner",
  "cairo-lang-sierra-gas",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ required-features = ["scarb"]
 [features]
 default = ["build-cli", "with-runtime"]
 build-cli = [
-  "dep:clap",
-  "dep:tracing-subscriber",
-  "dep:anyhow",
-  "dep:cairo-lang-test-plugin",
-  "dep:cairo-lang-runner",
-  "dep:colored",
+    "dep:clap",
+    "dep:tracing-subscriber",
+    "dep:anyhow",
+    "dep:cairo-lang-test-plugin",
+    "dep:cairo-lang-runner",
+    "dep:colored",
 ]
 scarb = ["build-cli", "dep:scarb-ui", "dep:scarb-metadata", "dep:serde_json"]
 with-debug-utils = []
@@ -72,8 +72,8 @@ melior = { version = "0.18.4", features = ["ods-dialects"] }
 mlir-sys = "0.2.2"
 num-bigint = "0.4.4"
 num-traits = "0.2"
-starknet-types-core = { version = "=0.1.2", default-features = false, features = [
-  "std", "serde", "num-traits"
+starknet-types-core = { version = "=0.1.5", default-features = false, features = [
+    "std", "serde", "num-traits"
 ] }
 tempfile = "3.6"
 thiserror = "1.0.59"
@@ -89,7 +89,7 @@ cairo-lang-starknet-classes = "2.7.0-rc.3"
 cairo-native-runtime = { version = "0.2.0", path = "runtime", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 libloading = "0.8.3"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"] , optional = true }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 anyhow = { version = "1.0", optional = true }
 cairo-lang-test-plugin = { version = "2.7.0-rc.3", optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 starknet-types-core = { version = "=0.1.5", default-features = false, features = [
     "std", "serde",
 ] }
-cairo-lang-runner = "2.7.0-rc.3"
 cairo-lang-sierra-gas = "2.7.0-rc.3"
 libc = "0.2.155"
 starknet-crypto = "0.6.2"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-starknet-types-core = { version = "=0.1.2", default-features = false, features = [
-  "std", "serde",
+starknet-types-core = { version = "=0.1.5", default-features = false, features = [
+    "std", "serde",
 ] }
 cairo-lang-runner = "2.7.0-rc.3"
 cairo-lang-sierra-gas = "2.7.0-rc.3"


### PR DESCRIPTION
While integrating cairo `2.7.0-rc.3` to the [blockifier](https://github.com/NethermindEth/blockifier/pull/121), we've got a dependency error with incorrect `starknet-types-core` version. Also while executing new CI after the update, we've found out that `cairo-lang-runner` is not being used in the `cairo-native-runtime` crate, so we've removed it.