### PR TITLE
Remove misused var_calle_type on llvm.call, which is only for variadic function types

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1237,15 +1237,6 @@ fn generate_entry_point_wrapper<'c>(
         OperationBuilder::new("llvm.call", location)
             .add_attributes(&[
                 (
-                    Identifier::new(context, "var_callee_type"),
-                    TypeAttribute::new(llvm::r#type::function(
-                        llvm::r#type::r#struct(context, ret_types, false),
-                        &args.iter().map(ValueLike::r#type).collect::<Vec<_>>(),
-                        false,
-                    ))
-                    .into(),
-                ),
-                (
                     Identifier::new(context, "callee"),
                     FlatSymbolRefAttribute::new(context, private_symbol).into(),
                 ),

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -184,15 +184,6 @@ pub fn build<'ctx, 'this>(
             OperationBuilder::new("llvm.call", location)
                 .add_attributes(&[
                     (
-                        Identifier::new(context, "var_callee_type"),
-                        TypeAttribute::new(llvm::r#type::function(
-                            llvm::r#type::r#struct(context, &result_types, false),
-                            &arguments.iter().map(ValueLike::r#type).collect::<Vec<_>>(),
-                            false,
-                        ))
-                        .into(),
-                    ),
-                    (
                         Identifier::new(context, "callee"),
                         FlatSymbolRefAttribute::new(
                             context,


### PR DESCRIPTION
<!--
Description of the pull request changes and motivation.
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
