### PR TITLE
Use starknet_types_core pedersen and hades permutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "rand",
- "starknet-crypto 0.7.1",
  "starknet-curve 0.5.0",
  "starknet-types-core",
 ]
@@ -1031,7 +1030,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "starknet-crypto 0.6.2",
+ "starknet-crypto",
  "starknet-types-core",
  "thiserror-no-std",
  "zip",
@@ -3495,29 +3494,9 @@ dependencies = [
  "num-traits 0.2.19",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen 0.3.3",
+ "starknet-crypto-codegen",
  "starknet-curve 0.4.2",
  "starknet-ff",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2a821ad8d98c6c3e4d0e5097f3fe6e2ed120ada9d32be87cd1330c7923a2f0"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.19",
- "rfc6979",
- "sha2",
- "starknet-crypto-codegen 0.4.0",
- "starknet-curve 0.5.0",
- "starknet-types-core",
  "zeroize",
 ]
 
@@ -3529,17 +3508,6 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e179dedc3fa6da064e56811d3e05d446aa2f7459e4eb0e3e49378a337235437"
-dependencies = [
- "starknet-curve 0.5.0",
- "starknet-types-core",
  "syn 2.0.77",
 ]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,11 +10,10 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
 starknet-types-core = { version = "0.1.5", default-features = false, features = [
-    "std", "serde",
+    "std", "serde", "hash"
 ] }
 cairo-lang-sierra-gas = "2.8.2"
 libc = "0.2.158"
-starknet-crypto = "0.7.1"
 starknet-curve = "0.5.0"
 lazy_static = "1.5.0"
 rand = "0.8.5"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,6 +9,7 @@ use starknet_curve::curve_params::BETA;
 use starknet_types_core::{
     curve::{AffinePoint, ProjectivePoint},
     felt::Felt,
+    hash::StarkHash,
 };
 use std::ops::Mul;
 use std::{collections::HashMap, fs::File, io::Write, os::fd::FromRawFd, ptr::NonNull, slice};
@@ -110,7 +111,7 @@ pub unsafe extern "C" fn cairo_native__libfunc__pedersen(
     let rhs = Felt::from_bytes_le_slice(rhs);
 
     // Compute pedersen hash and copy the result into `dst`.
-    let res = starknet_crypto::pedersen_hash(&lhs, &rhs);
+    let res = starknet_types_core::hash::Pedersen::hash(&lhs, &rhs);
     dst.copy_from_slice(&res.to_bytes_le());
 }
 
@@ -145,7 +146,7 @@ pub unsafe extern "C" fn cairo_native__libfunc__hades_permutation(
     ];
 
     // Compute Poseidon permutation.
-    starknet_crypto::poseidon_permute_comp(&mut state);
+    starknet_types_core::hash::Poseidon::hades_permutation(&mut state);
 
     // Write back the results.
     op0.copy_from_slice(&state[0].to_bytes_le());


### PR DESCRIPTION
Changes runtime to use starknet_types_core rather than starknet_crypto. This doesn't affect performance, as starknet_crypto uses starknet_types_core in its implementation


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
