### PR TITLE
Fix clone and drop implementations for enums, structs and snapshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ required-features = ["scarb"]
 [features]
 default = ["build-cli", "with-runtime"]
 build-cli = [
-  "dep:clap",
-  "dep:tracing-subscriber",
-  "dep:anyhow",
-  "dep:cairo-lang-test-plugin",
-  "dep:cairo-lang-runner",
-  "dep:colored",
+    "dep:clap",
+    "dep:tracing-subscriber",
+    "dep:anyhow",
+    "dep:cairo-lang-test-plugin",
+    "dep:cairo-lang-runner",
+    "dep:colored",
 ]
 scarb = ["build-cli", "dep:scarb-ui", "dep:scarb-metadata"]
 with-debug-utils = []
@@ -70,16 +70,14 @@ itertools = "0.13.0"
 lazy_static = "1.4"
 libc = "0.2"
 llvm-sys = "191.0.0"
-melior = { version = "0.19.0", features = [
-  "ods-dialects",
-] }
-mlir-sys = { version = "0.3.0"}
+melior = { version = "0.19.0", features = ["ods-dialects"] }
+mlir-sys = { version = "0.3.0" }
 num-bigint = "0.4.4"
 num-traits = "0.2"
 starknet-types-core = { version = "0.1.5", default-features = false, features = [
-  "std",
-  "serde",
-  "num-traits",
+    "std",
+    "serde",
+    "num-traits",
 ] }
 tempfile = "3.6"
 thiserror = "1.0.64"
@@ -97,9 +95,9 @@ cairo-native-runtime = { version = "0.2.0-alpha.2", path = "runtime", optional =
 clap = { version = "4.5.18", features = ["derive"], optional = true }
 libloading = "0.8.3"
 tracing-subscriber = { version = "0.3.18", features = [
-  "env-filter",
-  "json",
-  "registry",
+    "env-filter",
+    "json",
+    "registry",
 ], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "1.0", optional = true }
@@ -110,7 +108,7 @@ colored = { version = "2.1.0", optional = true }
 keccak = "0.1.5"
 k256 = "0.13.4"
 p256 = "0.13.2"
-sha2 = "0.10.8" # needed for the syscall handler stub
+sha2 = "0.10.8"                                          # needed for the syscall handler stub
 scarb-metadata = { version = "1.12.0", optional = true }
 scarb-ui = { version = "0.1.5", optional = true }
 sec1 = "0.7.3"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -134,73 +134,72 @@ pub unsafe extern "C" fn cairo_native__libfunc__hades_permutation(
 }
 
 /// Felt252 type used in cairo native runtime
-pub type FeltDict = (HashMap<[u8; 32], NonNull<std::ffi::c_void>>, u64);
-
-/// Allocates a new dictionary. Internally a rust hashmap: `HashMap<[u8; 32], NonNull<()>`
-///
-/// # Safety
-///
-/// This function is intended to be called from MLIR, deals with pointers, and is therefore
-/// definitely unsafe to use manually.
-#[no_mangle]
-pub unsafe extern "C" fn cairo_native__alloc_dict() -> *mut std::ffi::c_void {
-    Box::into_raw(Box::<FeltDict>::default()) as _
+#[derive(Debug, Default)]
+pub struct FeltDict {
+    pub inner: HashMap<[u8; 32], NonNull<std::ffi::c_void>>,
+    pub count: u64,
 }
 
-/// Frees the dictionary.
+/// Allocate a new dictionary.
 ///
 /// # Safety
 ///
 /// This function is intended to be called from MLIR, deals with pointers, and is therefore
 /// definitely unsafe to use manually.
 #[no_mangle]
-pub unsafe extern "C" fn cairo_native__dict_free(ptr: *mut FeltDict) {
-    let mut map = Box::from_raw(ptr);
+pub unsafe extern "C" fn cairo_native__dict_new() -> *mut FeltDict {
+    Box::into_raw(Box::<FeltDict>::default())
+}
+
+/// Free a dictionary using an optional callback to drop each element.
+///
+/// # Safety
+///
+/// This function is intended to be called from MLIR, deals with pointers, and is therefore
+/// definitely unsafe to use manually.
+#[no_mangle]
+pub unsafe extern "C" fn cairo_native__dict_drop(
+    ptr: *mut FeltDict,
+    drop_fn: Option<extern "C" fn(*mut std::ffi::c_void)>,
+) {
+    let map = Box::from_raw(ptr);
 
     // Free the entries manually.
-    for (_, entry) in map.as_mut().0.drain() {
-        libc::free(entry.as_ptr().cast());
+    for entry in map.inner.into_values() {
+        if let Some(drop_fn) = drop_fn {
+            drop_fn(entry.as_ptr());
+        }
+
+        libc::free(entry.as_ptr());
     }
 }
 
-/// Needed for the correct alignment,
-/// since the key [u8; 32] in rust has 8 byte alignment but its a felt,
-/// so in reality it has 16.
-#[repr(C, align(16))]
-pub struct DictValuesArrayAbi {
-    pub key: [u8; 32],
-    pub value: std::ptr::NonNull<libc::c_void>,
-}
-
-/// Returns a array over the values of the dict, used for deep cloning.
+/// Duplicate a dictionary using a provided callback to clone each element.
 ///
 /// # Safety
 ///
 /// This function is intended to be called from MLIR, deals with pointers, and is therefore
 /// definitely unsafe to use manually.
 #[no_mangle]
-pub unsafe extern "C" fn cairo_native__dict_values(
+pub unsafe extern "C" fn cairo_native__dict_dup(
     ptr: *mut FeltDict,
-    len: *mut u64,
-) -> *mut DictValuesArrayAbi {
-    let dict: &mut FeltDict = &mut *ptr;
+    dup_fn: extern "C" fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void,
+) -> *mut FeltDict {
+    let old_dict = &*ptr;
+    let mut new_dict = Box::<FeltDict>::default();
 
-    let values: Vec<_> = dict
-        .0
-        .clone()
-        .into_iter()
-        // make it ffi safe for use within MLIR.
-        .map(|x| DictValuesArrayAbi {
-            key: x.0,
-            value: x.1,
-        })
-        .collect();
-    *len = values.len() as u64;
-    values.leak::<'static>().as_mut_ptr()
+    new_dict.inner.extend(
+        old_dict
+            .inner
+            .iter()
+            .map(|(&k, &v)| (k, NonNull::new(dup_fn(v.as_ptr())).unwrap())),
+    );
+
+    Box::into_raw(new_dict)
 }
 
-/// Gets the value for a given key, the returned pointer is null if not found.
-/// Increments the access count.
+/// Return the value (reference) for a given key, or null if not present. Increment the access
+/// count.
 ///
 /// # Safety
 ///
@@ -212,13 +211,11 @@ pub unsafe extern "C" fn cairo_native__dict_get(
     key: &[u8; 32],
 ) -> *mut std::ffi::c_void {
     let dict: &mut FeltDict = &mut *ptr;
-    let map = &dict.0;
-    dict.1 += 1;
+    dict.count += 1;
 
-    if let Some(v) = map.get(key) {
-        v.as_ptr()
-    } else {
-        std::ptr::null_mut()
+    match dict.inner.get(key) {
+        Some(v) => v.as_ptr(),
+        None => std::ptr::null_mut(),
     }
 }
 
@@ -235,7 +232,7 @@ pub unsafe extern "C" fn cairo_native__dict_insert(
     value: NonNull<std::ffi::c_void>,
 ) -> *mut std::ffi::c_void {
     let dict = &mut *ptr;
-    let old_ptr = dict.0.insert(*key, value);
+    let old_ptr = dict.inner.insert(*key, value);
 
     if let Some(v) = old_ptr {
         v.as_ptr()
@@ -253,7 +250,7 @@ pub unsafe extern "C" fn cairo_native__dict_insert(
 #[no_mangle]
 pub unsafe extern "C" fn cairo_native__dict_gas_refund(ptr: *const FeltDict) -> u64 {
     let dict = &*ptr;
-    (dict.1 - dict.0.len() as u64) * *DICT_GAS_REFUND_PER_ACCESS
+    (dict.count - dict.inner.len() as u64) * *DICT_GAS_REFUND_PER_ACCESS
 }
 
 /// Compute `ec_point_from_x_nz(x)` and store it.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -157,6 +157,9 @@ pub unsafe extern "C" fn cairo_native__dict_new() -> *mut FeltDict {
 ///
 /// This function is intended to be called from MLIR, deals with pointers, and is therefore
 /// definitely unsafe to use manually.
+// Note: Using `Option<extern "C" fn(*mut std::ffi::c_void)>` is ffi-safe thanks to Option's null
+//   pointer optimization. Check out
+//   https://doc.rust-lang.org/nomicon/ffi.html#the-nullable-pointer-optimization for more info.
 #[no_mangle]
 pub unsafe extern "C" fn cairo_native__dict_drop(
     ptr: *mut FeltDict,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -491,6 +491,9 @@ pub fn build_get<'ctx, 'this>(
         // TODO: Support clone-only types (those that are not copy).
         valid_block.memcpy(context, location, elem_ptr, target_ptr, elem_size);
 
+        // TODO: Drop array values.
+        valid_block.append_operation(ReallocBindingsMeta::free(context, ptr, location));
+
         valid_block.append_operation(helper.br(0, &[range_check, target_ptr], location));
     }
 

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -521,7 +521,7 @@ pub fn build_get<'ctx, 'this>(
                             location,
                         )]));
 
-                        let value_ptr = block.append_operation(llvm::get_element_ptr_dynamic(
+                        let value_ptr = block.append_op_result(llvm::get_element_ptr_dynamic(
                             context,
                             ptr,
                             &[block.argument(0)?.into()],
@@ -533,7 +533,7 @@ pub fn build_get<'ctx, 'this>(
                         let is_target_element = block.append_op_result(
                             ods::llvm::icmp(
                                 context,
-                                IntegerType::new(context, 0).into(),
+                                IntegerType::new(context, 1).into(),
                                 value_ptr,
                                 elem_ptr,
                                 IntegerAttribute::new(IntegerType::new(context, 64).into(), 0)

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -7,8 +7,7 @@ use super::LibfuncHelper;
 use crate::{
     error::Result,
     metadata::{
-        drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
-        realloc_bindings::ReallocBindingsMeta, MetadataStorage,
+        drop_overrides::DropOverridesMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     types::TypeBuilder,
     utils::{BlockExt, ProgramRegistryExt},

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1135,6 +1135,12 @@ pub fn build_span_from_tuple<'ctx, 'this>(
         // load box
         entry.load(context, location, entry.argument(0)?.into(), struct_ty)?
     };
+    // TODO: Maybe reuse the pointer?
+    entry.append_operation(ReallocBindingsMeta::free(
+        context,
+        entry.argument(0)?.into(),
+        location,
+    ));
 
     let fields = struct_type_info.fields().expect("should have fields");
     let (field_ty, field_layout) =

--- a/src/libfuncs/drop.rs
+++ b/src/libfuncs/drop.rs
@@ -6,7 +6,11 @@
 //! However, types like an array need manual dropping.
 
 use super::LibfuncHelper;
-use crate::{error::Result, metadata::MetadataStorage, types::TypeBuilder};
+use crate::{
+    error::Result,
+    metadata::{drop_overrides::DropOverridesMeta, MetadataStorage},
+    utils::ProgramRegistryExt,
+};
 use cairo_lang_sierra::{
     extensions::{
         core::{CoreLibfunc, CoreType},
@@ -29,21 +33,24 @@ pub fn build<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    // Note: Complex types implement drop within the type itself (in `build_drop`).
-
-    let ty = registry.get_type(&info.signature.param_signatures[0].ty)?;
-    ty.build_drop(
+    registry.build_type(
         context,
-        registry,
-        entry,
-        location,
         helper,
+        registry,
         metadata,
         &info.signature.param_signatures[0].ty,
-        entry.argument(0)?.into(),
     )?;
 
-    entry.append_operation(helper.br(0, &[], location));
+    if let Some(drop_overrides_meta) = metadata.get::<DropOverridesMeta>() {
+        drop_overrides_meta.invoke_override(
+            context,
+            entry,
+            location,
+            &info.signature.param_signatures[0].ty,
+            entry.argument(0)?.into(),
+        )?;
+    }
 
+    entry.append_operation(helper.br(0, &[], location));
     Ok(())
 }

--- a/src/libfuncs/drop.rs
+++ b/src/libfuncs/drop.rs
@@ -40,6 +40,7 @@ pub fn build<'ctx, 'this>(
         helper,
         metadata,
         &info.signature.param_signatures[0].ty,
+        entry.argument(0)?.into(),
     )?;
 
     entry.append_operation(helper.br(0, &[], location));

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -42,16 +42,7 @@ pub fn build<'ctx, 'this>(
     {
         Some(clone_fn) => {
             let original_value = entry.argument(0)?.into();
-            metadata
-                .get_mut::<crate::metadata::debug_utils::DebugUtils>()
-                .unwrap()
-                .debug_print(
-                    context,
-                    helper,
-                    entry,
-                    &format!("cloning {}", info.signature.param_signatures[0].ty),
-                    location,
-                )?;
+            dbg!(&info.signature.param_signatures[0].ty);
             let (entry, cloned_value) = clone_fn(
                 context,
                 registry,

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -42,7 +42,6 @@ pub fn build<'ctx, 'this>(
     {
         Some(clone_fn) => {
             let original_value = entry.argument(0)?.into();
-            dbg!(&info.signature.param_signatures[0].ty);
             let (entry, cloned_value) = clone_fn(
                 context,
                 registry,

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -41,6 +41,7 @@ pub fn build<'ctx, 'this>(
         .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
     {
         Some(clone_fn) => {
+            let original_value = entry.argument(0)?.into();
             let (entry, cloned_value) = clone_fn(
                 context,
                 registry,
@@ -48,14 +49,10 @@ pub fn build<'ctx, 'this>(
                 location,
                 helper,
                 metadata,
-                entry.argument(0)?.into(),
+                original_value,
             )?;
 
-            entry.append_operation(helper.br(
-                0,
-                &[entry.argument(0)?.into(), cloned_value],
-                location,
-            ));
+            entry.append_operation(helper.br(0, &[original_value, cloned_value], location));
         }
         None => {
             entry.append_operation(helper.br(

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -42,6 +42,16 @@ pub fn build<'ctx, 'this>(
     {
         Some(clone_fn) => {
             let original_value = entry.argument(0)?.into();
+            metadata
+                .get_mut::<crate::metadata::debug_utils::DebugUtils>()
+                .unwrap()
+                .debug_print(
+                    context,
+                    helper,
+                    entry,
+                    &format!("cloning {}", info.signature.param_signatures[0].ty),
+                    location,
+                )?;
             let (entry, cloned_value) = clone_fn(
                 context,
                 registry,

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -8,7 +8,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::Result,
-    metadata::{snapshot_clones::SnapshotClonesMeta, MetadataStorage},
+    metadata::{dup_overrides::DupOverrideMeta, MetadataStorage},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -37,7 +37,7 @@ pub fn build<'ctx, 'this>(
     //   That's why we need to check for clone implementations within the compiler.
 
     match metadata
-        .get::<SnapshotClonesMeta>()
+        .get::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
     {
         Some(clone_fn) => {

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -25,7 +25,7 @@ use melior::{
 /// Generate MLIR operations for the `dup` libfunc.
 pub fn build<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
@@ -36,32 +36,16 @@ pub fn build<'ctx, 'this>(
     //   not all of them. For example, it'll not generate a clone implementation for `Box<T>`.
     //   That's why we need to check for clone implementations within the compiler.
 
-    match metadata
-        .get::<DupOverrideMeta>()
-        .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
-    {
-        Some(clone_fn) => {
-            let original_value = entry.argument(0)?.into();
-            let (entry, cloned_value) = clone_fn(
-                context,
-                registry,
-                entry,
-                location,
-                helper,
-                metadata,
-                original_value,
-            )?;
-
-            entry.append_operation(helper.br(0, &[original_value, cloned_value], location));
-        }
-        None => {
-            entry.append_operation(helper.br(
-                0,
-                &[entry.argument(0)?.into(), entry.argument(0)?.into()],
-                location,
-            ));
-        }
-    }
+    let values = metadata
+        .get_or_insert_with(DupOverrideMeta::default)
+        .invoke_override(
+            context,
+            entry,
+            location,
+            &info.signature.param_signatures[0].ty,
+            entry.argument(0)?.into(),
+        )?;
+    entry.append_operation(helper.br(0, &[values.0, values.1], location));
 
     Ok(())
 }

--- a/src/libfuncs/dup.rs
+++ b/src/libfuncs/dup.rs
@@ -8,7 +8,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::Result,
-    metadata::{dup_overrides::DupOverrideMeta, MetadataStorage},
+    metadata::{dup_overrides::DupOverridesMeta, MetadataStorage},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -37,7 +37,7 @@ pub fn build<'ctx, 'this>(
     //   That's why we need to check for clone implementations within the compiler.
 
     let values = metadata
-        .get_or_insert_with(DupOverrideMeta::default)
+        .get_or_insert_with(DupOverridesMeta::default)
         .invoke_override(
             context,
             entry,

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -56,7 +56,7 @@ pub fn build_new<'ctx, 'this>(
         .get_mut::<RuntimeBindingsMeta>()
         .expect("Runtime library not available.");
 
-    let op = runtime_bindings.dict_alloc_new(context, helper, entry, location)?;
+    let op = runtime_bindings.dict_new(context, helper, entry, location)?;
     let dict_ptr = op.result(0)?.into();
 
     entry.append_operation(helper.br(0, &[segment_arena, dict_ptr], location));

--- a/src/libfuncs/snapshot_take.rs
+++ b/src/libfuncs/snapshot_take.rs
@@ -3,7 +3,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::Result,
-    metadata::{snapshot_clones::SnapshotClonesMeta, MetadataStorage},
+    metadata::{dup_overrides::DupOverrideMeta, MetadataStorage},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -31,7 +31,7 @@ pub fn build<'ctx, 'this>(
     // original value otherwise.
     let original_value = entry.argument(0)?.into();
     let (entry, cloned_value) = match metadata
-        .get_mut::<SnapshotClonesMeta>()
+        .get_mut::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.signature.param_signatures[0].ty))
     {
         Some(invoke_fn) => invoke_fn(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,11 +16,11 @@ use std::{
 
 pub mod auto_breakpoint;
 pub mod debug_utils;
+pub mod dup_overrides;
 pub mod enum_snapshot_variants;
 pub mod gas;
 pub mod realloc_bindings;
 pub mod runtime_bindings;
-pub mod snapshot_clones;
 pub mod tail_recursion;
 
 /// Metadata container.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,6 +16,7 @@ use std::{
 
 pub mod auto_breakpoint;
 pub mod debug_utils;
+pub mod drop_overrides;
 pub mod dup_overrides;
 pub mod enum_snapshot_variants;
 pub mod gas;

--- a/src/metadata/drop_overrides.rs
+++ b/src/metadata/drop_overrides.rs
@@ -1,3 +1,25 @@
+//! # Dropping logic overrides
+//!
+//! By default, values are discarded, but some cases (like arrays, boxes, nullables, dictionaries
+//! and some structs and enums) need a drop implementation instad. This metadata is a register of
+//! types that require a drop implementation as well as the logic to register and invoke those
+//! implementations.
+//!
+//! ## Drop implementations
+//!
+//! The drop logic is implemented as a function for each type that requires it. It has to be a
+//! function to allow self-referencing types. If we inlined the drop implementations,
+//! self-referencing types would generate infinite code thus overflowing the stack when generating
+//! code.
+//!
+//! The generated functions are not public (they are internal) and follow this naming convention:
+//!
+//! ```text
+//! drop${type id}
+//! ```
+//!
+//! where `{type id}` is the numeric value of the `ConcreteTypeId`.
+
 use super::MetadataStorage;
 use crate::{error::Result, utils::ProgramRegistryExt};
 use cairo_lang_sierra::{
@@ -22,6 +44,22 @@ pub struct DropOverridesMeta {
 }
 
 impl DropOverridesMeta {
+    /// Register a drop override using a closure.
+    ///
+    /// This function does several things:
+    ///   - Registers `DropOverrideMeta` if it wasn't already present.
+    ///   - If the type id was already registered it returns and does nothing.
+    ///   - Registers the type (without it being actually registered yet).
+    ///   - Calls the closure, which returns an `Option<Region>`.
+    ///   - If the closure returns a region, generates the function implementation.
+    ///   - If the closure returns `None`, it removes the registry entry for the type.
+    ///
+    /// The type need to be registered before calling the closure, otherwise self-referencing types
+    /// would cause stack overflow when registering themselves.
+    ///
+    /// The callback serves two purposes:
+    ///   - To generate the drop implementation, if necessary.
+    ///   - To check if we need to generate the implementation (for example, in structs and enums).
     pub(crate) fn register_with<'ctx>(
         context: &'ctx Context,
         module: &Module<'ctx>,
@@ -63,11 +101,13 @@ impl DropOverridesMeta {
         Ok(())
     }
 
-    /// Returns whether a type has a registered clone implementation.
+    /// Returns whether a type has a registered drop implementation.
     pub(crate) fn is_overriden(&self, id: &ConcreteTypeId) -> bool {
         self.overriden_types.contains(id)
     }
 
+    /// Generates code to invoke a drop implementation for a type, or does nothing if no
+    /// implementation was registered.
     pub(crate) fn invoke_override<'ctx, 'this>(
         &self,
         context: &'ctx Context,

--- a/src/metadata/drop_overrides.rs
+++ b/src/metadata/drop_overrides.rs
@@ -1,0 +1,91 @@
+use super::MetadataStorage;
+use crate::{error::Result, utils::ProgramRegistryExt};
+use cairo_lang_sierra::{
+    extensions::core::{CoreLibfunc, CoreType},
+    ids::ConcreteTypeId,
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    dialect::func,
+    ir::{
+        attribute::{FlatSymbolRefAttribute, StringAttribute, TypeAttribute},
+        r#type::FunctionType,
+        Block, Location, Module, Region, Value,
+    },
+    Context,
+};
+use std::collections::HashSet;
+
+#[derive(Debug, Default)]
+pub struct DropOverridesMeta {
+    overriden_types: HashSet<ConcreteTypeId>,
+}
+
+impl DropOverridesMeta {
+    pub(crate) fn register_with<'ctx>(
+        context: &'ctx Context,
+        module: &Module<'ctx>,
+        registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+        metadata: &mut MetadataStorage,
+        id: &ConcreteTypeId,
+        f: impl FnOnce(&mut MetadataStorage) -> Result<Option<Region<'ctx>>>,
+    ) -> Result<()> {
+        {
+            let drop_override_meta = metadata.get_or_insert_with(Self::default);
+            if drop_override_meta.overriden_types.contains(id) {
+                return Ok(());
+            }
+
+            drop_override_meta.overriden_types.insert(id.clone());
+        }
+
+        match f(metadata)? {
+            Some(region) => {
+                let ty = registry.build_type(context, module, registry, metadata, id)?;
+                module.body().append_operation(func::func(
+                    context,
+                    StringAttribute::new(context, &format!("drop${}", id.id)),
+                    TypeAttribute::new(FunctionType::new(context, &[ty], &[]).into()),
+                    region,
+                    &[],
+                    Location::unknown(context),
+                ));
+            }
+            None => {
+                // The following getter should always return a value, but the if statement is kept
+                // just in case the meta has been removed (which it shouldn't).
+                if let Some(drop_override_meta) = metadata.get_mut::<Self>() {
+                    drop_override_meta.overriden_types.remove(id);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns whether a type has a registered clone implementation.
+    pub(crate) fn is_overriden(&self, id: &ConcreteTypeId) -> bool {
+        self.overriden_types.contains(id)
+    }
+
+    pub(crate) fn invoke_override<'ctx, 'this>(
+        &self,
+        context: &'ctx Context,
+        block: &'this Block<'ctx>,
+        location: Location<'ctx>,
+        id: &ConcreteTypeId,
+        value: Value<'ctx, 'this>,
+    ) -> Result<()> {
+        if self.overriden_types.contains(id) {
+            block.append_operation(func::call(
+                context,
+                FlatSymbolRefAttribute::new(context, &format!("drop${}", id.id)),
+                &[value],
+                &[],
+                location,
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/src/metadata/dup_overrides.rs
+++ b/src/metadata/dup_overrides.rs
@@ -1,110 +1,203 @@
 use super::MetadataStorage;
-use crate::{error::Result, libfuncs::LibfuncHelper, types::WithSelf};
+use crate::{error::Result, utils::ProgramRegistryExt};
 use cairo_lang_sierra::{
     extensions::core::{CoreLibfunc, CoreType},
     ids::ConcreteTypeId,
     program_registry::ProgramRegistry,
 };
 use melior::{
-    ir::{Block, Location, Value},
+    dialect::func,
+    ir::{
+        attribute::{FlatSymbolRefAttribute, StringAttribute, TypeAttribute},
+        r#type::FunctionType,
+        Block, Location, Module, Region, Value, ValueLike,
+    },
     Context,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashSet;
 
-type DupFn<P> = for<'ctx, 'this> fn(
-    &'ctx Context,
-    &ProgramRegistry<CoreType, CoreLibfunc>,
-    &'this Block<'ctx>,
-    Location<'ctx>,
-    &LibfuncHelper<'ctx, 'this>,
-    &mut MetadataStorage,
-    WithSelf<P>,
-    Value<'ctx, 'this>,
-) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>;
-
-type DupFnWrapper = Arc<
-    dyn for<'ctx, 'this> Fn(
-        &'ctx Context,
-        &ProgramRegistry<CoreType, CoreLibfunc>,
-        &'this Block<'ctx>,
-        Location<'ctx>,
-        &LibfuncHelper<'ctx, 'this>,
-        &mut MetadataStorage,
-        Value<'this, 'ctx>,
-    ) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>,
->;
-
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DupOverrideMeta {
-    mappings: HashMap<ConcreteTypeId, DupFnWrapper>,
-    partials: Vec<ConcreteTypeId>,
+    overriden_types: HashSet<ConcreteTypeId>,
 }
 
 impl DupOverrideMeta {
-    pub(crate) fn register_with<P>(
+    pub(crate) fn register_with<'ctx>(
+        context: &'ctx Context,
+        module: &Module<'ctx>,
+        registry: &ProgramRegistry<CoreType, CoreLibfunc>,
         metadata: &mut MetadataStorage,
-        id: ConcreteTypeId,
-        f: impl FnOnce(&mut MetadataStorage) -> Result<Option<(DupFn<P>, P)>>,
-    ) -> Result<()>
-    where
-        P: 'static,
-    {
+        id: &ConcreteTypeId,
+        f: impl FnOnce(&mut MetadataStorage) -> Result<Option<Region<'ctx>>>,
+    ) -> Result<()> {
         {
             let dup_override_meta = metadata.get_or_insert_with(Self::default);
-            if dup_override_meta.is_registered(&id) {
+            if dup_override_meta.overriden_types.contains(id) {
                 return Ok(());
             }
 
-            dup_override_meta.partials.push(id);
+            dup_override_meta.overriden_types.insert(id.clone());
         }
 
-        let result = f(metadata)?;
-        {
-            // This unwrap is unreachble because the meta was created just before if it wasn't
-            // already present.
-            let dup_override_meta = metadata.get_mut::<Self>().unwrap();
-
-            let self_id = dup_override_meta.partials.pop().unwrap();
-            if let Some((clone_fn, params)) = result {
-                dup_override_meta.mappings.insert(
-                    self_id.clone(),
-                    Arc::new(
-                        move |context, registry, entry, location, helper, metadata, value| {
-                            clone_fn(
-                                context,
-                                registry,
-                                entry,
-                                location,
-                                helper,
-                                metadata,
-                                WithSelf::new(&self_id, &params),
-                                value,
-                            )
-                        },
-                    ),
-                );
+        match f(metadata)? {
+            Some(region) => {
+                let ty = registry.build_type(context, module, registry, metadata, id)?;
+                module.body().append_operation(func::func(
+                    context,
+                    StringAttribute::new(context, &format!("dup${}", id.id)),
+                    TypeAttribute::new(FunctionType::new(context, &[ty], &[ty, ty]).into()),
+                    region,
+                    &[],
+                    Location::unknown(context),
+                ));
+            }
+            None => {
+                // The following getter should always return a value, but the if statement is kept
+                // just in case the meta has been removed (which it shouldn't).
+                if let Some(dup_override_meta) = metadata.get_mut::<Self>() {
+                    dup_override_meta.overriden_types.remove(id);
+                }
             }
         }
 
         Ok(())
     }
 
-    pub(crate) fn register_dup(&mut self, id: ConcreteTypeId, from_id: &ConcreteTypeId) {
-        assert!(
-            !self.is_registered(&id),
-            "attempting to register a clone impl that is already registered",
-        );
-
-        if let Some(clone_fn) = self.mappings.get(from_id) {
-            self.mappings.insert(id, clone_fn.clone());
-        }
+    pub(crate) fn is_overriden(&self, id: &ConcreteTypeId) -> bool {
+        self.overriden_types.contains(id)
     }
 
-    pub(crate) fn is_registered(&self, id: &ConcreteTypeId) -> bool {
-        self.mappings.contains_key(id) || self.partials.contains(id)
-    }
+    pub(crate) fn invoke_override<'ctx, 'this>(
+        &self,
+        context: &'ctx Context,
+        block: &'this Block<'ctx>,
+        location: Location<'ctx>,
+        id: &ConcreteTypeId,
+        value: Value<'ctx, 'this>,
+    ) -> Result<(Value<'ctx, 'this>, Value<'ctx, 'this>)> {
+        Ok(if self.overriden_types.contains(id) {
+            let res = block.append_operation(func::call(
+                context,
+                FlatSymbolRefAttribute::new(context, &format!("dup${}", id.id)),
+                &[value],
+                &[value.r#type(), value.r#type()],
+                location,
+            ));
 
-    pub(crate) fn wrap_invoke(&self, id: &ConcreteTypeId) -> Option<DupFnWrapper> {
-        self.mappings.get(id).cloned()
+            (res.result(0)?.into(), res.result(1)?.into())
+        } else {
+            (value, value)
+        })
     }
 }
+
+// use super::MetadataStorage;
+// use crate::{error::Result, libfuncs::LibfuncHelper, types::WithSelf};
+// use cairo_lang_sierra::{
+//     extensions::core::{CoreLibfunc, CoreType},
+//     ids::ConcreteTypeId,
+//     program_registry::ProgramRegistry,
+// };
+// use melior::{
+//     ir::{Block, Location, Value},
+//     Context,
+// };
+// use std::{collections::HashMap, sync::Arc};
+//
+// type DupFn<P> = for<'ctx, 'this> fn(
+//     &'ctx Context,
+//     &ProgramRegistry<CoreType, CoreLibfunc>,
+//     &'this Block<'ctx>,
+//     Location<'ctx>,
+//     &LibfuncHelper<'ctx, 'this>,
+//     &mut MetadataStorage,
+//     WithSelf<P>,
+//     Value<'ctx, 'this>,
+// ) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>;
+//
+// type DupFnWrapper = Arc<
+//     dyn for<'ctx, 'this> Fn(
+//         &'ctx Context,
+//         &ProgramRegistry<CoreType, CoreLibfunc>,
+//         &'this Block<'ctx>,
+//         Location<'ctx>,
+//         &LibfuncHelper<'ctx, 'this>,
+//         &mut MetadataStorage,
+//         Value<'this, 'ctx>,
+//     ) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)>,
+// >;
+
+// #[derive(Default)]
+// pub struct DupOverrideMeta {
+//     mappings: HashMap<ConcreteTypeId, DupFnWrapper>,
+//     partials: Vec<ConcreteTypeId>,
+// }
+
+// impl DupOverrideMeta {
+//     pub(crate) fn register_with<P>(
+//         metadata: &mut MetadataStorage,
+//         id: ConcreteTypeId,
+//         f: impl FnOnce(&mut MetadataStorage) -> Result<Option<(DupFn<P>, P)>>,
+//     ) -> Result<()>
+//     where
+//         P: 'static,
+//     {
+//         {
+//             let dup_override_meta = metadata.get_or_insert_with(Self::default);
+//             if dup_override_meta.is_registered(&id) {
+//                 return Ok(());
+//             }
+
+//             dup_override_meta.partials.push(id);
+//         }
+
+//         let result = f(metadata)?;
+//         {
+//             // This unwrap is unreachble because the meta was created just before if it wasn't
+//             // already present.
+//             let dup_override_meta = metadata.get_mut::<Self>().unwrap();
+
+//             let self_id = dup_override_meta.partials.pop().unwrap();
+//             if let Some((clone_fn, params)) = result {
+//                 dup_override_meta.mappings.insert(
+//                     self_id.clone(),
+//                     Arc::new(
+//                         move |context, registry, entry, location, helper, metadata, value| {
+//                             clone_fn(
+//                                 context,
+//                                 registry,
+//                                 entry,
+//                                 location,
+//                                 helper,
+//                                 metadata,
+//                                 WithSelf::new(&self_id, &params),
+//                                 value,
+//                             )
+//                         },
+//                     ),
+//                 );
+//             }
+//         }
+
+//         Ok(())
+//     }
+
+//     pub(crate) fn register_dup(&mut self, id: ConcreteTypeId, from_id: &ConcreteTypeId) {
+//         assert!(
+//             !self.is_registered(&id),
+//             "attempting to register a clone impl that is already registered",
+//         );
+
+//         if let Some(clone_fn) = self.mappings.get(from_id) {
+//             self.mappings.insert(id, clone_fn.clone());
+//         }
+//     }
+
+//     pub(crate) fn is_registered(&self, id: &ConcreteTypeId) -> bool {
+//         self.mappings.contains_key(id) || self.partials.contains(id)
+//     }
+
+//     pub(crate) fn wrap_invoke(&self, id: &ConcreteTypeId) -> Option<DupFnWrapper> {
+//         self.mappings.get(id).cloned()
+//     }
+// }

--- a/src/metadata/dup_overrides.rs
+++ b/src/metadata/dup_overrides.rs
@@ -8,7 +8,7 @@
 //! ## Clone implementations
 //!
 //! The clone logic is implemented as a function for each type that requires it. It has to be a
-//! function to allow self-referencing types. If we inlined the drop implementations,
+//! function to allow self-referencing types. If we inlined the clone implementations,
 //! self-referencing types would generate infinite code thus overflowing the stack when generating
 //! code.
 //!
@@ -58,7 +58,7 @@ impl DupOverridesMeta {
     /// would cause stack overflow when registering themselves.
     ///
     /// The callback serves two purposes:
-    ///   - To generate the drop implementation, if necessary.
+    ///   - To generate the dup implementation, if necessary.
     ///   - To check if we need to generate the implementation (for example, in structs and enums).
     pub(crate) fn register_with<'ctx>(
         context: &'ctx Context,
@@ -101,12 +101,12 @@ impl DupOverridesMeta {
         Ok(())
     }
 
-    /// Returns whether a type has a registered clone implementation.
+    /// Returns whether a type has a registered dup implementation.
     pub(crate) fn is_overriden(&self, id: &ConcreteTypeId) -> bool {
         self.overriden_types.contains(id)
     }
 
-    /// Generates code to invoke a clone implementation for a type, or just returns the same value
+    /// Generates code to invoke a dup implementation for a type, or just returns the same value
     /// twice if no implementation was registered.
     pub(crate) fn invoke_override<'ctx, 'this>(
         &self,

--- a/src/metadata/dup_overrides.rs
+++ b/src/metadata/dup_overrides.rs
@@ -14,7 +14,9 @@
 //!
 //! The generated functions are not public (they are internal) and follow this naming convention:
 //!
-//!     dup${type id}
+//! ```text
+//! dup${type id}
+//! ```
 //!
 //! where `{type id}` is the numeric value of the `ConcreteTypeId`.
 
@@ -54,6 +56,10 @@ impl DupOverridesMeta {
     ///
     /// The type need to be registered before calling the closure, otherwise self-referencing types
     /// would cause stack overflow when registering themselves.
+    ///
+    /// The callback serves two purposes:
+    ///   - To generate the drop implementation, if necessary.
+    ///   - To check if we need to generate the implementation (for example, in structs and enums).
     pub(crate) fn register_with<'ctx>(
         context: &'ctx Context,
         module: &Module<'ctx>,

--- a/src/metadata/enum_snapshot_variants.rs
+++ b/src/metadata/enum_snapshot_variants.rs
@@ -9,14 +9,8 @@ pub struct EnumSnapshotVariantsMeta {
 }
 
 impl EnumSnapshotVariantsMeta {
-    pub fn set_mapping(
-        &mut self,
-        snapshot_id: &ConcreteTypeId,
-        enum_variants: Option<&[ConcreteTypeId]>,
-    ) {
-        if let Some(variants) = enum_variants {
-            self.map.insert(snapshot_id.clone(), variants.to_vec());
-        }
+    pub fn set_mapping(&mut self, snapshot_id: &ConcreteTypeId, variants: &[ConcreteTypeId]) {
+        self.map.insert(snapshot_id.clone(), variants.to_vec());
     }
 
     pub fn get_variants(&self, snapshot_id: &ConcreteTypeId) -> Option<&Vec<ConcreteTypeId>> {

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -64,6 +64,12 @@ impl SnapshotClonesMeta {
         );
     }
 
+    pub(crate) fn register_dup(&mut self, id: ConcreteTypeId, from_id: &ConcreteTypeId) {
+        if let Some(clone_fn) = self.mappings.get(from_id) {
+            self.mappings.insert(id, clone_fn.clone());
+        }
+    }
+
     pub(crate) fn wrap_invoke(&self, id: &ConcreteTypeId) -> Option<CloneFnWrapper> {
         self.mappings.get(id).cloned()
     }

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -9,10 +9,7 @@ use melior::{
     ir::{Block, Location, Value},
     Context,
 };
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 type CloneFn<P> = for<'ctx, 'this> fn(
     &'ctx Context,
@@ -40,39 +37,71 @@ type CloneFnWrapper = Arc<
 #[derive(Default)]
 pub struct SnapshotClonesMeta {
     mappings: HashMap<ConcreteTypeId, CloneFnWrapper>,
+    partials: Vec<ConcreteTypeId>,
 }
 
 impl SnapshotClonesMeta {
-    pub(crate) fn register<P>(&mut self, id: ConcreteTypeId, handler: CloneFn<P>, params: P)
+    pub(crate) fn register_with<P>(
+        metadata: &mut MetadataStorage,
+        id: ConcreteTypeId,
+        f: impl FnOnce(&mut MetadataStorage) -> Result<Option<(CloneFn<P>, P)>>,
+    ) -> Result<()>
     where
         P: 'static,
     {
-        match self.mappings.entry(id) {
-            Entry::Occupied(_) => {}
-            Entry::Vacant(map_entry) => {
-                let self_id = map_entry.key().clone();
-                map_entry.insert(Arc::new(
-                    move |context, registry, entry, location, helper, metadata, value| {
-                        handler(
-                            context,
-                            registry,
-                            entry,
-                            location,
-                            helper,
-                            metadata,
-                            WithSelf::new(&self_id, &params),
-                            value,
-                        )
-                    },
-                ));
+        {
+            let snapshot_clones_meta = metadata.get_or_insert_with(Self::default);
+            if snapshot_clones_meta.is_registered(&id) {
+                return Ok(());
+            }
+
+            snapshot_clones_meta.partials.push(id);
+        }
+
+        let result = f(metadata)?;
+        {
+            // This unwrap is unreachble because the meta was created just before if it wasn't
+            // already present.
+            let snapshot_clones_meta = metadata.get_mut::<Self>().unwrap();
+
+            let self_id = snapshot_clones_meta.partials.pop().unwrap();
+            if let Some((clone_fn, params)) = result {
+                snapshot_clones_meta.mappings.insert(
+                    self_id.clone(),
+                    Arc::new(
+                        move |context, registry, entry, location, helper, metadata, value| {
+                            clone_fn(
+                                context,
+                                registry,
+                                entry,
+                                location,
+                                helper,
+                                metadata,
+                                WithSelf::new(&self_id, &params),
+                                value,
+                            )
+                        },
+                    ),
+                );
             }
         }
+
+        Ok(())
     }
 
     pub(crate) fn register_dup(&mut self, id: ConcreteTypeId, from_id: &ConcreteTypeId) {
+        assert!(
+            !self.is_registered(&id),
+            "attempting to register a clone impl that is already registered",
+        );
+
         if let Some(clone_fn) = self.mappings.get(from_id) {
             self.mappings.insert(id, clone_fn.clone());
         }
+    }
+
+    pub(crate) fn is_registered(&self, id: &ConcreteTypeId) -> bool {
+        self.mappings.contains_key(id) || self.partials.contains(id)
     }
 
     pub(crate) fn wrap_invoke(&self, id: &ConcreteTypeId) -> Option<CloneFnWrapper> {

--- a/src/metadata/snapshot_clones.rs
+++ b/src/metadata/snapshot_clones.rs
@@ -44,6 +44,11 @@ impl SnapshotClonesMeta {
     where
         P: 'static,
     {
+        assert!(
+            !self.mappings.contains_key(&id),
+            "attempt to register a custom clone that's already registered"
+        );
+
         let self_ty = id.clone();
         self.mappings.insert(
             id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -146,19 +146,6 @@ pub trait TypeBuilder {
         metadata: &mut MetadataStorage,
         self_ty: &ConcreteTypeId,
     ) -> Result<Value<'ctx, 'this>, Self::Error>;
-
-    // #[allow(clippy::too_many_arguments)]
-    // fn build_drop<'ctx, 'this>(
-    //     &self,
-    //     context: &'ctx Context,
-    //     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    //     entry: &'this Block<'ctx>,
-    //     location: Location<'ctx>,
-    //     helper: &LibfuncHelper<'ctx, 'this>,
-    //     metadata: &mut MetadataStorage,
-    //     self_ty: &ConcreteTypeId,
-    //     value: Value<'ctx, 'this>,
-    // ) -> Result<(), Self::Error>;
 }
 
 impl TypeBuilder for CoreTypeConcrete {
@@ -942,87 +929,6 @@ impl TypeBuilder for CoreTypeConcrete {
             _ => unimplemented!("unsupported dict value type"),
         })
     }
-
-    // fn build_drop<'ctx, 'this>(
-    //     &self,
-    //     context: &'ctx Context,
-    //     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    //     entry: &'this Block<'ctx>,
-    //     location: Location<'ctx>,
-    //     helper: &LibfuncHelper<'ctx, 'this>,
-    //     metadata: &mut MetadataStorage,
-    //     self_ty: &ConcreteTypeId,
-    //     value: Value<'ctx, 'this>,
-    // ) -> Result<(), Self::Error> {
-    //     match self {
-    //         CoreTypeConcrete::Array(info) => {
-    //             if metadata.get::<ReallocBindingsMeta>().is_none() {
-    //                 metadata.insert(ReallocBindingsMeta::new(context, helper));
-    //             }
-
-    //             self::array::build_drop(
-    //                 context,
-    //                 registry,
-    //                 entry,
-    //                 location,
-    //                 helper,
-    //                 metadata,
-    //                 WithSelf::new(
-    //                     self_ty,
-    //                     &InfoAndTypeConcreteType {
-    //                         info: info.info.clone(),
-    //                         ty: info.ty.clone(),
-    //                     },
-    //                 ),
-    //                 value,
-    //             )?;
-
-    //             let array_ty = registry.build_type(context, helper, registry, metadata, self_ty)?;
-    //             let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
-
-    //             let ptr = entry.extract_value(context, location, value, ptr_ty, 0)?;
-
-    //             entry.append_operation(ReallocBindingsMeta::free(context, ptr, location));
-    //         }
-    //         CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => {
-    //             // TODO: Drop the dictionary.
-    //         }
-    //         CoreTypeConcrete::Box(_) | CoreTypeConcrete::Nullable(_) => {
-    //             if metadata.get::<ReallocBindingsMeta>().is_none() {
-    //                 metadata.insert(ReallocBindingsMeta::new(context, helper));
-    //             }
-
-    //             // self::r#box::build_drop();
-
-    //             entry.append_operation(ReallocBindingsMeta::free(context, value, location));
-    //         }
-    //         CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.build_drop(
-    //             context, registry, entry, location, helper, metadata, &info.ty, value,
-    //         )?,
-    //         CoreTypeConcrete::Struct(info) => self::r#struct::build_drop(
-    //             context,
-    //             registry,
-    //             entry,
-    //             location,
-    //             helper,
-    //             metadata,
-    //             WithSelf::new(self_ty, info),
-    //             value,
-    //         )?,
-    //         CoreTypeConcrete::Enum(info) => self::r#enum::build_drop(
-    //             context,
-    //             registry,
-    //             entry,
-    //             location,
-    //             helper,
-    //             metadata,
-    //             WithSelf::new(self_ty, info),
-    //             value,
-    //         )?,
-    //         _ => {}
-    //     };
-    //     Ok(())
-    // }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,10 +5,7 @@
 use crate::{
     error::Error as CoreTypeBuilderError,
     libfuncs::LibfuncHelper,
-    metadata::{
-        realloc_bindings::ReallocBindingsMeta, runtime_bindings::RuntimeBindingsMeta,
-        MetadataStorage,
-    },
+    metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
     utils::{get_integer_layout, layout_repeat, BlockExt, ProgramRegistryExt, RangeExt, PRIME},
 };
 use cairo_lang_sierra::{
@@ -989,11 +986,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 entry.append_operation(ReallocBindingsMeta::free(context, ptr, location));
             }
             CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => {
-                let runtime: &mut RuntimeBindingsMeta = metadata.get_mut().unwrap();
-
-                // TODO: Drop the entries.
-
-                runtime.dict_alloc_free(context, helper, value, entry, location)?;
+                // TODO: Drop the dictionary.
             }
             CoreTypeConcrete::Box(_) | CoreTypeConcrete::Nullable(_) => {
                 if metadata.get::<ReallocBindingsMeta>().is_none() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -986,6 +986,9 @@ impl TypeBuilder for CoreTypeConcrete {
                 let ptr = entry.argument(0)?.into();
                 entry.append_operation(ReallocBindingsMeta::free(context, ptr, location));
             }
+            CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.build_drop(
+                context, registry, entry, location, helper, metadata, &info.ty,
+            )?,
             _ => {}
         };
         Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -1000,7 +1000,7 @@ impl TypeBuilder for CoreTypeConcrete {
                     metadata.insert(ReallocBindingsMeta::new(context, helper));
                 }
 
-                // TODO: Drop the values.
+                // self::r#box::build_drop();
 
                 entry.append_operation(ReallocBindingsMeta::free(context, value, location));
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,15 +5,14 @@
 use crate::{
     error::Error as CoreTypeBuilderError,
     libfuncs::LibfuncHelper,
-    metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
-    utils::{get_integer_layout, layout_repeat, BlockExt, ProgramRegistryExt, RangeExt, PRIME},
+    metadata::MetadataStorage,
+    utils::{get_integer_layout, layout_repeat, BlockExt, RangeExt, PRIME},
 };
 use cairo_lang_sierra::{
     extensions::{
         circuit::CircuitTypeConcrete,
         core::{CoreLibfunc, CoreType, CoreTypeConcrete},
         starknet::StarkNetTypeConcrete,
-        types::InfoAndTypeConcreteType,
         utils::Range,
     },
     ids::{ConcreteTypeId, UserTypeId},
@@ -148,18 +147,18 @@ pub trait TypeBuilder {
         self_ty: &ConcreteTypeId,
     ) -> Result<Value<'ctx, 'this>, Self::Error>;
 
-    #[allow(clippy::too_many_arguments)]
-    fn build_drop<'ctx, 'this>(
-        &self,
-        context: &'ctx Context,
-        registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-        entry: &'this Block<'ctx>,
-        location: Location<'ctx>,
-        helper: &LibfuncHelper<'ctx, 'this>,
-        metadata: &mut MetadataStorage,
-        self_ty: &ConcreteTypeId,
-        value: Value<'ctx, 'this>,
-    ) -> Result<(), Self::Error>;
+    // #[allow(clippy::too_many_arguments)]
+    // fn build_drop<'ctx, 'this>(
+    //     &self,
+    //     context: &'ctx Context,
+    //     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    //     entry: &'this Block<'ctx>,
+    //     location: Location<'ctx>,
+    //     helper: &LibfuncHelper<'ctx, 'this>,
+    //     metadata: &mut MetadataStorage,
+    //     self_ty: &ConcreteTypeId,
+    //     value: Value<'ctx, 'this>,
+    // ) -> Result<(), Self::Error>;
 }
 
 impl TypeBuilder for CoreTypeConcrete {
@@ -944,86 +943,86 @@ impl TypeBuilder for CoreTypeConcrete {
         })
     }
 
-    fn build_drop<'ctx, 'this>(
-        &self,
-        context: &'ctx Context,
-        registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-        entry: &'this Block<'ctx>,
-        location: Location<'ctx>,
-        helper: &LibfuncHelper<'ctx, 'this>,
-        metadata: &mut MetadataStorage,
-        self_ty: &ConcreteTypeId,
-        value: Value<'ctx, 'this>,
-    ) -> Result<(), Self::Error> {
-        match self {
-            CoreTypeConcrete::Array(info) => {
-                if metadata.get::<ReallocBindingsMeta>().is_none() {
-                    metadata.insert(ReallocBindingsMeta::new(context, helper));
-                }
+    // fn build_drop<'ctx, 'this>(
+    //     &self,
+    //     context: &'ctx Context,
+    //     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    //     entry: &'this Block<'ctx>,
+    //     location: Location<'ctx>,
+    //     helper: &LibfuncHelper<'ctx, 'this>,
+    //     metadata: &mut MetadataStorage,
+    //     self_ty: &ConcreteTypeId,
+    //     value: Value<'ctx, 'this>,
+    // ) -> Result<(), Self::Error> {
+    //     match self {
+    //         CoreTypeConcrete::Array(info) => {
+    //             if metadata.get::<ReallocBindingsMeta>().is_none() {
+    //                 metadata.insert(ReallocBindingsMeta::new(context, helper));
+    //             }
 
-                self::array::build_drop(
-                    context,
-                    registry,
-                    entry,
-                    location,
-                    helper,
-                    metadata,
-                    WithSelf::new(
-                        self_ty,
-                        &InfoAndTypeConcreteType {
-                            info: info.info.clone(),
-                            ty: info.ty.clone(),
-                        },
-                    ),
-                    value,
-                )?;
+    //             self::array::build_drop(
+    //                 context,
+    //                 registry,
+    //                 entry,
+    //                 location,
+    //                 helper,
+    //                 metadata,
+    //                 WithSelf::new(
+    //                     self_ty,
+    //                     &InfoAndTypeConcreteType {
+    //                         info: info.info.clone(),
+    //                         ty: info.ty.clone(),
+    //                     },
+    //                 ),
+    //                 value,
+    //             )?;
 
-                let array_ty = registry.build_type(context, helper, registry, metadata, self_ty)?;
-                let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
+    //             let array_ty = registry.build_type(context, helper, registry, metadata, self_ty)?;
+    //             let ptr_ty = crate::ffi::get_struct_field_type_at(&array_ty, 0);
 
-                let ptr = entry.extract_value(context, location, value, ptr_ty, 0)?;
+    //             let ptr = entry.extract_value(context, location, value, ptr_ty, 0)?;
 
-                entry.append_operation(ReallocBindingsMeta::free(context, ptr, location));
-            }
-            CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => {
-                // TODO: Drop the dictionary.
-            }
-            CoreTypeConcrete::Box(_) | CoreTypeConcrete::Nullable(_) => {
-                if metadata.get::<ReallocBindingsMeta>().is_none() {
-                    metadata.insert(ReallocBindingsMeta::new(context, helper));
-                }
+    //             entry.append_operation(ReallocBindingsMeta::free(context, ptr, location));
+    //         }
+    //         CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => {
+    //             // TODO: Drop the dictionary.
+    //         }
+    //         CoreTypeConcrete::Box(_) | CoreTypeConcrete::Nullable(_) => {
+    //             if metadata.get::<ReallocBindingsMeta>().is_none() {
+    //                 metadata.insert(ReallocBindingsMeta::new(context, helper));
+    //             }
 
-                // self::r#box::build_drop();
+    //             // self::r#box::build_drop();
 
-                entry.append_operation(ReallocBindingsMeta::free(context, value, location));
-            }
-            CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.build_drop(
-                context, registry, entry, location, helper, metadata, &info.ty, value,
-            )?,
-            CoreTypeConcrete::Struct(info) => self::r#struct::build_drop(
-                context,
-                registry,
-                entry,
-                location,
-                helper,
-                metadata,
-                WithSelf::new(self_ty, info),
-                value,
-            )?,
-            CoreTypeConcrete::Enum(info) => self::r#enum::build_drop(
-                context,
-                registry,
-                entry,
-                location,
-                helper,
-                metadata,
-                WithSelf::new(self_ty, info),
-                value,
-            )?,
-            _ => {}
-        };
-        Ok(())
-    }
+    //             entry.append_operation(ReallocBindingsMeta::free(context, value, location));
+    //         }
+    //         CoreTypeConcrete::Snapshot(info) => registry.get_type(&info.ty)?.build_drop(
+    //             context, registry, entry, location, helper, metadata, &info.ty, value,
+    //         )?,
+    //         CoreTypeConcrete::Struct(info) => self::r#struct::build_drop(
+    //             context,
+    //             registry,
+    //             entry,
+    //             location,
+    //             helper,
+    //             metadata,
+    //             WithSelf::new(self_ty, info),
+    //             value,
+    //         )?,
+    //         CoreTypeConcrete::Enum(info) => self::r#enum::build_drop(
+    //             context,
+    //             registry,
+    //             entry,
+    //             location,
+    //             helper,
+    //             metadata,
+    //             WithSelf::new(self_ty, info),
+    //             value,
+    //         )?,
+    //         _ => {}
+    //     };
+    //     Ok(())
+    // }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -366,6 +366,8 @@ pub(crate) fn build_drop<'ctx, 'this>(
         },
         location,
     ));
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -366,8 +366,6 @@ pub(crate) fn build_drop<'ctx, 'this>(
         },
         location,
     ));
-
-    todo!()
 }
 
 #[cfg(test)]

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -33,18 +33,11 @@ use cairo_lang_sierra::{
     },
     program_registry::ProgramRegistry,
 };
-use melior::dialect::scf;
+use melior::dialect::{arith::CmpiPredicate, func, scf};
 use melior::ir::Region;
 use melior::{
-    dialect::{
-        arith, cf,
-        llvm::{self, r#type::pointer},
-        ods,
-    },
-    ir::{
-        attribute::IntegerAttribute, r#type::IntegerType, Block, Location, Module, Type, Value,
-        ValueLike,
-    },
+    dialect::{arith, cf, llvm, ods},
+    ir::{attribute::IntegerAttribute, r#type::IntegerType, Block, Location, Module, Type, Value},
     Context,
 };
 use std::cell::Cell;
@@ -59,17 +52,19 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
-        registry.build_type(context, module, registry, metadata, &info.ty)?;
+    DupOverrideMeta::register_with(
+        context,
+        module,
+        registry,
+        metadata,
+        info.self_ty(),
+        |metadata| {
+            // There's no need to build the type here because it'll always be built within
+            // `snapshot_take`.
 
-        Ok(Some((
-            snapshot_take,
-            InfoAndTypeConcreteType {
-                info: info.info.clone(),
-                ty: info.ty.clone(),
-            },
-        )))
-    })?;
+            Ok(Some(build_dup(context, module, registry, metadata, &info)?))
+        },
+    )?;
 
     let ptr_ty = llvm::r#type::pointer(context, 0);
     let len_ty = IntegerType::new(context, 32).into();
@@ -81,45 +76,42 @@ pub fn build<'ctx>(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn snapshot_take<'ctx, 'this>(
+fn build_dup<'ctx>(
     context: &'ctx Context,
+    module: &Module<'ctx>,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: WithSelf<InfoAndTypeConcreteType>,
-    src_value: Value<'ctx, 'this>,
-) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
+    info: &WithSelf<InfoAndTypeConcreteType>,
+) -> Result<Region<'ctx>> {
+    let location = Location::unknown(context);
     if metadata.get::<ReallocBindingsMeta>().is_none() {
-        metadata.insert(ReallocBindingsMeta::new(context, helper));
+        metadata.insert(ReallocBindingsMeta::new(context, module));
     }
 
-    let elem_snapshot_take = metadata
-        .get::<DupOverrideMeta>()
-        .and_then(|meta| meta.wrap_invoke(&info.ty));
-
+    let value_ty = registry.build_type(context, module, registry, metadata, info.self_ty())?;
     let elem_ty = registry.get_type(&info.ty)?;
-    let elem_layout = elem_ty.layout(registry)?;
-    let elem_stride = elem_layout.pad_to_align().size();
-    let elem_ty = elem_ty.build(context, helper, registry, metadata, &info.ty)?;
+    let elem_stride = elem_ty.layout(registry)?.pad_to_align().size();
+    let elem_ty = elem_ty.build(context, module, registry, metadata, &info.ty)?;
 
-    let src_ptr = entry.extract_value(
+    let region = Region::new();
+    let entry = region.append_block(Block::new(&[(value_ty, location)]));
+
+    let src_value = entry.argument(0)?.into();
+    let value_ptr = entry.extract_value(
         context,
         location,
         src_value,
         llvm::r#type::pointer(context, 0),
         0,
     )?;
-    let array_start = entry.extract_value(
+    let value_start = entry.extract_value(
         context,
         location,
         src_value,
         IntegerType::new(context, 32).into(),
         1,
     )?;
-    let array_end = entry.extract_value(
+    let value_end = entry.extract_value(
         context,
         location,
         src_value,
@@ -127,85 +119,79 @@ fn snapshot_take<'ctx, 'this>(
         2,
     )?;
 
-    let elem_stride = entry.const_int(context, location, elem_stride, 64)?;
+    let value_len = entry.append_op_result(arith::subi(value_end, value_start, location))?;
 
-    let array_ty = registry.build_type(context, helper, registry, metadata, info.self_ty())?;
-
-    let array_len: Value = entry.append_op_result(arith::subi(array_end, array_start, location))?;
-
-    let k0 = entry.const_int_from_type(context, location, 0, array_len.r#type())?;
-    let is_len_zero = entry.append_op_result(arith::cmpi(
+    let k0 = entry.const_int(context, location, 0, 32)?;
+    let value_is_empty = entry.append_op_result(arith::cmpi(
         context,
-        arith::CmpiPredicate::Eq,
-        array_len,
+        CmpiPredicate::Eq,
+        value_len,
         k0,
         location,
     ))?;
 
-    let null_ptr = entry
-        .append_op_result(ods::llvm::mlir_zero(context, pointer(context, 0), location).into())?;
+    let null_ptr =
+        entry.append_op_result(llvm::zero(llvm::r#type::pointer(context, 0), location))?;
 
-    let block_realloc = helper.append_block(Block::new(&[]));
+    let block_realloc = region.append_block(Block::new(&[]));
     let block_finish =
-        helper.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
-
+        region.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
     entry.append_operation(cf::cond_br(
         context,
-        is_len_zero,
-        block_finish,
-        block_realloc,
+        value_is_empty,
+        &block_finish,
+        &block_realloc,
         &[null_ptr],
         &[],
         location,
     ));
 
     {
-        // realloc
-        let dst_len_bytes: Value = {
-            let array_len = block_realloc.append_op_result(arith::extui(
-                array_len,
+        let elem_stride = block_realloc.const_int(context, location, elem_stride, 64)?;
+
+        let dst_value_len = {
+            let value_len = block_realloc.append_op_result(arith::extui(
+                value_len,
                 IntegerType::new(context, 64).into(),
                 location,
             ))?;
 
-            block_realloc.append_op_result(arith::muli(array_len, elem_stride, location))?
+            block_realloc.append_op_result(arith::muli(value_len, elem_stride, location))?
         };
-
-        let dst_ptr = {
-            let dst_ptr = null_ptr;
-
+        let dst_value_ptr = {
             block_realloc.append_op_result(ReallocBindingsMeta::realloc(
                 context,
-                dst_ptr,
-                dst_len_bytes,
+                null_ptr,
+                dst_value_len,
                 location,
             ))?
         };
 
-        let src_ptr_offset = {
-            let array_start = block_realloc.append_op_result(arith::extui(
-                array_start,
+        let src_value_ptr = {
+            let value_offset = block_realloc.append_op_result(arith::extui(
+                value_start,
                 IntegerType::new(context, 64).into(),
                 location,
             ))?;
 
-            block_realloc.append_op_result(arith::muli(array_start, elem_stride, location))?
+            let src_value_offset =
+                block_realloc.append_op_result(arith::muli(value_offset, elem_stride, location))?;
+            block_realloc.append_op_result(llvm::get_element_ptr_dynamic(
+                context,
+                value_ptr,
+                &[src_value_offset],
+                IntegerType::new(context, 8).into(),
+                llvm::r#type::pointer(context, 0),
+                location,
+            ))?
         };
-        let src_ptr = block_realloc.append_op_result(llvm::get_element_ptr_dynamic(
-            context,
-            src_ptr,
-            &[src_ptr_offset],
-            IntegerType::new(context, 8).into(),
-            llvm::r#type::pointer(context, 0),
-            location,
-        ))?;
 
-        match elem_snapshot_take {
-            Some(elem_snapshot_take) => {
+        match metadata.get::<DupOverrideMeta>() {
+            Some(dup_override_meta) if dup_override_meta.is_overriden(&info.ty) => {
                 let k0 = block_realloc.const_int(context, location, 0, 64)?;
                 block_realloc.append_operation(scf::r#for(
                     k0,
-                    dst_len_bytes,
+                    dst_value_len,
                     elem_stride,
                     {
                         let region = Region::new();
@@ -214,89 +200,70 @@ fn snapshot_take<'ctx, 'this>(
                             location,
                         )]));
 
-                        let i = block.argument(0)?.into();
-                        block.append_operation(scf::execute_region(
-                            &[],
-                            {
-                                let region = Region::new();
-                                let block = region.append_block(Block::new(&[]));
+                        let idx = block.argument(0)?.into();
 
-                                let src_ptr =
-                                    block.append_op_result(llvm::get_element_ptr_dynamic(
-                                        context,
-                                        src_ptr,
-                                        &[i],
-                                        IntegerType::new(context, 8).into(),
-                                        llvm::r#type::pointer(context, 0),
-                                        location,
-                                    ))?;
-                                let dst_ptr =
-                                    block.append_op_result(llvm::get_element_ptr_dynamic(
-                                        context,
-                                        dst_ptr,
-                                        &[i],
-                                        IntegerType::new(context, 8).into(),
-                                        llvm::r#type::pointer(context, 0),
-                                        location,
-                                    ))?;
+                        let src_value_ptr =
+                            block.append_op_result(llvm::get_element_ptr_dynamic(
+                                context,
+                                src_value_ptr,
+                                &[idx],
+                                IntegerType::new(context, 8).into(),
+                                llvm::r#type::pointer(context, 0),
+                                location,
+                            ))?;
+                        let dst_value_ptr =
+                            block.append_op_result(llvm::get_element_ptr_dynamic(
+                                context,
+                                dst_value_ptr,
+                                &[idx],
+                                IntegerType::new(context, 8).into(),
+                                llvm::r#type::pointer(context, 0),
+                                location,
+                            ))?;
 
-                                let helper = LibfuncHelper {
-                                    module: helper.module,
-                                    init_block: helper.init_block,
-                                    region: &region,
-                                    blocks_arena: helper.blocks_arena,
-                                    last_block: Cell::new(&block),
-                                    branches: Vec::new(),
-                                    results: Vec::new(),
-                                };
-
-                                let value = block.load(context, location, src_ptr, elem_ty)?;
-                                let (block, value) = elem_snapshot_take(
-                                    context, registry, &block, location, &helper, metadata, value,
-                                )?;
-                                block.store(context, location, dst_ptr, value)?;
-
-                                block.append_operation(scf::r#yield(&[], location));
-                                region
-                            },
-                            location,
-                        ));
+                        let value = block.load(context, location, src_value_ptr, elem_ty)?;
+                        let values = dup_override_meta
+                            .invoke_override(context, &block, location, &info.ty, value)?;
+                        block.store(context, location, src_value_ptr, values.0)?;
+                        block.store(context, location, dst_value_ptr, values.1)?;
 
                         block.append_operation(scf::r#yield(&[], location));
                         region
                     },
                     location,
                 ));
-
-                block_realloc.append_operation(cf::br(block_finish, &[dst_ptr], location));
             }
-            None => {
+            _ => {
                 block_realloc.append_operation(
                     ods::llvm::intr_memcpy(
                         context,
-                        dst_ptr,
-                        src_ptr,
-                        dst_len_bytes,
+                        dst_value_ptr,
+                        src_value_ptr,
+                        dst_value_len,
                         IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
                         location,
                     )
                     .into(),
                 );
-                block_realloc.append_operation(cf::br(block_finish, &[dst_ptr], location));
             }
         }
+
+        block_realloc.append_operation(cf::br(&block_finish, &[dst_value_ptr], location));
     }
 
-    let dst_value = block_finish.append_op_result(llvm::undef(array_ty, location))?;
-    let dst_ptr = block_finish.argument(0)?.into();
+    {
+        let dst_value = block_finish.append_op_result(llvm::undef(value_ty, location))?;
+        let dst_value = block_finish.insert_values(
+            context,
+            location,
+            dst_value,
+            &[block_finish.argument(0)?.into(), k0, value_len, value_len],
+        )?;
 
-    let k0 = block_finish.const_int(context, location, 0, 32)?;
-    let dst_value = block_finish.insert_value(context, location, dst_value, dst_ptr, 0)?;
-    let dst_value = block_finish.insert_value(context, location, dst_value, k0, 1)?;
-    let dst_value = block_finish.insert_value(context, location, dst_value, array_len, 2)?;
-    let dst_value = block_finish.insert_value(context, location, dst_value, array_len, 3)?;
+        block_finish.append_operation(func::r#return(&[src_value, dst_value], location));
+    }
 
-    Ok((block_finish, dst_value))
+    Ok(region)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -22,7 +22,7 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{
-        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
+        dup_overrides::DupOverridesMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     utils::{BlockExt, ProgramRegistryExt},
 };
@@ -52,7 +52,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -186,7 +186,7 @@ fn build_dup<'ctx>(
             ))?
         };
 
-        match metadata.get::<DupOverrideMeta>() {
+        match metadata.get::<DupOverridesMeta>() {
             Some(dup_override_meta) if dup_override_meta.is_overriden(&info.ty) => {
                 let k0 = block_realloc.const_int(context, location, 0, 64)?;
                 block_realloc.append_operation(scf::r#for(

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -362,6 +362,8 @@ pub(crate) fn build_drop<'ctx, 'this>(
                 payload_value,
             )?;
 
+            block.append_operation(scf::r#yield(&[], location));
+
             region
         },
         location,

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -22,7 +22,7 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{
-        realloc_bindings::ReallocBindingsMeta, snapshot_clones::SnapshotClonesMeta, MetadataStorage,
+        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     utils::{BlockExt, ProgramRegistryExt},
 };
@@ -59,7 +59,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+    DupOverrideMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
         registry.build_type(context, module, registry, metadata, &info.ty)?;
 
         Ok(Some((
@@ -97,7 +97,7 @@ fn snapshot_take<'ctx, 'this>(
     }
 
     let elem_snapshot_take = metadata
-        .get::<SnapshotClonesMeta>()
+        .get::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.ty));
 
     let elem_ty = registry.get_type(&info.ty)?;

--- a/src/types/box.rs
+++ b/src/types/box.rs
@@ -16,7 +16,7 @@ use super::WithSelf;
 use crate::{
     error::Result,
     metadata::{
-        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
+        dup_overrides::DupOverridesMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     types::TypeBuilder,
     utils::BlockExt,
@@ -44,7 +44,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -92,7 +92,7 @@ fn build_dup<'ctx>(
         location,
     ))?;
 
-    match metadata.get::<DupOverrideMeta>() {
+    match metadata.get::<DupOverridesMeta>() {
         Some(dup_override_meta) if dup_override_meta.is_overriden(&info.ty) => {
             let value = entry.load(context, location, src_value, inner_ty)?;
             let values =

--- a/src/types/box.rs
+++ b/src/types/box.rs
@@ -20,7 +20,7 @@ use crate::{
         realloc_bindings::ReallocBindingsMeta, snapshot_clones::SnapshotClonesMeta, MetadataStorage,
     },
     types::TypeBuilder,
-    utils::BlockExt,
+    utils::{BlockExt, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -43,21 +43,22 @@ use melior::{
 /// Check out [the module](self) for more info.
 pub fn build<'ctx>(
     context: &'ctx Context,
-    _module: &Module<'ctx>,
-    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    module: &Module<'ctx>,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    metadata
-        .get_or_insert_with::<SnapshotClonesMeta>(SnapshotClonesMeta::default)
-        .register(
-            info.self_ty().clone(),
+    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+        registry.build_type(context, module, registry, metadata, &info.ty)?;
+
+        Ok(Some((
             snapshot_take,
             InfoAndTypeConcreteType {
                 info: info.info.clone(),
                 ty: info.ty.clone(),
             },
-        );
+        )))
+    })?;
 
     Ok(llvm::r#type::pointer(context, 0))
 }

--- a/src/types/box.rs
+++ b/src/types/box.rs
@@ -17,7 +17,7 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{
-        realloc_bindings::ReallocBindingsMeta, snapshot_clones::SnapshotClonesMeta, MetadataStorage,
+        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     types::TypeBuilder,
     utils::{BlockExt, ProgramRegistryExt},
@@ -48,7 +48,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+    DupOverrideMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
         registry.build_type(context, module, registry, metadata, &info.ty)?;
 
         Ok(Some((
@@ -79,7 +79,7 @@ fn snapshot_take<'ctx, 'this>(
     }
 
     let inner_snapshot_take = metadata
-        .get::<SnapshotClonesMeta>()
+        .get::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.ty));
 
     let inner_type = registry.get_type(&info.ty)?;

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -404,8 +404,9 @@
 use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
-    libfuncs::LibfuncHelper,
-    metadata::{dup_overrides::DupOverridesMeta, MetadataStorage},
+    metadata::{
+        drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta, MetadataStorage,
+    },
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
@@ -417,13 +418,12 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::{cf, func, llvm, scf},
-    ir::{r#type::IntegerType, Block, Location, Module, Region, Type, Value, ValueLike},
+    dialect::{cf, func, llvm},
+    ir::{r#type::IntegerType, Block, Location, Module, Region, Type, Value},
     Context,
 };
 use std::{
     alloc::Layout,
-    cell::Cell,
     collections::{hash_map::Entry, HashMap},
 };
 
@@ -450,7 +450,7 @@ pub fn build<'ctx>(
         |metadata| {
             // The following unwrap is unreachable because `register_with` will always insert it
             // before calling this closure.
-            let mut needs_clone_override = false;
+            let mut needs_override = false;
             for variant in &info.variants {
                 registry.build_type(context, module, registry, metadata, variant)?;
                 if metadata
@@ -458,13 +458,40 @@ pub fn build<'ctx>(
                     .unwrap()
                     .is_overriden(variant)
                 {
-                    needs_clone_override = true;
+                    needs_override = true;
                     break;
                 }
             }
 
-            needs_clone_override
+            needs_override
                 .then(|| build_dup(context, module, registry, metadata, &info))
+                .transpose()
+        },
+    )?;
+    DropOverridesMeta::register_with(
+        context,
+        module,
+        registry,
+        metadata,
+        info.self_ty(),
+        |metadata| {
+            // The following unwrap is unreachable because `register_with` will always insert it
+            // before calling this closure.
+            let mut needs_override = false;
+            for variant in &info.variants {
+                registry.build_type(context, module, registry, metadata, variant)?;
+                if metadata
+                    .get::<DropOverridesMeta>()
+                    .unwrap()
+                    .is_overriden(variant)
+                {
+                    needs_override = true;
+                    break;
+                }
+            }
+
+            needs_override
+                .then(|| build_drop(context, module, registry, metadata, &info))
                 .transpose()
         },
     )?;
@@ -620,20 +647,23 @@ fn build_dup<'ctx>(
     Ok(region)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_drop<'ctx, 'this>(
+fn build_drop<'ctx>(
     context: &'ctx Context,
+    module: &Module<'ctx>,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: WithSelf<EnumConcreteType>,
-    value: Value<'ctx, 'this>,
-) -> Result<()> {
+    info: &WithSelf<EnumConcreteType>,
+) -> Result<Region<'ctx>> {
+    let location = Location::unknown(context);
+
+    let self_ty = registry.build_type(context, module, registry, metadata, info.self_ty())?;
+
+    let region = Region::new();
+    let entry = region.append_block(Block::new(&[(self_ty, location)]));
+
     let (layout, (tag_ty, _), variant_tys) = crate::types::r#enum::get_type_for_variants(
         context,
-        helper,
+        module,
         registry,
         metadata,
         &info.variants,
@@ -641,97 +671,76 @@ pub(crate) fn build_drop<'ctx, 'this>(
 
     match variant_tys.len() {
         0 => panic!("attempt to drop a zero-variant enum"),
-        1 => registry.get_type(&info.variants[0])?.build_drop(
-            context,
-            registry,
-            entry,
-            location,
-            helper,
-            metadata,
-            &info.variants[0],
-            value,
-        )?,
+        1 => {
+            // The following unwrap is unreachable because the registration logic will always insert
+            // it.
+            metadata
+                .get::<DropOverridesMeta>()
+                .unwrap()
+                .invoke_override(
+                    context,
+                    &entry,
+                    location,
+                    &info.variants[0],
+                    entry.argument(0)?.into(),
+                )?;
+
+            entry.append_operation(func::r#return(&[], location));
+        }
         _ => {
-            entry.append_operation(scf::execute_region(
-                &[],
-                {
-                    let region = Region::new();
-                    let block = region.append_block(Block::new(&[]));
+            let ptr = entry.alloca1(context, location, self_ty, layout.align())?;
+            entry.store(context, location, ptr, entry.argument(0)?.into())?;
 
-                    let mut variant_blocks = Vec::with_capacity(info.variants.len());
+            let mut variant_blocks = HashMap::new();
+            for (variant_id, variant_ty) in info
+                .variants
+                .iter()
+                .zip(variant_tys.iter().map(|(x, _)| *x))
+            {
+                if let Entry::Vacant(entry) = variant_blocks.entry(variant_id.id) {
+                    let block = entry.insert(region.append_block(Block::new(&[])));
 
-                    let ptr = helper.init_block().alloca1(
+                    let container = block.load(
                         context,
                         location,
-                        value.r#type(),
-                        layout.align(),
+                        ptr,
+                        llvm::r#type::r#struct(context, &[tag_ty, variant_ty], false),
                     )?;
+                    let value = block.extract_value(context, location, container, variant_ty, 1)?;
 
-                    block.store(context, location, ptr, value)?;
-                    for (idx, (variant_ty, _)) in variant_tys.iter().copied().enumerate() {
-                        let block = region.append_block(Block::new(&[]));
-                        variant_blocks.push(block);
+                    // The following unwrap is unreachable because the registration logic will
+                    // always insert it.
+                    metadata
+                        .get::<DropOverridesMeta>()
+                        .unwrap()
+                        .invoke_override(context, block, location, variant_id, value)?;
 
-                        let value = block.load(
-                            context,
-                            location,
-                            ptr,
-                            llvm::r#type::r#struct(context, &[tag_ty, variant_ty], false),
-                        )?;
+                    block.append_operation(func::r#return(&[], location));
+                }
+            }
 
-                        let payload =
-                            block.extract_value(context, location, value, variant_ty, 1)?;
+            let default_block = region.append_block(Block::new(&[]));
 
-                        let helper = LibfuncHelper {
-                            module: helper.module,
-                            init_block: helper.init_block,
-                            region: &region,
-                            blocks_arena: helper.blocks_arena,
-                            last_block: Cell::new(&block),
-                            branches: Vec::new(),
-                            results: Vec::new(),
-                        };
-                        registry.get_type(&info.variants[idx])?.build_drop(
-                            context,
-                            registry,
-                            &block,
-                            location,
-                            &helper,
-                            metadata,
-                            &info.variants[idx],
-                            payload,
-                        )?;
-
-                        block.append_operation(scf::r#yield(&[], location));
-                    }
-
-                    let default_block = region.append_block(Block::new(&[]));
-
-                    let tag_value = entry.load(context, location, ptr, tag_ty)?;
-                    block.append_operation(cf::switch(
-                        context,
-                        &(0..info.variants.len())
-                            .map(|x| x as i64)
-                            .collect::<Vec<_>>(),
-                        tag_value,
-                        tag_ty,
-                        (&default_block, &[]),
-                        &variant_blocks
-                            .iter()
-                            .map(|x| (x as &Block, &[] as &[Value]))
-                            .collect::<Vec<_>>(),
-                        location,
-                    )?);
-
-                    default_block.append_operation(scf::r#yield(&[], location));
-
-                    region
-                },
+            let tag_value = entry.load(context, location, ptr, tag_ty)?;
+            entry.append_operation(cf::switch(
+                context,
+                &(0..info.variants.len() as _).collect::<Vec<_>>(),
+                tag_value,
+                tag_ty,
+                (&default_block, &[]),
+                &info
+                    .variants
+                    .iter()
+                    .map(|id| (&*variant_blocks[&id.id], &[] as &[Value]))
+                    .collect::<Vec<_>>(),
                 location,
-            ));
+            )?);
+
+            default_block.append_operation(llvm::unreachable(location));
         }
     }
-    Ok(())
+
+    Ok(region)
 }
 
 /// Extract layout for the default enum representation, its discriminant and all its payloads.

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -648,7 +648,7 @@ pub(crate) fn build_drop<'ctx, 'this>(
                 &[],
                 {
                     let region = Region::new();
-                    let block = &*region.append_block(Block::new(&[]));
+                    let block = region.append_block(Block::new(&[]));
 
                     let mut variant_blocks = Vec::with_capacity(info.variants.len());
 
@@ -697,7 +697,7 @@ pub(crate) fn build_drop<'ctx, 'this>(
                         block.append_operation(scf::r#yield(&[], location));
                     }
 
-                    let default_block = helper.append_block(Block::new(&[]));
+                    let default_block = region.append_block(Block::new(&[]));
 
                     let tag_value = entry.load(context, location, ptr, tag_ty)?;
                     block.append_operation(cf::switch(
@@ -707,7 +707,7 @@ pub(crate) fn build_drop<'ctx, 'this>(
                             .collect::<Vec<_>>(),
                         tag_value,
                         tag_ty,
-                        (default_block, &[]),
+                        (&default_block, &[]),
                         &variant_blocks
                             .iter()
                             .map(|x| (x as &Block, &[] as &[Value]))

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -448,7 +448,6 @@ pub fn build<'ctx>(
                 .variants
                 .iter()
                 .any(|ty| snapshot_clones_meta.wrap_invoke(ty).is_some())
-                && snapshot_clones_meta.wrap_invoke(info.self_ty()).is_none()
             {
                 snapshot_clones_meta.register(
                     info.self_ty().clone(),

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -485,27 +485,28 @@ pub fn build<'ctx>(
 
 #[allow(clippy::too_many_arguments)]
 fn snapshot_take<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<EnumConcreteType>,
-    src_value: Value<'ctx, 'this>,
+    _context: &'ctx Context,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _entry: &'this Block<'ctx>,
+    _location: Location<'ctx>,
+    _helper: &LibfuncHelper<'ctx, 'this>,
+    _metadata: &mut MetadataStorage,
+    _info: WithSelf<EnumConcreteType>,
+    _src_value: Value<'ctx, 'this>,
 ) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
     todo!()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_drop<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<EnumConcreteType>,
-    value: Value<'ctx, 'this>,
+    _context: &'ctx Context,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _entry: &'this Block<'ctx>,
+    _location: Location<'ctx>,
+    _helper: &LibfuncHelper<'ctx, 'this>,
+    _metadata: &mut MetadataStorage,
+    _info: WithSelf<EnumConcreteType>,
+    _value: Value<'ctx, 'this>,
 ) -> Result<()> {
     todo!()
 }

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -405,7 +405,7 @@ use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
-    metadata::{dup_overrides::DupOverrideMeta, MetadataStorage},
+    metadata::{dup_overrides::DupOverridesMeta, MetadataStorage},
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
@@ -441,7 +441,7 @@ pub fn build<'ctx>(
     info: WithSelf<EnumConcreteType>,
 ) -> Result<Type<'ctx>> {
     // Register enum's clone impl (if required).
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -454,7 +454,7 @@ pub fn build<'ctx>(
             for variant in &info.variants {
                 registry.build_type(context, module, registry, metadata, variant)?;
                 if metadata
-                    .get::<DupOverrideMeta>()
+                    .get::<DupOverridesMeta>()
                     .unwrap()
                     .is_overriden(variant)
                 {
@@ -543,13 +543,16 @@ fn build_dup<'ctx>(
         1 => {
             // The following unwrap is unreachable because the registration logic will always insert
             // it.
-            let values = metadata.get::<DupOverrideMeta>().unwrap().invoke_override(
-                context,
-                &entry,
-                location,
-                &info.variants[0],
-                entry.argument(0)?.into(),
-            )?;
+            let values = metadata
+                .get::<DupOverridesMeta>()
+                .unwrap()
+                .invoke_override(
+                    context,
+                    &entry,
+                    location,
+                    &info.variants[0],
+                    entry.argument(0)?.into(),
+                )?;
 
             entry.append_operation(func::r#return(&[values.0, values.1], location));
         }
@@ -577,7 +580,7 @@ fn build_dup<'ctx>(
                     // The following unwrap is unreachable because the registration logic will
                     // always insert it.
                     let values = metadata
-                        .get::<DupOverrideMeta>()
+                        .get::<DupOverridesMeta>()
                         .unwrap()
                         .invoke_override(context, block, location, variant_id, value)?;
 

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -448,6 +448,7 @@ pub fn build<'ctx>(
                 .variants
                 .iter()
                 .any(|ty| snapshot_clones_meta.wrap_invoke(ty).is_some())
+                && snapshot_clones_meta.wrap_invoke(info.self_ty()).is_none()
             {
                 snapshot_clones_meta.register(
                     info.self_ty().clone(),

--- a/src/types/enum.rs
+++ b/src/types/enum.rs
@@ -404,6 +404,7 @@
 use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
+    libfuncs::LibfuncHelper,
     metadata::MetadataStorage,
     utils::{get_integer_layout, ProgramRegistryExt},
 };
@@ -417,7 +418,7 @@ use cairo_lang_sierra::{
 };
 use melior::{
     dialect::llvm,
-    ir::{r#type::IntegerType, Module, Type},
+    ir::{r#type::IntegerType, Block, Location, Module, Type, Value},
     Context,
 };
 use std::alloc::Layout;
@@ -480,6 +481,33 @@ pub fn build<'ctx>(
             false,
         ),
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn snapshot_take<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: WithSelf<EnumConcreteType>,
+    src_value: Value<'ctx, 'this>,
+) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
+    todo!()
+}
+
+pub(crate) fn build_drop<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: WithSelf<EnumConcreteType>,
+    value: Value<'ctx, 'this>,
+) -> Result<()> {
+    todo!()
 }
 
 /// Extract layout for the default enum representation, its discriminant and all its payloads.

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -144,6 +144,7 @@ fn build_dup<'ctx>(
         .into(),
     )?;
 
+    // The following unwrap is unreachable because the registration logic will always insert it.
     let value0 = entry.argument(0)?.into();
     let value1 = metadata
         .get_mut::<RuntimeBindingsMeta>()
@@ -217,6 +218,7 @@ fn build_drop<'ctx>(
         None => None,
     };
 
+    // The following unwrap is unreachable because the registration logic will always insert it.
     let runtime_bindings_meta = metadata.get_mut::<RuntimeBindingsMeta>().unwrap();
     runtime_bindings_meta.dict_drop(
         context,

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -15,7 +15,7 @@ use crate::{
         snapshot_clones::SnapshotClonesMeta, MetadataStorage,
     },
     types::TypeBuilder,
-    utils::BlockExt,
+    utils::{BlockExt, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -42,21 +42,22 @@ use std::cell::Cell;
 /// Check out [the module](self) for more info.
 pub fn build<'ctx>(
     context: &'ctx Context,
-    _module: &Module<'ctx>,
-    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    module: &Module<'ctx>,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    metadata
-        .get_or_insert_with::<SnapshotClonesMeta>(SnapshotClonesMeta::default)
-        .register(
-            info.self_ty().clone(),
+    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+        registry.build_type(context, module, registry, metadata, &info.ty)?;
+
+        Ok(Some((
             snapshot_take,
             InfoAndTypeConcreteType {
                 info: info.info.clone(),
                 ty: info.ty.clone(),
             },
-        );
+        )))
+    })?;
 
     Ok(llvm::r#type::pointer(context, 0))
 }

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -11,8 +11,8 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{
-        realloc_bindings::ReallocBindingsMeta, runtime_bindings::RuntimeBindingsMeta,
-        snapshot_clones::SnapshotClonesMeta, MetadataStorage,
+        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta,
+        runtime_bindings::RuntimeBindingsMeta, MetadataStorage,
     },
     types::TypeBuilder,
     utils::{BlockExt, ProgramRegistryExt},
@@ -47,7 +47,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+    DupOverrideMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
         registry.build_type(context, module, registry, metadata, &info.ty)?;
 
         Ok(Some((
@@ -78,7 +78,7 @@ fn snapshot_take<'ctx, 'this>(
     }
 
     let elem_snapshot_take = metadata
-        .get::<SnapshotClonesMeta>()
+        .get::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.ty));
 
     let elem_ty = registry.get_type(&info.ty)?;

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -10,7 +10,7 @@ use super::WithSelf;
 use crate::{
     error::Result,
     metadata::{
-        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta,
+        dup_overrides::DupOverridesMeta, realloc_bindings::ReallocBindingsMeta,
         runtime_bindings::RuntimeBindingsMeta, MetadataStorage,
     },
     types::TypeBuilder,
@@ -42,7 +42,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -93,7 +93,7 @@ fn build_dup<'ctx>(
 
         let value = entry.load(context, location, old_ptr, inner_ty)?;
         let values = metadata
-            .get_or_insert_with(DupOverrideMeta::default)
+            .get_or_insert_with(DupOverridesMeta::default)
             .invoke_override(context, &entry, location, &info.ty, value)?;
 
         entry.store(context, location, old_ptr, values.0)?;

--- a/src/types/non_zero.rs
+++ b/src/types/non_zero.rs
@@ -36,5 +36,6 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
+    // TODO: Can its inner type require dup or drop?
     registry.build_type(context, module, registry, metadata, &info.ty)
 }

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -10,7 +10,7 @@ use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
     metadata::{
-        realloc_bindings::ReallocBindingsMeta, snapshot_clones::SnapshotClonesMeta, MetadataStorage,
+        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     utils::{BlockExt, ProgramRegistryExt},
 };
@@ -41,7 +41,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    SnapshotClonesMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
+    DupOverrideMeta::register_with(metadata, info.self_ty().clone(), |metadata| {
         registry.build_type(context, module, registry, metadata, &info.ty)?;
 
         Ok(Some((
@@ -73,7 +73,7 @@ fn snapshot_take<'ctx, 'this>(
     }
 
     let inner_snapshot_take = metadata
-        .get::<SnapshotClonesMeta>()
+        .get::<DupOverrideMeta>()
         .and_then(|meta| meta.wrap_invoke(&info.ty));
 
     let inner_type = registry.get_type(&info.ty)?;

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -101,7 +101,7 @@ fn build_dup<'ctx>(
     let src_is_null = entry.append_op_result(
         ods::llvm::icmp(
             context,
-            IntegerType::new(context, 1).into(),
+            IntegerType::new(context, 0).into(),
             src_value,
             null_ptr,
             IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),
@@ -196,7 +196,7 @@ fn build_drop<'ctx>(
     let is_null = entry.append_op_result(
         ods::llvm::icmp(
             context,
-            IntegerType::new(context, 1).into(),
+            IntegerType::new(context, 0).into(),
             value,
             null_ptr,
             IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -101,7 +101,7 @@ fn build_dup<'ctx>(
     let src_is_null = entry.append_op_result(
         ods::llvm::icmp(
             context,
-            IntegerType::new(context, 0).into(),
+            IntegerType::new(context, 1).into(),
             src_value,
             null_ptr,
             IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),
@@ -196,7 +196,7 @@ fn build_drop<'ctx>(
     let is_null = entry.append_op_result(
         ods::llvm::icmp(
             context,
-            IntegerType::new(context, 0).into(),
+            IntegerType::new(context, 1).into(),
             value,
             null_ptr,
             IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),

--- a/src/types/nullable.rs
+++ b/src/types/nullable.rs
@@ -9,7 +9,7 @@ use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
     metadata::{
-        dup_overrides::DupOverrideMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
+        dup_overrides::DupOverridesMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
     utils::BlockExt,
 };
@@ -40,7 +40,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<InfoAndTypeConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -115,7 +115,7 @@ fn build_dup<'ctx>(
             location,
         ))?;
 
-        match metadata.get::<DupOverrideMeta>() {
+        match metadata.get::<DupOverridesMeta>() {
             Some(dup_override_meta) if dup_override_meta.is_overriden(&info.ty) => {
                 let value = block_realloc.load(context, location, src_value, inner_ty)?;
                 let values = dup_override_meta.invoke_override(

--- a/src/types/snapshot.rs
+++ b/src/types/snapshot.rs
@@ -16,7 +16,7 @@ use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
     metadata::{
-        dup_overrides::DupOverrideMeta, enum_snapshot_variants::EnumSnapshotVariantsMeta,
+        dup_overrides::DupOverridesMeta, enum_snapshot_variants::EnumSnapshotVariantsMeta,
         MetadataStorage,
     },
     utils::ProgramRegistryExt,
@@ -56,7 +56,7 @@ pub fn build<'ctx>(
     }
 
     // Register clone override (if required).
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -68,7 +68,7 @@ pub fn build<'ctx>(
             // The following unwrap is unreachable because `register_with` will always insert it before
             // calling this closure.
             metadata
-                .get::<DupOverrideMeta>()
+                .get::<DupOverridesMeta>()
                 .unwrap()
                 .is_overriden(&info.ty)
                 .then(|| build_dup(context, module, registry, metadata, &info))
@@ -94,13 +94,16 @@ fn build_dup<'ctx>(
     let entry = region.append_block(Block::new(&[(inner_ty, location)]));
 
     // The following unwrap is unreachable because the registration logic will always insert it.
-    let values = metadata.get::<DupOverrideMeta>().unwrap().invoke_override(
-        context,
-        &entry,
-        location,
-        &info.ty,
-        entry.argument(0)?.into(),
-    )?;
+    let values = metadata
+        .get::<DupOverridesMeta>()
+        .unwrap()
+        .invoke_override(
+            context,
+            &entry,
+            location,
+            &info.ty,
+            entry.argument(0)?.into(),
+        )?;
 
     entry.append_operation(func::r#return(&[values.0, values.1], location));
     Ok(region)

--- a/src/types/snapshot.rs
+++ b/src/types/snapshot.rs
@@ -57,7 +57,9 @@ pub fn build<'ctx>(
     // Ensure the inner type is built and register the snapshot clone logic builder.
     let self_ty = registry.build_type(context, module, registry, metadata, &info.ty)?;
     if let Some(snapshot_clones_meta) = metadata.get_mut::<SnapshotClonesMeta>() {
-        snapshot_clones_meta.register_dup(info.self_ty.clone(), &info.ty);
+        if !snapshot_clones_meta.is_registered(info.self_ty()) {
+            snapshot_clones_meta.register_dup(info.self_ty().clone(), &info.ty);
+        }
     }
 
     Ok(self_ty)

--- a/src/types/snapshot.rs
+++ b/src/types/snapshot.rs
@@ -16,7 +16,7 @@ use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
     metadata::{
-        enum_snapshot_variants::EnumSnapshotVariantsMeta, snapshot_clones::SnapshotClonesMeta,
+        dup_overrides::DupOverrideMeta, enum_snapshot_variants::EnumSnapshotVariantsMeta,
         MetadataStorage,
     },
     utils::ProgramRegistryExt,
@@ -56,9 +56,9 @@ pub fn build<'ctx>(
 
     // Ensure the inner type is built and register the snapshot clone logic builder.
     let self_ty = registry.build_type(context, module, registry, metadata, &info.ty)?;
-    if let Some(snapshot_clones_meta) = metadata.get_mut::<SnapshotClonesMeta>() {
-        if !snapshot_clones_meta.is_registered(info.self_ty()) {
-            snapshot_clones_meta.register_dup(info.self_ty().clone(), &info.ty);
+    if let Some(dup_override_meta) = metadata.get_mut::<DupOverrideMeta>() {
+        if !dup_override_meta.is_registered(info.self_ty()) {
+            dup_override_meta.register_dup(info.self_ty().clone(), &info.ty);
         }
     }
 

--- a/src/types/snapshot.rs
+++ b/src/types/snapshot.rs
@@ -29,7 +29,8 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    ir::{Module, Type},
+    dialect::func,
+    ir::{Block, Location, Module, Region, Type},
     Context,
 };
 
@@ -54,13 +55,53 @@ pub fn build<'ctx>(
             .set_mapping(info.self_ty, variants);
     }
 
-    // Ensure the inner type is built and register the snapshot clone logic builder.
-    let self_ty = registry.build_type(context, module, registry, metadata, &info.ty)?;
-    if let Some(dup_override_meta) = metadata.get_mut::<DupOverrideMeta>() {
-        if !dup_override_meta.is_registered(info.self_ty()) {
-            dup_override_meta.register_dup(info.self_ty().clone(), &info.ty);
-        }
-    }
+    // Register clone override (if required).
+    DupOverrideMeta::register_with(
+        context,
+        module,
+        registry,
+        metadata,
+        info.self_ty(),
+        |metadata| {
+            registry.build_type(context, module, registry, metadata, &info.ty)?;
 
-    Ok(self_ty)
+            // The following unwrap is unreachable because `register_with` will always insert it before
+            // calling this closure.
+            metadata
+                .get::<DupOverrideMeta>()
+                .unwrap()
+                .is_overriden(&info.ty)
+                .then(|| build_dup(context, module, registry, metadata, &info))
+                .transpose()
+        },
+    )?;
+
+    registry.build_type(context, module, registry, metadata, &info.ty)
+}
+
+fn build_dup<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    metadata: &mut MetadataStorage,
+    info: &WithSelf<InfoAndTypeConcreteType>,
+) -> Result<Region<'ctx>> {
+    let location = Location::unknown(context);
+
+    let inner_ty = registry.build_type(context, module, registry, metadata, &info.ty)?;
+
+    let region = Region::new();
+    let entry = region.append_block(Block::new(&[(inner_ty, location)]));
+
+    // The following unwrap is unreachable because the registration logic will always insert it.
+    let values = metadata.get::<DupOverrideMeta>().unwrap().invoke_override(
+        context,
+        &entry,
+        location,
+        &info.ty,
+        entry.argument(0)?.into(),
+    )?;
+
+    entry.append_operation(func::r#return(&[values.0, values.1], location));
+    Ok(region)
 }

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -47,8 +47,8 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::llvm,
-    ir::{Block, Location, Module, Type, Value},
+    dialect::{func, llvm},
+    ir::{Block, Location, Module, Region, Type, Value},
     Context,
 };
 
@@ -62,27 +62,33 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<StructConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(metadata, info.self_ty.clone(), |metadata| {
-        let mut has_clone_impl = false;
-        for member in &info.members {
-            registry.build_type(context, module, registry, metadata, member)?;
-            has_clone_impl |= metadata
-                .get::<DupOverrideMeta>()
-                .is_some_and(|x| x.is_registered(member));
-        }
+    DupOverrideMeta::register_with(
+        context,
+        module,
+        registry,
+        metadata,
+        info.self_ty(),
+        |metadata| {
+            // The following unwrap is unreachable because `register_with` will always insert it
+            // before calling this closure.
+            let mut needs_clone_override = false;
+            for member in &info.members {
+                registry.build_type(context, module, registry, metadata, member)?;
+                if metadata
+                    .get::<DupOverrideMeta>()
+                    .unwrap()
+                    .is_overriden(member)
+                {
+                    needs_clone_override = true;
+                    break;
+                }
+            }
 
-        Ok(if has_clone_impl {
-            Some((
-                snapshot_take,
-                StructConcreteType {
-                    info: info.info.clone(),
-                    members: info.members.clone(),
-                },
-            ))
-        } else {
-            None
-        })
-    })?;
+            needs_clone_override
+                .then(|| build_dup(context, module, registry, metadata, &info))
+                .transpose()
+        },
+    )?;
 
     let members = info
         .members
@@ -92,41 +98,39 @@ pub fn build<'ctx>(
     Ok(llvm::r#type::r#struct(context, &members, false))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn snapshot_take<'ctx, 'this>(
+fn build_dup<'ctx>(
     context: &'ctx Context,
+    module: &Module<'ctx>,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    mut entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
     metadata: &mut MetadataStorage,
-    info: WithSelf<StructConcreteType>,
-    src_value: Value<'ctx, 'this>,
-) -> Result<(&'this Block<'ctx>, Value<'ctx, 'this>)> {
-    let self_ty = registry.build_type(context, helper, registry, metadata, info.self_ty)?;
-    let mut value = entry.append_op_result(llvm::undef(self_ty, location))?;
+    info: &WithSelf<StructConcreteType>,
+) -> Result<Region<'ctx>> {
+    let location = Location::unknown(context);
 
-    for (member_idx, member_id) in info.members.iter().enumerate() {
-        let member_ty = registry.build_type(context, helper, registry, metadata, member_id)?;
-        let member_val =
-            entry.extract_value(context, location, src_value, member_ty, member_idx)?;
+    let self_ty = registry.build_type(context, module, registry, metadata, info.self_ty())?;
 
-        // The following unwrap is unreachable because we've already check that at least one of the
-        // struct's members have a custom clone implementation before registering this function.
-        let dup_override_meta = metadata.get::<DupOverrideMeta>().unwrap();
+    let region = Region::new();
+    let entry = region.append_block(Block::new(&[(self_ty, location)]));
 
-        let cloned_member_val;
-        (entry, cloned_member_val) = match dup_override_meta.wrap_invoke(member_id) {
-            Some(clone_fn) => clone_fn(
-                context, registry, entry, location, helper, metadata, member_val,
-            )?,
-            None => (entry, member_val),
-        };
+    let mut src_value = entry.argument(0)?.into();
+    let mut dst_value = entry.append_op_result(llvm::undef(self_ty, location))?;
 
-        value = entry.insert_value(context, location, value, cloned_member_val, member_idx)?;
+    for (idx, member_id) in info.members.iter().enumerate() {
+        let member_ty = registry.build_type(context, module, registry, metadata, member_id)?;
+        let member_val = entry.extract_value(context, location, src_value, member_ty, idx)?;
+
+        // The following unwrap is unreachable because the registration logic will always insert it.
+        let values = metadata
+            .get::<DupOverrideMeta>()
+            .unwrap()
+            .invoke_override(context, &entry, location, member_id, member_val)?;
+
+        src_value = entry.insert_value(context, location, src_value, values.0, idx)?;
+        dst_value = entry.insert_value(context, location, dst_value, values.1, idx)?;
     }
 
-    Ok((entry, value))
+    entry.append_operation(func::r#return(&[src_value, dst_value], location));
+    Ok(region)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -36,7 +36,7 @@ use super::{TypeBuilder, WithSelf};
 use crate::{
     error::Result,
     libfuncs::LibfuncHelper,
-    metadata::{dup_overrides::DupOverrideMeta, MetadataStorage},
+    metadata::{dup_overrides::DupOverridesMeta, MetadataStorage},
     utils::{BlockExt, ProgramRegistryExt},
 };
 use cairo_lang_sierra::{
@@ -62,7 +62,7 @@ pub fn build<'ctx>(
     metadata: &mut MetadataStorage,
     info: WithSelf<StructConcreteType>,
 ) -> Result<Type<'ctx>> {
-    DupOverrideMeta::register_with(
+    DupOverridesMeta::register_with(
         context,
         module,
         registry,
@@ -75,7 +75,7 @@ pub fn build<'ctx>(
             for member in &info.members {
                 registry.build_type(context, module, registry, metadata, member)?;
                 if metadata
-                    .get::<DupOverrideMeta>()
+                    .get::<DupOverridesMeta>()
                     .unwrap()
                     .is_overriden(member)
                 {
@@ -121,7 +121,7 @@ fn build_dup<'ctx>(
 
         // The following unwrap is unreachable because the registration logic will always insert it.
         let values = metadata
-            .get::<DupOverrideMeta>()
+            .get::<DupOverridesMeta>()
             .unwrap()
             .invoke_override(context, &entry, location, member_id, member_val)?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -302,24 +302,24 @@ pub fn register_runtime_symbols(engine: &ExecutionEngine) {
         );
 
         engine.register_symbol(
-            "cairo_native__alloc_dict",
-            cairo_native_runtime::cairo_native__alloc_dict as *const fn() -> *mut FeltDict
+            "cairo_native__dict_new",
+            cairo_native_runtime::cairo_native__dict_new as *const fn() -> *mut FeltDict as *mut (),
+        );
+
+        engine.register_symbol(
+            "cairo_native__dict_drop",
+            cairo_native_runtime::cairo_native__dict_drop
+                as *const fn(*mut FeltDict, Option<extern "C" fn(*mut std::ffi::c_void)>) -> ()
                 as *mut (),
         );
 
         engine.register_symbol(
-            "cairo_native__dict_free",
-            cairo_native_runtime::cairo_native__dict_free as *const fn(*mut FeltDict) -> ()
-                as *mut (),
-        );
-
-        engine.register_symbol(
-            "cairo_native__dict_values",
-            cairo_native_runtime::cairo_native__dict_values
+            "cairo_native__dict_dup",
+            cairo_native_runtime::cairo_native__dict_dup
                 as *const fn(
                     *mut FeltDict,
-                    *mut u64,
-                ) -> *mut ([u8; 32], std::ptr::NonNull<libc::c_void>) as *mut (),
+                    extern "C" fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void,
+                ) -> *mut FeltDict as *mut (),
         );
 
         engine.register_symbol(
@@ -336,7 +336,6 @@ pub fn register_runtime_symbols(engine: &ExecutionEngine) {
                     *mut FeltDict,
                     &[u8; 32],
                     NonNull<std::ffi::c_void>,
-                    usize,
                 ) -> *mut std::ffi::c_void as *mut (),
         );
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -404,7 +404,7 @@ impl Value {
                                 elem_layout.size(),
                             );
 
-                            value_map.0.insert(
+                            value_map.inner.insert(
                                 key,
                                 NonNull::new(value_malloc_ptr)
                                     .expect("allocation failure")
@@ -690,15 +690,15 @@ impl Value {
                 }
                 CoreTypeConcrete::Felt252Dict(info)
                 | CoreTypeConcrete::SquashedFelt252Dict(info) => {
-                    let (map, _) = *Box::from_raw(
+                    let FeltDict { inner, .. } = *Box::from_raw(
                         ptr.cast::<NonNull<()>>()
                             .as_ref()
                             .cast::<FeltDict>()
                             .as_ptr(),
                     );
 
-                    let mut output_map = HashMap::with_capacity(map.len());
-                    for (key, val_ptr) in map.iter() {
+                    let mut output_map = HashMap::with_capacity(inner.len());
+                    for (key, val_ptr) in inner.iter() {
                         let key = Felt::from_bytes_le(key);
                         output_map.insert(key, Self::from_jit(val_ptr.cast(), &info.ty, registry)?);
                         libc::free(val_ptr.as_ptr());

--- a/src/values.rs
+++ b/src/values.rs
@@ -653,10 +653,9 @@ impl Value {
                     let payload_ptr =
                         NonNull::new(ptr.as_ptr().byte_add(tag_layout.extend(payload_layout)?.1))
                             .unwrap();
-                    let payload =
-                        Value::from_jit(payload_ptr, &info.variants[tag_value], registry)?;
+                    let payload = Self::from_jit(payload_ptr, &info.variants[tag_value], registry)?;
 
-                    Value::Enum {
+                    Self::Enum {
                         tag: tag_value,
                         value: Box::new(payload),
                         debug_name: type_id.debug_name.as_ref().map(|x| x.to_string()),
@@ -683,7 +682,7 @@ impl Value {
                         )?);
                     }
 
-                    Value::Struct {
+                    Self::Struct {
                         fields: members,
                         debug_name: type_id.debug_name.as_ref().map(|x| x.to_string()),
                     }
@@ -704,7 +703,7 @@ impl Value {
                         libc::free(val_ptr.as_ptr());
                     }
 
-                    Value::Felt252Dict {
+                    Self::Felt252Dict {
                         value: output_map,
                         debug_name: type_id.debug_name.as_ref().map(|x| x.to_string()),
                     }
@@ -731,7 +730,7 @@ impl Value {
                         // felt values
                         let data = ptr.cast::<[u8; 32]>().as_ref();
                         let data = Felt::from_bytes_le(data);
-                        Value::Felt252(data)
+                        Self::Felt252(data)
                     }
                     StarkNetTypeConcrete::System(_) => {
                         unimplemented!("should be handled before")
@@ -743,8 +742,8 @@ impl Value {
                         let y = (data[1][0], data[1][1]);
 
                         match info {
-                            Secp256PointTypeConcrete::K1(_) => Value::Secp256K1Point { x, y },
-                            Secp256PointTypeConcrete::R1(_) => Value::Secp256R1Point { x, y },
+                            Secp256PointTypeConcrete::K1(_) => Self::Secp256K1Point { x, y },
+                            Secp256PointTypeConcrete::R1(_) => Self::Secp256R1Point { x, y },
                         }
                     }
                     StarkNetTypeConcrete::Sha256StateHandle(_) => todo!(),

--- a/tests/tests/programs.rs
+++ b/tests/tests/programs.rs
@@ -369,6 +369,7 @@ proptest! {
 }
 
 #[test]
+#[ignore = "stack overflow (fixed by refactoring drop implementations)"]
 fn self_referencing_struct() {
     let result_vm = run_vm_program(
         &SELF_REFERENCING,

--- a/tests/tests/programs.rs
+++ b/tests/tests/programs.rs
@@ -369,7 +369,6 @@ proptest! {
 }
 
 #[test]
-#[ignore = "stack overflow (fixed by refactoring drop implementations)"]
 fn self_referencing_struct() {
     let result_vm = run_vm_program(
         &SELF_REFERENCING,


### PR DESCRIPTION
**Changes**
  - Rename a few things.
  - Remove `SnapshotClonesMeta`.
  - Remove old drop implementation system.
  - Add `DupOverridesMeta` (successor of `SnapshotClonesMeta`) and `DropOverridesMeta`.
  - Make all types that require it use the new dup and drop systems.
  - Refactor some dict methods to make them work with the new dup and drop system.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
