### PR TITLE
Optimize AOT 

### DIFF
--- a/src/executor/aot.rs
+++ b/src/executor/aot.rs
@@ -209,12 +209,15 @@ mod tests {
     }
 
     #[rstest]
-    fn test_invoke_dynamic(program: Program) {
+    #[case(OptLevel::None)]
+    #[case(OptLevel::Default)]
+    #[case(OptLevel::Aggressive)]
+    fn test_invoke_dynamic(program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
             .compile(&program)
             .expect("failed to compile context");
-        let executor = AotNativeExecutor::from_native_module(module, OptLevel::default());
+        let executor = AotNativeExecutor::from_native_module(module, optlevel);
 
         // The first function in the program is `run_test`.
         let entrypoint_function_id = &program.funcs.first().expect("should have a function").id;
@@ -227,12 +230,15 @@ mod tests {
     }
 
     #[rstest]
-    fn test_invoke_dynamic_with_syscall_handler(program: Program) {
+    #[case(OptLevel::None)]
+    #[case(OptLevel::Default)]
+    #[case(OptLevel::Aggressive)]
+    fn test_invoke_dynamic_with_syscall_handler(program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
             .compile(&program)
             .expect("failed to compile context");
-        let executor = AotNativeExecutor::from_native_module(module, OptLevel::default());
+        let executor = AotNativeExecutor::from_native_module(module, optlevel);
 
         // The second function in the program is `get_block_hash`.
         let entrypoint_function_id = &program.funcs.get(1).expect("should have a function").id;
@@ -263,12 +269,15 @@ mod tests {
     }
 
     #[rstest]
-    fn test_invoke_contract_dynamic(starknet_program: Program) {
+    #[case(OptLevel::None)]
+    #[case(OptLevel::Default)]
+    #[case(OptLevel::Aggressive)]
+    fn test_invoke_contract_dynamic(starknet_program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
             .compile(&starknet_program)
             .expect("failed to compile context");
-        let executor = AotNativeExecutor::from_native_module(module, OptLevel::default());
+        let executor = AotNativeExecutor::from_native_module(module, optlevel);
 
         // The last function in the program is the `get` wrapper function.
         let entrypoint_function_id = &starknet_program


### PR DESCRIPTION
Previously when using AOT the llvm ir was not optimized, in JIT if you pass the optlevel it internally optimizes the llvm ir but with AOT we have to do it ourselves.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
