### PR TITLE
remove unused dep: `cairo-lang-runner` from `cairo-native-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,6 @@ dependencies = [
 name = "cairo-native-runtime"
 version = "0.2.0"
 dependencies = [
- "cairo-lang-runner",
  "cairo-lang-sierra-gas",
  "lazy_static",
  "libc",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 starknet-types-core = { version = "=0.1.5", default-features = false, features = [
     "std", "serde",
 ] }
-cairo-lang-runner = "2.7.0"
 cairo-lang-sierra-gas = "2.7.0"
 libc = "0.2.155"
 starknet-crypto = "0.6.2"


### PR DESCRIPTION
Machete (https://github.com/bnjbvr/cargo-machete) found that `cairo-lang-runner` is not used in `cairo-native-runtime`, so I've removed it from the dependencies

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
