### PR TITLE
ContractExecutor changes

### DIFF
--- a/benches/compile_time.rs
+++ b/benches/compile_time.rs
@@ -14,7 +14,7 @@ pub fn bench_compile_time(c: &mut Criterion) {
             c.bench_with_input(BenchmarkId::new(filename, 1), &program, |b, program| {
                 b.iter(|| {
                     let native_context = NativeContext::new();
-                    native_context.compile(program).unwrap();
+                    native_context.compile(program, false).unwrap();
                     // pass manager internally verifies the MLIR output is correct.
                 })
             });
@@ -29,7 +29,7 @@ pub fn bench_compile_time(c: &mut Criterion) {
         for (program, filename) in &programs {
             c.bench_with_input(BenchmarkId::new(filename, 1), &program, |b, program| {
                 b.iter(|| {
-                    native_context.compile(program).unwrap();
+                    native_context.compile(program, false).unwrap();
                     // pass manager internally verifies the MLIR output is correct.
                 })
             });
@@ -43,7 +43,7 @@ pub fn bench_compile_time(c: &mut Criterion) {
             c.bench_with_input(BenchmarkId::new(filename, 1), &program, |b, program| {
                 b.iter(|| {
                     let native_context = NativeContext::new();
-                    let module = native_context.compile(black_box(program)).unwrap();
+                    let module = native_context.compile(black_box(program), false).unwrap();
                     let object = module_to_object(module.module(), OptLevel::None)
                         .expect("to compile correctly to a object file");
                     black_box(object)
@@ -60,7 +60,7 @@ pub fn bench_compile_time(c: &mut Criterion) {
         for (program, filename) in &programs {
             c.bench_with_input(BenchmarkId::new(filename, 1), &program, |b, program| {
                 b.iter(|| {
-                    let module = native_context.compile(black_box(program)).unwrap();
+                    let module = native_context.compile(black_box(program), false).unwrap();
                     let object = module_to_object(module.module(), OptLevel::None)
                         .expect("to compile correctly to a object file");
                     black_box(object)

--- a/benches/libfuncs.rs
+++ b/benches/libfuncs.rs
@@ -50,7 +50,7 @@ pub fn bench_libfuncs(c: &mut Criterion) {
                 |b, program| {
                     let native_context = NativeContext::new();
                     b.iter(|| {
-                        let module = native_context.compile(program).unwrap();
+                        let module = native_context.compile(program, false).unwrap();
                         // pass manager internally verifies the MLIR output is correct.
                         let native_executor =
                             JitNativeExecutor::from_native_module(module, Default::default());
@@ -69,7 +69,7 @@ pub fn bench_libfuncs(c: &mut Criterion) {
                 program,
                 |b, program| {
                     let native_context = NativeContext::new();
-                    let module = native_context.compile(program).unwrap();
+                    let module = native_context.compile(program, false).unwrap();
                     // pass manager internally verifies the MLIR output is correct.
                     let native_executor =
                         JitNativeExecutor::from_native_module(module, Default::default());

--- a/examples/easy_api.rs
+++ b/examples/easy_api.rs
@@ -15,7 +15,7 @@ fn main() {
     let sierra_program = cairo_to_sierra(program_path);
 
     // Compile the sierra program into a MLIR module.
-    let native_program = native_context.compile(&sierra_program).unwrap();
+    let native_program = native_context.compile(&sierra_program, false).unwrap();
 
     // The parameters of the entry point.
     let params = &[JitValue::Felt252(Felt::from_bytes_be_slice(b"user"))];

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -305,7 +305,7 @@ fn main() {
 
     let native_context = NativeContext::new();
 
-    let native_program = native_context.compile(&sierra_program).unwrap();
+    let native_program = native_context.compile(&sierra_program, false).unwrap();
 
     let entry_point_fn =
         find_entry_point_by_idx(&sierra_program, entry_point.function_idx).unwrap();

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let native_context = NativeContext::new();
 
-    let native_program = native_context.compile(&sierra_program).unwrap();
+    let native_program = native_context.compile(&sierra_program, false).unwrap();
 
     // Call the echo function from the contract using the generated wrapper.
 

--- a/examples/starknet.rs
+++ b/examples/starknet.rs
@@ -433,7 +433,7 @@ fn main() {
 
     let native_context = NativeContext::new();
 
-    let native_program = native_context.compile(&sierra_program).unwrap();
+    let native_program = native_context.compile(&sierra_program, false).unwrap();
 
     // Call the echo function from the contract using the generated wrapper.
 

--- a/src/bin/cairo-native-compile.rs
+++ b/src/bin/cairo-native-compile.rs
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
     let sierra_program = cairo_to_sierra(&args.path);
 
     // Compile the sierra program into a MLIR module.
-    let native_module = native_context.compile(&sierra_program).unwrap();
+    let native_module = native_context.compile(&sierra_program, false).unwrap();
 
     let output_mlir = args
         .output_mlir

--- a/src/bin/cairo-native-dump.rs
+++ b/src/bin/cairo-native-dump.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let program = load_program(Path::new(&args.input), args.starknet)?;
 
     // Compile the program.
-    let module = context.compile(&program)?;
+    let module = context.compile(&program, false)?;
 
     // Write the output.
     let output_str = module

--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
     let native_context = NativeContext::new();
 
     // Compile the sierra program into a MLIR module.
-    let native_module = native_context.compile(&sierra_program).unwrap();
+    let native_module = native_context.compile(&sierra_program, false).unwrap();
 
     let native_executor: NativeExecutor = match args.run_mode {
         RunMode::Aot => {

--- a/src/bin/cairo-native-stress/main.rs
+++ b/src/bin/cairo-native-stress/main.rs
@@ -275,7 +275,7 @@ where
     ) -> Arc<AotNativeExecutor> {
         let native_module = self
             .context
-            .compile(program)
+            .compile(program, false)
             .expect("failed to compile program");
 
         let registry = ProgramRegistry::new(program).expect("failed to get program registry");

--- a/src/bin/scarb-native-dump.rs
+++ b/src/bin/scarb-native-dump.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
                 // Compile the sierra program into a MLIR module.
                 let native_module = native_context
-                    .compile(&compiled.into_v1().unwrap().program)
+                    .compile(&compiled.into_v1().unwrap().program, false)
                     .unwrap();
 
                 // Write the output.

--- a/src/bin/utils/test.rs
+++ b/src/bin/utils/test.rs
@@ -138,7 +138,7 @@ pub fn run_tests(
     let native_context = NativeContext::new();
 
     // Compile the sierra program into a MLIR module.
-    let native_module = native_context.compile(&sierra_program).unwrap();
+    let native_module = native_context.compile(&sierra_program, false).unwrap();
 
     let native_executor: NativeExecutor = match args.run_mode {
         RunMode::Aot => {

--- a/src/cache/aot.rs
+++ b/src/cache/aot.rs
@@ -44,7 +44,10 @@ where
             module,
             registry,
             metadata,
-        } = self.context.compile(program).expect("should compile");
+        } = self
+            .context
+            .compile(program, false)
+            .expect("should compile");
 
         // Compile module into an object.
         let object_data = crate::ffi::module_to_object(&module, opt_level).unwrap();

--- a/src/cache/jit.rs
+++ b/src/cache/jit.rs
@@ -45,7 +45,10 @@ where
         program: &Program,
         opt_level: OptLevel,
     ) -> Arc<JitNativeExecutor<'a>> {
-        let module = self.context.compile(program).expect("should compile");
+        let module = self
+            .context
+            .compile(program, false)
+            .expect("should compile");
         let executor = JitNativeExecutor::from_native_module(module, opt_level);
 
         let executor = Arc::new(executor);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -127,6 +127,7 @@ pub fn compile(
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     metadata: &mut MetadataStorage,
     di_compile_unit_id: Attribute,
+    ignore_debug_names: bool,
 ) -> Result<(), Error> {
     if let Ok(x) = std::env::var("NATIVE_DEBUG_DUMP") {
         if x == "1" || x == "true" {
@@ -155,6 +156,7 @@ pub fn compile(
             metadata,
             di_compile_unit_id,
             sierra_stmt_start_offset,
+            ignore_debug_names,
         )?;
     }
 
@@ -168,6 +170,8 @@ pub fn compile(
 /// and name. Check out [compile](self::compile) for a description of the other arguments.
 ///
 /// The [module docs](self) contain more information about the compilation process.
+///
+/// If [`ignore_debug_names`] is true, then the function name will always be `f{id}` without any debug name info if it ever exists.
 #[allow(clippy::too_many_arguments)]
 fn compile_func(
     context: &Context,
@@ -178,6 +182,7 @@ fn compile_func(
     metadata: &mut MetadataStorage,
     di_compile_unit_id: Attribute,
     sierra_stmt_start_offset: usize,
+    ignore_debug_names: bool,
 ) -> Result<(), Error> {
     let fn_location = Location::new(
         context,
@@ -278,7 +283,10 @@ fn compile_func(
         None
     };
 
-    let function_name = generate_function_name(&function.id);
+    let function_name = generate_function_name(&function.id, ignore_debug_names);
+    // Don't care about whether it is for the contract executor for inner impls
+    // so we don't have to pass the boolean to the function call libfunc.
+    let function_name_for_inner = generate_function_name(&function.id, false);
 
     let di_subprogram = unsafe {
         // Various DWARF debug attributes for this function.
@@ -876,7 +884,7 @@ fn compile_func(
         pre_entry_block.append_operation(cf::br(&entry_block, &arg_values, fn_location));
     }
 
-    let inner_function_name = format!("impl${function_name}");
+    let inner_function_name = format!("impl${function_name_for_inner}");
     module.body().append_operation(llvm::func(
         context,
         StringAttribute::new(context, &inner_function_name),

--- a/src/context.rs
+++ b/src/context.rs
@@ -62,7 +62,14 @@ impl NativeContext {
 
     /// Compiles a sierra program into MLIR and then lowers to LLVM.
     /// Returns the corresponding NativeModule struct.
-    pub fn compile(&self, program: &Program) -> Result<NativeModule, Error> {
+    ///
+    /// If `ignore_debug_names` is true then debug names will not be added to function names.
+    /// Mainly useful for the ContractExecutor.
+    pub fn compile(
+        &self,
+        program: &Program,
+        ignore_debug_names: bool,
+    ) -> Result<NativeModule, Error> {
         static INITIALIZED: OnceLock<()> = OnceLock::new();
         INITIALIZED.get_or_init(|| unsafe {
             LLVM_InitializeAllTargets();
@@ -170,6 +177,7 @@ impl NativeContext {
             &registry,
             &mut metadata,
             unsafe { Attribute::from_raw(di_unit_id) },
+            ignore_debug_names,
         )?;
 
         if let Ok(x) = std::env::var("NATIVE_DEBUG_DUMP") {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -705,7 +705,7 @@ mod tests {
     fn test_invoke_dynamic_aot_native_executor(program: Program) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&program)
+            .compile(&program, false)
             .expect("failed to compile context");
         let executor = AotNativeExecutor::from_native_module(module, OptLevel::default());
 
@@ -725,7 +725,7 @@ mod tests {
     fn test_invoke_dynamic_jit_native_executor(program: Program) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&program)
+            .compile(&program, false)
             .expect("failed to compile context");
         let executor = JitNativeExecutor::from_native_module(module, OptLevel::default());
 
@@ -745,7 +745,7 @@ mod tests {
     fn test_invoke_contract_dynamic_aot(starknet_program: Program) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&starknet_program)
+            .compile(&starknet_program, false)
             .expect("failed to compile context");
         let executor = AotNativeExecutor::from_native_module(module, OptLevel::default());
 
@@ -774,7 +774,7 @@ mod tests {
     fn test_invoke_contract_dynamic_jit(starknet_program: Program) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&starknet_program)
+            .compile(&starknet_program, false)
             .expect("failed to compile context");
         let executor = JitNativeExecutor::from_native_module(module, OptLevel::default());
 

--- a/src/executor/aot.rs
+++ b/src/executor/aot.rs
@@ -139,7 +139,7 @@ impl AotNativeExecutor {
     }
 
     pub fn find_function_ptr(&self, function_id: &FunctionId) -> *mut c_void {
-        let function_name = generate_function_name(function_id);
+        let function_name = generate_function_name(function_id, false);
         let function_name = format!("_mlir_ciface_{function_name}");
 
         // Arguments and return values are hardcoded since they'll be handled by the trampoline.
@@ -215,7 +215,7 @@ mod tests {
     fn test_invoke_dynamic(program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&program)
+            .compile(&program, false)
             .expect("failed to compile context");
         let executor = AotNativeExecutor::from_native_module(module, optlevel);
 
@@ -236,7 +236,7 @@ mod tests {
     fn test_invoke_dynamic_with_syscall_handler(program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&program)
+            .compile(&program, false)
             .expect("failed to compile context");
         let executor = AotNativeExecutor::from_native_module(module, optlevel);
 
@@ -275,7 +275,7 @@ mod tests {
     fn test_invoke_contract_dynamic(starknet_program: Program, #[case] optlevel: OptLevel) {
         let native_context = NativeContext::new();
         let module = native_context
-            .compile(&starknet_program)
+            .compile(&starknet_program, false)
             .expect("failed to compile context");
         let executor = AotNativeExecutor::from_native_module(module, optlevel);
 

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -75,6 +75,7 @@ pub struct ContractExecutor {
     #[educe(Debug(ignore))]
     library: Arc<Library>,
     path: PathBuf,
+    is_temp_path: bool,
     entry_points_info: BTreeMap<u64, EntryPointInfo>,
 }
 
@@ -100,10 +101,13 @@ pub enum BuiltinType {
 
 impl ContractExecutor {
     /// Create the executor from a sierra program with the given optimization level.
-    /// You can save the library on the desired location later using `save`
+    /// You can save the library on the desired location later using `save`.
+    /// If not saved, the path is treated as
+    /// a temporary file an deleted when dropped.
+    /// If you loaded a ContractExecutor using [`load`] then it will not be treated as a temp file.
     pub fn new(sierra_program: &Program, opt_level: OptLevel) -> Result<Self> {
         let native_context = NativeContext::new();
-        let module = native_context.compile(sierra_program)?;
+        let module = native_context.compile(sierra_program, true)?;
 
         let NativeModule {
             module,
@@ -167,18 +171,22 @@ impl ContractExecutor {
         Ok(Self {
             library: Arc::new(unsafe { Library::new(&library_path)? }),
             path: library_path,
+            is_temp_path: true,
             entry_points_info: infos,
         })
     }
 
     /// Save the library to the desired path, alongside it is saved also a json file with additional info.
-    pub fn save(&self, to: impl AsRef<Path>) -> Result<()> {
+    pub fn save(&mut self, to: impl AsRef<Path>) -> Result<()> {
         let to = to.as_ref();
         std::fs::copy(&self.path, to)?;
 
         let info = serde_json::to_string(&self.entry_points_info)?;
         let path = to.with_extension("json");
         std::fs::write(path, info)?;
+
+        self.path = to.to_path_buf();
+        self.is_temp_path = false;
 
         Ok(())
     }
@@ -190,6 +198,7 @@ impl ContractExecutor {
         Ok(Self {
             library: Arc::new(unsafe { Library::new(library_path)? }),
             path: library_path.to_path_buf(),
+            is_temp_path: false,
             entry_points_info: info,
         })
     }
@@ -205,7 +214,7 @@ impl ContractExecutor {
         let arena = Bump::new();
         let mut invoke_data = Vec::<u8>::new();
 
-        let function_ptr = self.find_function_ptr(function_id)?;
+        let function_ptr = self.find_function_ptr(function_id, true)?;
 
         //  it can vary from contract to contract thats why we need to store/ load it.
         // substract 2, which are the gas and syscall builtin
@@ -405,8 +414,12 @@ impl ContractExecutor {
         })
     }
 
-    pub fn find_function_ptr(&self, function_id: &FunctionId) -> Result<*mut c_void> {
-        let function_name = generate_function_name(function_id);
+    pub fn find_function_ptr(
+        &self,
+        function_id: &FunctionId,
+        is_for_contract_executor: bool,
+    ) -> Result<*mut c_void> {
+        let function_name = generate_function_name(function_id, is_for_contract_executor);
         let function_name = format!("_mlir_ciface_{function_name}");
 
         // Arguments and return values are hardcoded since they'll be handled by the trampoline.
@@ -416,6 +429,15 @@ impl ContractExecutor {
                 .into_raw()
                 .into_raw()
         })
+    }
+}
+
+impl Drop for ContractExecutor {
+    fn drop(&mut self) {
+        if self.is_temp_path {
+            std::fs::remove_file(&self.path).ok();
+            std::fs::remove_file(self.path.with_extension("json")).ok();
+        }
     }
 }
 

--- a/src/executor/jit.rs
+++ b/src/executor/jit.rs
@@ -138,7 +138,7 @@ impl<'m> JitNativeExecutor<'m> {
     }
 
     pub fn find_function_ptr(&self, function_id: &FunctionId) -> *mut c_void {
-        let function_name = generate_function_name(function_id);
+        let function_name = generate_function_name(function_id, false);
         let function_name = format!("_mlir_ciface_{function_name}");
 
         // Arguments and return values are hardcoded since they'll be handled by the trampoline.

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -639,6 +639,6 @@ mod test {
         };
 
         let native_context = NativeContext::new();
-        native_context.compile(&program).unwrap();
+        native_context.compile(&program, false).unwrap();
     }
 }

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -192,7 +192,7 @@ pub fn build<'ctx, 'this>(
                         Identifier::new(context, "callee"),
                         FlatSymbolRefAttribute::new(
                             context,
-                            &format!("impl${}", generate_function_name(&info.function.id)),
+                            &format!("impl${}", generate_function_name(&info.function.id, false)),
                         )
                         .into(),
                     ),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,10 +43,16 @@ pub const SHARED_LIBRARY_EXT: &str = "so";
 ///
 /// If the program includes function identifiers, return those. Otherwise return `f` followed by the
 /// identifier number.
-pub fn generate_function_name(function_id: &FunctionId) -> Cow<str> {
+pub fn generate_function_name(
+    function_id: &FunctionId,
+    is_for_contract_executor: bool,
+) -> Cow<str> {
     // Generic functions can omit their type in the debug_name, leading to multiple functions
     // having the same name, we solve this by adding the id number even if the function has a debug_name
-    if let Some(name) = function_id.debug_name.as_deref() {
+
+    if is_for_contract_executor {
+        Cow::Owned(format!("f{}", function_id.id))
+    } else if let Some(name) = function_id.debug_name.as_deref() {
         Cow::Owned(format!("{}(f{})", name, function_id.id))
     } else {
         Cow::Owned(format!("f{}", function_id.id))
@@ -659,7 +665,7 @@ pub mod test {
         let context = NativeContext::new();
 
         let module = context
-            .compile(program)
+            .compile(program, false)
             .expect("Could not compile test program to MLIR.");
 
         // FIXME: There are some bugs with non-zero LLVM optimization levels.
@@ -973,7 +979,20 @@ pub mod test {
             debug_name: Some("function_name".into()),
         };
 
-        assert_eq!(generate_function_name(&function_id), "function_name(f123)");
+        assert_eq!(
+            generate_function_name(&function_id, false),
+            "function_name(f123)"
+        );
+    }
+
+    #[test]
+    fn test_generate_function_name_debug_name_for_contract_executor() {
+        let function_id = FunctionId {
+            id: 123,
+            debug_name: Some("function_name".into()),
+        };
+
+        assert_eq!(generate_function_name(&function_id, true), "f123");
     }
 
     #[test]
@@ -983,7 +1002,7 @@ pub mod test {
             debug_name: None,
         };
 
-        assert_eq!(generate_function_name(&function_id), "f123");
+        assert_eq!(generate_function_name(&function_id, false), "f123");
     }
 
     #[test]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -230,7 +230,7 @@ pub fn run_native_program(
     let context = NativeContext::new();
 
     let module = context
-        .compile(program)
+        .compile(program, false)
         .expect("Could not compile test program to MLIR.");
 
     assert!(
@@ -426,7 +426,7 @@ pub fn run_native_starknet_contract(
 ) -> ContractExecutionResult {
     let native_context = NativeContext::new();
 
-    let native_program = native_context.compile(sierra_program).unwrap();
+    let native_program = native_context.compile(sierra_program, false).unwrap();
 
     let entry_point_fn = find_entry_point_by_idx(sierra_program, entry_point_function_idx).unwrap();
     let entry_point_id = &entry_point_fn.id;

--- a/tests/tests/compile_library.rs
+++ b/tests/tests/compile_library.rs
@@ -14,7 +14,7 @@ pub fn compile_library() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let module = context.compile(&program.1)?;
+    let module = context.compile(&program.1, false)?;
 
     let object = cairo_native::module_to_object(module.module(), Default::default())?;
 

--- a/tests/tests/trampoline.rs
+++ b/tests/tests/trampoline.rs
@@ -14,7 +14,7 @@ fn run_program(program: &Program, entry_point: &str, args: &[JitValue]) -> Execu
     let entry_point_id = find_function_id(program, entry_point).expect("entry point not found");
 
     let context = NativeContext::new();
-    let module = context.compile(program).unwrap();
+    let module = context.compile(program, false).unwrap();
     // FIXME: There are some bugs with non-zero LLVM optimization levels.
     let executor = JitNativeExecutor::from_native_module(module, OptLevel::None);
 


### PR DESCRIPTION
Add option to never have debug names in functions and enable it on ContractExecutor, fix dangling temp library file

<!--
Description of the pull request changes and motivation.
-->


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
