### PR TITLE
Update to 2.8.4, add release docs, version alpha.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,6 @@ jobs:
           - partition: 4
             output: lcov-4.info
     env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
       LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
       TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
@@ -257,7 +256,7 @@ jobs:
       - name: Build runtime and alexandria
         run: make runtime && make check-llvm && make needs-cairo2 && make build-alexandria
       - name: Build cairo-native-runtime library.
-        run: export PATH=$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH && cargo build --profile=ci --package=cairo-native-runtime
+        run: cargo build --profile=ci --package=cairo-native-runtime
 
       - name: Run tests and generate coverage partition ${{ matrix.partition }}
         run: cargo llvm-cov nextest --verbose --all-features --workspace --lcov --output-path ${{ matrix.output }} --partition count:${{ matrix.partition }}/4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install scarb
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.8.2"
+          scarb-version: "2.8.4"
       - name: Install deps
         run: make deps
       - name: Build cairo-native-runtime library.
@@ -251,7 +251,7 @@ jobs:
       - name: Install scarb
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.8.2"
+          scarb-version: "2.8.4"
       - name: Install deps
         run: make deps
       - name: Build runtime and alexandria

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,6 @@ jobs:
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
       - name: Install deps
         run: make deps
-      - name: Build cairo-native-runtime library.
-        run: cargo build --profile=ci --package=cairo-native-runtime
       - name: test
         run: make test-ci
       - name: test-cairo
@@ -183,8 +181,6 @@ jobs:
           scarb-version: "2.8.4"
       - name: Install deps
         run: make deps
-      - name: Build cairo-native-runtime library.
-        run: cargo build --profile=ci --package=cairo-native-runtime
       - name: Run tests
         run: make test-ci
       - name: test-cairo
@@ -254,9 +250,7 @@ jobs:
       - name: Install deps
         run: make deps
       - name: Build runtime and alexandria
-        run: make runtime && make check-llvm && make needs-cairo2 && make build-alexandria
-      - name: Build cairo-native-runtime library.
-        run: cargo build --profile=ci --package=cairo-native-runtime
+        run: make runtime-ci && make check-llvm && make needs-cairo2 && make build-alexandria
 
       - name: Run tests and generate coverage partition ${{ matrix.partition }}
         run: cargo llvm-cov nextest --verbose --all-features --workspace --lcov --output-path ${{ matrix.output }} --partition count:${{ matrix.partition }}/4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: free HDD space
         run: |
           # deleting space

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: free HDD space
         run: |
           # deleting space

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a4b4ca8473c25d1e760c83c2a49d953197556f82f6feb636004d3b6d6cc4a7"
+checksum = "fd4d6659539ace9649c8e8a7434e51b0c50a7a700111d0a2b967dde220ddff49"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5852668d1c6966b34d6e4fe249732769ab9cb2012c201e3889d8119f206760a0"
+checksum = "e2016966ed29f3a44487fd1bbdb05320fb6ea8ec46201c04c6b222ccb5264e0a"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -473,18 +473,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0644fab571f598547993936918c85f0e89b0bbc15140ca3ea723bff376be07d"
+checksum = "50c804649297ca417206435ee3e8041d2100cc31ebf4a95bc4b92ed02dc63469"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5f437d75ac25644880458effde562edcac45a888d27f2e497d30c6450fa97d"
+checksum = "e8fbda467ac36f73bb1879e1f741898fc719d6f9239a01cc422e6a023281319b"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec5b44d3eaf50e28e068d163e56b9effcea6afe3625c32dd96418d2d4ebc34c"
+checksum = "c843ef4715e3d21de5388d02206db2506e2d2ec0e80e2629e0ae9900a08b8674"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cd844e568f51e39729e8ac18bd27ada2e2b6dc9138f8c81adad48456480681"
+checksum = "33a416c5871960fb4823160ebef2abc51e0c1b86fef1e97a1ebb2e5f3c3795d3"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323a2385e000589f7591f8a46599b4a462db6e36e5935bad3bceddcc1a1608e1"
+checksum = "47189e0cb84b21defd201af4cf24a94c6b0d09f48706cf659c9ffa0def8a7a43"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf9cf637e12d41260dc59f3d988c76a6347424913ac8b6b8449ff3e79b59750"
+checksum = "6409ff1f4a93ce7c0968d9d857d2a8c03657617a827159d33f978110b718b31d"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d71bc5b1f19a00eb662c2cac33259b16b9cdbf9c005047aca0d538c13936407"
+checksum = "1e224e006c82ef21bd9e243390992de2be25ae6fbbdaa8544067b3f0c31977f1"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d939d258e26ace0f3cb1e50338ae18981a7505e3c20eabd24a62d70ee862d6c"
+checksum = "afb260ba349c2b699639e56f9b64deb969ff01179a0253087e2c8ceec7e32157"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67a553a6d2d2b54264e77e3c8cb5bc866b40b32d5e2144a58b74c559c7e289f"
+checksum = "05a2e500dc8ddea4d25a866d8a839158b0e4c41a6c023f21911e2da252bd91b3"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33b5f4502b7efde6ac07fd5468f6dae15d88760aeece3d57a7bc4c224ba693e"
+checksum = "d72f17373740f242d6995e896b9195c2cedff7e8b14e496afdd16b405039d1fb"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63d6a3cc86a79a29978acaaf6f94738c5487e265247fe06c7bf359645d8c200"
+checksum = "13294f08d2013fcd6e815e7235935680963dec3390e5baf454f33da866fc44b6"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528a247ac59cb35b2f99d64605a81de815fa5fb0b0e7f7ece1d4e7fcf267d4ea"
+checksum = "6c5b9e6a21d92255b92f64c60658b4224dd7d290cde8beea783fadc10fbfcd8c"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c284031fd14796dad91483c3039d7929f8440e1e9e334017744b1d22df5aa8"
+checksum = "6936215bca75c23e71873998420a3d46c322507a09917ce676c8d39f8c1bd6fe"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891488c1a3184ce91679f5bdb63015a1d24769a48bd07e5d51a1779d0031dfbe"
+checksum = "424f55450494e959c1ae26c52a71075767a90f76e3ecca6e81056dd7517e8ba0"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7752cd48c86b2cde8603b753a6df4da086dacd16a73d288854d5f040b51171"
+checksum = "053dd520e0b9d1c1078d93ea69045f6f334c3d41b4b75db183ab33e32cfd8570"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340892a09c9421414b2ac45b03c705f16e2bd737e4559dfd98ee1d20718dec9e"
+checksum = "9a73227867377efc62ebb893cddaa88df3940bf2be5dbdc2f0b00f9edf69288e"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5cc616e8df44c4d685fe3c5f81f35ebbda57225098b35cea8602457c45c9e96"
+checksum = "a3752cacd475ea089d9a536357804150e693a124e703fcc33a55566d568094b3"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c22ff7e8113a46a907f82f191096c96935cc48247e3079971ddf536ccc2f4f8"
+checksum = "7162fb3c93960dfc6d8005b65064e518e3f1ed6102e8981b42ea41879c331184"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf41941776e7410a8853a8e2a116292fc24d219df1989a92ffe5ab0e98037eb"
+checksum = "a51b80c117e2b05a6d300f2e2247892cc99e42e950e79f6085e6ed6cbcb44d12"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5508fa5ee8d24adf7d2c65505d0ac35efc892eac16d1449c6f7e314a0288cb8"
+checksum = "aafaabc43f78dfa2f45d935993ba21c05c164bbb3bf277d348847a51e5939a9f"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482b8f9d7f8cc7140f1260ee71f3308a66d15bd228a06281067ca3f8f4410db2"
+checksum = "832fd9072ddf4204ca6d227c0238929349f10146bd066a98025d51ac15d27fad"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db0776c3d06cea65d7afe7a3c7685f6867eb6d951cf505caf35abfd1746773b"
+checksum = "cebe67c0d68f9acf8709d170c1308ca57a778d22f70da38a57f74ae250eee28a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce0f7fa01c26cc731bc1d6350ac02fae91a68b5fdf60e684f991e861715adc4"
+checksum = "31cef5b4347626e61bad8f070495cd35d637a5cb6744c34d20dd382c7431aff8"
 dependencies = [
  "genco",
  "xshell",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1597b8229a3649183ff33b19f0aeca5d86505253ebbbce377b271d1732835"
+checksum = "4d5f036132e07b7829cb1d61b1ecc02789a70c7d16b2733722a2aca992492bc3"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630a070a69c387eee9c0eda65e4f2508d129d4fbe081091077e661020ab95637"
+checksum = "060c61ac4a3ae0428771244ff8db903105f127392b7d725d919fe3fb1ec4132f"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.8.2"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73104609a7d865e4cd1de9cbf4e750683d076b6d0233bf81be511df274a26916"
+checksum = "8bfc6372538143afad658c853a35bdc9f5210c5cb54e0c8f04ab78e268139466"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-native"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -979,7 +979,7 @@ dependencies = [
  "itertools 0.13.0",
  "k256",
  "keccak",
- "lambdaworks-math 0.10.0",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "libloading",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-native-runtime"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "cairo-lang-sierra-gas",
  "itertools 0.13.0",
@@ -1086,9 +1086,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
@@ -1729,6 +1729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,9 +1742,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1751,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1761,15 +1767,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1778,15 +1784,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1795,15 +1801,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -1813,9 +1819,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1956,6 +1962,11 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2264,24 +2275,14 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb5d4f22241504f7c7b8d2c3a7d7835d7c07117f10bff2a7d96a9ef6ef217c3"
+checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
 dependencies = [
- "lambdaworks-math 0.7.0",
+ "lambdaworks-math",
  "serde",
  "sha2",
  "sha3",
-]
-
-[[package]]
-name = "lambdaworks-math"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358e172628e713b80a530a59654154bfc45783a6ed70ea284839800cebdf8f97"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2380,11 +2381,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -2604,12 +2605,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -2919,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -3120,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3132,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
 dependencies = [
  "cfg-if",
  "glob",
@@ -3577,12 +3575,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b889ee5734db8b3c8a6551135c16764bf4ce1ab4955fffbb2ac5b6706542b64"
+checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
 dependencies = [
  "lambdaworks-crypto",
- "lambdaworks-math 0.7.0",
+ "lambdaworks-math",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -3931,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 dependencies = [
  "serde",
  "stable_deref_trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-native"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A compiler to convert Cairo's intermediate representation Sierra code to MLIR."
@@ -58,42 +58,42 @@ normal = ["aquamarine"]
 [dependencies]
 aquamarine = "0.5.0"
 bumpalo = "3.16.0"
-cairo-lang-compiler = "2.8.2"
-cairo-lang-defs = "2.8.2"
-cairo-lang-filesystem = "2.8.2"
-cairo-lang-semantic = "2.8.2"
-cairo-lang-sierra = "2.8.2"
-cairo-lang-sierra-generator = "2.8.2"
-cairo-lang-diagnostics = "2.8.2"
+cairo-lang-compiler = "2.8.4"
+cairo-lang-defs = "2.8.4"
+cairo-lang-filesystem = "2.8.4"
+cairo-lang-semantic = "2.8.4"
+cairo-lang-sierra = "2.8.4"
+cairo-lang-sierra-generator = "2.8.4"
+cairo-lang-diagnostics = "2.8.4"
 educe = "0.5.11" # can't update until https://github.com/magiclen/educe/issues/27
 itertools = "0.13.0"
-lazy_static = "1.4"
+lazy_static = "1.5"
 libc = "0.2"
 llvm-sys = "191.0.0"
 melior = { version = "0.19.0", features = ["ods-dialects"] }
 mlir-sys = { version = "0.3.0" }
-num-bigint = "0.4.4"
+num-bigint = "0.4.6"
 num-traits = "0.2"
-starknet-types-core = { version = "0.1.5", default-features = false, features = [
+starknet-types-core = { version = "0.1.7", default-features = false, features = [
     "std",
     "serde",
     "num-traits",
 ] }
-tempfile = "3.6"
+tempfile = "3.13"
 thiserror = "1.0.64"
 tracing = "0.1"
 utf8_iter = "1.0.4"
 
 
 # CLI dependencies
-cairo-lang-sierra-ap-change = "2.8.2"
-cairo-lang-sierra-gas = "2.8.2"
-cairo-lang-starknet = "2.8.2"
-cairo-lang-utils = "2.8.2"
-cairo-lang-starknet-classes = "2.8.2"
-cairo-native-runtime = { version = "0.2.0-alpha.2", path = "runtime", optional = true }
-clap = { version = "4.5.18", features = ["derive"], optional = true }
-libloading = "0.8.3"
+cairo-lang-sierra-ap-change = "2.8.4"
+cairo-lang-sierra-gas = "2.8.4"
+cairo-lang-starknet = "2.8.4"
+cairo-lang-utils = "2.8.4"
+cairo-lang-starknet-classes = "2.8.4"
+cairo-native-runtime = { version = "0.2.0-alpha.3", path = "runtime", optional = true }
+clap = { version = "4.5.19", features = ["derive"], optional = true }
+libloading = "0.8.5"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",
@@ -101,8 +101,8 @@ tracing-subscriber = { version = "0.3.18", features = [
 ], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "1.0", optional = true }
-cairo-lang-test-plugin = { version = "2.8.2", optional = true }
-cairo-lang-runner = { version = "2.8.2", optional = true }
+cairo-lang-test-plugin = { version = "2.8.4", optional = true }
+cairo-lang-runner = { version = "2.8.4", optional = true }
 colored = { version = "2.1.0", optional = true }
 # needed to interface with cairo-lang-*
 keccak = "0.1.5"
@@ -112,24 +112,24 @@ sha2 = "0.10.8"                                          # needed for the syscal
 scarb-metadata = { version = "1.12.0", optional = true }
 scarb-ui = { version = "0.1.5", optional = true }
 sec1 = "0.7.3"
-serde_json = { version = "1.0.125" }
+serde_json = { version = "1.0.128" }
 stats_alloc = "0.1.10"
 
 [dev-dependencies]
 cairo-vm = { version = "1.0.1", features = ["cairo-1-hints"] }
-cairo-lang-runner = "2.8.2"
-cairo-lang-semantic = { version = "2.8.2", features = ["testing"] }
+cairo-lang-runner = "2.8.4"
+cairo-lang-semantic = { version = "2.8.4", features = ["testing"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.10.0"
 pretty_assertions_sorted = "1.2.3"
-proptest = "1.4.0"
-rstest = "0.22.0"
+proptest = "1.5.0"
+rstest = "0.23.0"
 test-case = "3.3"
 walkdir = "2.5.0"
-serde_json = { version = "1.0.117" }
+serde_json = { version = "1.0.128" }
 
 [build-dependencies]
-cc = "1.1.21"
+cc = "1.1.28"
 
 [profile.optimized-dev]
 inherits = "dev"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Environment detection.
 
 UNAME := $(shell uname)
-CAIRO_2_VERSION = 2.8.2
-SCARB_VERSION = 2.8.3
+CAIRO_2_VERSION = 2.8.4
+SCARB_VERSION = 2.8.4
 
 # Usage is the default target for newcomers running `make`.
 .PHONY: usage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to machine code via MLIR and LLVM.
 [![codecov](https://img.shields.io/codecov/c/github/lambdaclass/cairo_native)](https://codecov.io/gh/lambdaclass/cairo_native)
 [![license](https://img.shields.io/github/license/lambdaclass/cairo_native)](/LICENSE)
 [![pr-welcome]](#-contributing)
+[![Crates.io Version](https://img.shields.io/crates/v/cairo_native)](https://crates.io/crates/cairo-native)
+
 
 [tg-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Ftg.sumanjay.workers.dev%2FLambdaStarkNet%2F&logo=telegram&label=chat&color=neon
 [tg-url]: https://t.me/LambdaStarkNet

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,10 @@
+# Release Process
+
+- Update version on root Cargo.toml
+- Update version on runtime Cargo.toml
+- Update Cargo.toml runtime dependency version to match the new version
+- Make a PR
+- Wait for PR to be merged
+- Pull changes once merged
+- `git tag v<version>`
+- `git push --tags` # this will test, build and publish the version if successful.

--- a/env.sh
+++ b/env.sh
@@ -11,24 +11,24 @@ case $(uname) in
     MLIR_SYS_190_PREFIX="$(brew --prefix llvm@19)"
     LLVM_SYS_191_PREFIX="$(brew --prefix llvm@19)"
     TABLEGEN_190_PREFIX="$(brew --prefix llvm@19)"
-    CAIRO_NATIVE_RUNTIME_LIBDIR="$(pwd)/target/debug"
+    CAIRO_NATIVE_RUNTIME_LIBRARY="$(pwd)/target/debug/libcairo_native_runtime.a"
 
     export LIBRARY_PATH
     export MLIR_SYS_190_PREFIX
     export LLVM_SYS_191_PREFIX
     export TABLEGEN_190_PREFIX
-    export CAIRO_NATIVE_RUNTIME_LIBDIR
+    export CAIRO_NATIVE_RUNTIME_LIBRARY
   ;;
   Linux)
     # If installed from Debian/Ubuntu repository:
     MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
     LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
     TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-    CAIRO_NATIVE_RUNTIME_LIBDIR="$(pwd)/target/debug"
+    CAIRO_NATIVE_RUNTIME_LIBRARY="$(pwd)/target/debug/libcairo_native_runtime.a"
 
     export MLIR_SYS_190_PREFIX
     export LLVM_SYS_191_PREFIX
     export TABLEGEN_190_PREFIX
-    export CAIRO_NATIVE_RUNTIME_LIBDIR
+    export CAIRO_NATIVE_RUNTIME_LIBRARY
   ;;
 esac

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-native-runtime"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "A compiler to convert Cairo's intermediate representation Sierra code to MLIR."
 edition = "2021"
 license = "Apache-2.0"
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-starknet-types-core = { version = "0.1.5", default-features = false, features = [
+starknet-types-core = { version = "0.1.7", default-features = false, features = [
     "std", "serde", "hash"
 ] }
-cairo-lang-sierra-gas = "2.8.2"
+cairo-lang-sierra-gas = "2.8.4"
 libc = "0.2"
-starknet-curve = "0.5.0"
+starknet-curve = "0.5.1"
 lazy_static = "1.5.0"
 rand = "0.8.5"
 itertools = "0.13.0"

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -59,7 +59,7 @@ impl<'a> AbiArgument for JitValueWithInfoWrapper<'a> {
     fn to_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), error::Error> {
         match (self.value, self.info) {
             (value, CoreTypeConcrete::Box(info)) => {
-                let ptr = value.to_jit(self.arena, self.registry, self.type_id)?;
+                let ptr = value.to_ptr(self.arena, self.registry, self.type_id)?;
 
                 let layout = self.registry.get_type(&info.ty)?.layout(self.registry)?;
                 let heap_ptr = unsafe {
@@ -74,7 +74,7 @@ impl<'a> AbiArgument for JitValueWithInfoWrapper<'a> {
                 if matches!(value, Value::Null) {
                     null::<()>().to_bytes(buffer)?;
                 } else {
-                    let ptr = value.to_jit(self.arena, self.registry, self.type_id)?;
+                    let ptr = value.to_ptr(self.arena, self.registry, self.type_id)?;
 
                     let layout = self.registry.get_type(&info.ty)?.layout(self.registry)?;
                     let heap_ptr = unsafe {
@@ -93,7 +93,7 @@ impl<'a> AbiArgument for JitValueWithInfoWrapper<'a> {
             (Value::Array(_), CoreTypeConcrete::Array(_)) => {
                 // TODO: Assert that `info.ty` matches all the values' types.
 
-                let abi_ptr = self.value.to_jit(self.arena, self.registry, self.type_id)?;
+                let abi_ptr = self.value.to_ptr(self.arena, self.registry, self.type_id)?;
                 let abi = unsafe { abi_ptr.cast::<ArrayAbi<()>>().as_ref() };
 
                 abi.ptr.to_bytes(buffer)?;
@@ -115,7 +115,7 @@ impl<'a> AbiArgument for JitValueWithInfoWrapper<'a> {
             }
             (Value::Enum { tag, value, .. }, CoreTypeConcrete::Enum(info)) => {
                 if self.info.is_memory_allocated(self.registry)? {
-                    let abi_ptr = self.value.to_jit(self.arena, self.registry, self.type_id)?;
+                    let abi_ptr = self.value.to_ptr(self.arena, self.registry, self.type_id)?;
 
                     let abi_ptr = unsafe { *abi_ptr.cast::<NonNull<()>>().as_ref() };
                     abi_ptr.as_ptr().to_bytes(buffer)?;
@@ -145,7 +145,7 @@ impl<'a> AbiArgument for JitValueWithInfoWrapper<'a> {
                 // TODO: Assert that `info.ty` matches all the values' types.
 
                 self.value
-                    .to_jit(self.arena, self.registry, self.type_id)?
+                    .to_ptr(self.arena, self.registry, self.type_id)?
                     .as_ptr()
                     .to_bytes(buffer)?
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,8 +54,11 @@ pub enum Error {
     #[error(transparent)]
     GasMetadataError(#[from] GasMetadataError),
 
-    #[error("llvm error")]
+    #[error("llvm compile error: {0}")]
     LLVMCompileError(String),
+
+    #[error("ld link error: {0}")]
+    LinkError(String),
 
     #[error("cairo const data mismatch")]
     ConstDataMismatch,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -332,15 +332,15 @@ fn parse_result(
     }
 
     match type_info {
-        CoreTypeConcrete::Array(_) => Ok(Value::from_jit(return_ptr.unwrap(), type_id, registry)?),
+        CoreTypeConcrete::Array(_) => Ok(Value::from_ptr(return_ptr.unwrap(), type_id, registry)?),
         CoreTypeConcrete::Box(info) => unsafe {
             let ptr = return_ptr.unwrap_or(NonNull::new_unchecked(ret_registers[0] as *mut ()));
-            let value = Value::from_jit(ptr, &info.ty, registry)?;
+            let value = Value::from_ptr(ptr, &info.ty, registry)?;
             libc::free(ptr.cast().as_ptr());
             Ok(value)
         },
         CoreTypeConcrete::EcPoint(_) | CoreTypeConcrete::EcState(_) => {
-            Ok(Value::from_jit(return_ptr.unwrap(), type_id, registry)?)
+            Ok(Value::from_ptr(return_ptr.unwrap(), type_id, registry)?)
         }
         CoreTypeConcrete::Felt252(_)
         | CoreTypeConcrete::StarkNet(
@@ -349,7 +349,7 @@ fn parse_result(
             | StarkNetTypeConcrete::StorageAddress(_)
             | StarkNetTypeConcrete::StorageBaseAddress(_),
         ) => match return_ptr {
-            Some(return_ptr) => Ok(Value::from_jit(return_ptr, type_id, registry)?),
+            Some(return_ptr) => Ok(Value::from_ptr(return_ptr, type_id, registry)?),
             None => {
                 #[cfg(target_arch = "x86_64")]
                 // Since x86_64's return values hold at most two different 64bit registers,
@@ -366,7 +366,7 @@ fn parse_result(
             }
         },
         CoreTypeConcrete::Bytes31(_) => match return_ptr {
-            Some(return_ptr) => Ok(Value::from_jit(return_ptr, type_id, registry)?),
+            Some(return_ptr) => Ok(Value::from_ptr(return_ptr, type_id, registry)?),
             None => {
                 #[cfg(target_arch = "x86_64")]
                 // Since x86_64's return values hold at most two different 64bit registers,
@@ -381,7 +381,7 @@ fn parse_result(
             }
         },
         CoreTypeConcrete::BoundedInt(info) => match return_ptr {
-            Some(return_ptr) => Ok(Value::from_jit(return_ptr, type_id, registry)?),
+            Some(return_ptr) => Ok(Value::from_ptr(return_ptr, type_id, registry)?),
             None => {
                 let mut data = if info.range.offset_bit_width() <= 64 {
                     BigInt::from(ret_registers[0])
@@ -453,7 +453,7 @@ fn parse_result(
                 Ok(Value::Null)
             } else {
                 let ptr = NonNull::new_unchecked(ptr);
-                let value = Value::from_jit(ptr, &info.ty, registry)?;
+                let value = Value::from_ptr(ptr, &info.ty, registry)?;
                 libc::free(ptr.as_ptr().cast());
                 Ok(value)
             }
@@ -503,7 +503,7 @@ fn parse_result(
                 }
             };
             let value = match ptr {
-                Ok(ptr) => Box::new(Value::from_jit(ptr, &info.variants[tag], registry)?),
+                Ok(ptr) => Box::new(Value::from_ptr(ptr, &info.variants[tag], registry)?),
                 Err(offset) => {
                     ret_registers.copy_within(offset.., 0);
                     Box::new(parse_result(
@@ -528,14 +528,14 @@ fn parse_result(
                     debug_name: Some(debug_name),
                 })
             } else {
-                Ok(Value::from_jit(return_ptr.unwrap(), type_id, registry)?)
+                Ok(Value::from_ptr(return_ptr.unwrap(), type_id, registry)?)
             }
         }
         CoreTypeConcrete::Felt252Dict(_) | CoreTypeConcrete::SquashedFelt252Dict(_) => unsafe {
             let ptr = return_ptr.unwrap_or(NonNull::new_unchecked(
                 addr_of_mut!(ret_registers[0]) as *mut ()
             ));
-            Ok(Value::from_jit(ptr, type_id, registry)?)
+            Ok(Value::from_ptr(ptr, type_id, registry)?)
         },
 
         CoreTypeConcrete::Snapshot(info) => {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -260,7 +260,6 @@ pub fn object_to_shared_lib(object: &[u8], output_filename: &Path) -> Result<()>
                 "-o".into(),
                 Cow::from(output_path),
                 "-lc".into(),
-                //"-lcairo_native_runtime".into(),
                 Cow::from(file_path),
             ]);
 
@@ -284,7 +283,7 @@ pub fn object_to_shared_lib(object: &[u8], output_filename: &Path) -> Result<()>
         Ok(())
     } else {
         let msg = String::from_utf8_lossy(&proc.stderr);
-        panic!("error linking:\n{}", msg);
+        Err(Error::LinkError(msg.to_string()))
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -24,11 +24,11 @@ use num_traits::{Euclid, One};
 use starknet_types_core::felt::Felt;
 use std::{alloc::Layout, collections::HashMap, ptr::NonNull, slice};
 
-/// A JitValue is a value that can be passed to the JIT engine as an argument or received as a result.
+/// A Value is a value that can be passed to either the JIT engine or a compiled program as an argument or received as a result.
 ///
 /// They map to the cairo/sierra types.
 ///
-/// The debug_name field on some variants is `Some` when receiving a [`JitValue`] as a result.
+/// The debug_name field on some variants is `Some` when receiving a [`Value`] as a result.
 ///
 /// A Boxed value or a non-null Nullable value is returned with it's inner value.
 #[derive(Clone, Educe, serde::Serialize, serde::Deserialize)]
@@ -180,8 +180,8 @@ impl Value {
         })
     }
 
-    /// Allocates the value in the given arena so it can be passed to the JIT engine.
-    pub(crate) fn to_jit(
+    /// Allocates the value in the given arena so it can be passed to the JIT engine or a compiled program.
+    pub(crate) fn to_ptr(
         &self,
         arena: &Bump,
         registry: &ProgramRegistry<CoreType, CoreLibfunc>,
@@ -246,7 +246,7 @@ impl Value {
                             .map_err(|_| Error::IntegerConversion)?;
 
                         for (idx, elem) in data.iter().enumerate() {
-                            let elem = elem.to_jit(arena, registry, &info.ty)?;
+                            let elem = elem.to_ptr(arena, registry, &info.ty)?;
 
                             std::ptr::copy_nonoverlapping(
                                 elem.cast::<u8>().as_ptr(),
@@ -305,7 +305,7 @@ impl Value {
                             };
                             layout = Some(new_layout);
 
-                            let member_ptr = member.to_jit(arena, registry, member_type_id)?;
+                            let member_ptr = member.to_ptr(arena, registry, member_type_id)?;
                             data.push((
                                 member_layout,
                                 offset,
@@ -351,7 +351,7 @@ impl Value {
                         assert!(*tag < info.variants.len(), "Variant index out of range.");
 
                         let payload_type_id = &info.variants[*tag];
-                        let payload = value.to_jit(arena, registry, payload_type_id)?;
+                        let payload = value.to_ptr(arena, registry, payload_type_id)?;
 
                         let (layout, tag_layout, variant_layouts) =
                             crate::types::r#enum::get_layout_for_variants(registry, &info.variants)
@@ -394,7 +394,7 @@ impl Value {
 
                         for (key, value) in map.iter() {
                             let key = key.to_bytes_le();
-                            let value = value.to_jit(arena, registry, &info.ty)?;
+                            let value = value.to_ptr(arena, registry, &info.ty)?;
 
                             let value_malloc_ptr = libc::malloc(elem_layout.size());
 
@@ -517,8 +517,8 @@ impl Value {
         })
     }
 
-    /// From the given pointer acquired from the JIT outputs, convert it to a [`Self`]
-    pub(crate) fn from_jit(
+    /// From the given pointer acquired from the either the JIT / compiled program outputs, convert it to a [`Self`]
+    pub(crate) fn from_ptr(
         ptr: NonNull<()>,
         type_id: &ConcreteTypeId,
         registry: &ProgramRegistry<CoreType, CoreLibfunc>,
@@ -561,7 +561,7 @@ impl Value {
                         let cur_elem_ptr =
                             NonNull::new(data_ptr.byte_add(elem_stride * i)).unwrap();
 
-                        array_value.push(Self::from_jit(cur_elem_ptr, &info.ty, registry)?);
+                        array_value.push(Self::from_ptr(cur_elem_ptr, &info.ty, registry)?);
                     }
 
                     if !init_data_ptr.is_null() {
@@ -572,7 +572,7 @@ impl Value {
                 }
                 CoreTypeConcrete::Box(info) => {
                     let inner = *ptr.cast::<NonNull<()>>().as_ptr();
-                    let value = Self::from_jit(inner, &info.ty, registry)?;
+                    let value = Self::from_ptr(inner, &info.ty, registry)?;
                     libc::free(inner.as_ptr().cast());
                     value
                 }
@@ -607,13 +607,13 @@ impl Value {
                 CoreTypeConcrete::Sint32(_) => Self::Sint32(*ptr.cast::<i32>().as_ref()),
                 CoreTypeConcrete::Sint64(_) => Self::Sint64(*ptr.cast::<i64>().as_ref()),
                 CoreTypeConcrete::Sint128(_) => Self::Sint128(*ptr.cast::<i128>().as_ref()),
-                CoreTypeConcrete::NonZero(info) => Self::from_jit(ptr, &info.ty, registry)?,
+                CoreTypeConcrete::NonZero(info) => Self::from_ptr(ptr, &info.ty, registry)?,
                 CoreTypeConcrete::Nullable(info) => {
                     let inner_ptr = *ptr.cast::<*mut ()>().as_ptr();
                     if inner_ptr.is_null() {
                         Self::Null
                     } else {
-                        let value = Self::from_jit(
+                        let value = Self::from_ptr(
                             NonNull::new_unchecked(inner_ptr).cast(),
                             &info.ty,
                             registry,
@@ -623,7 +623,7 @@ impl Value {
                     }
                 }
                 CoreTypeConcrete::Uninitialized(_) => {
-                    todo!("implement uninit from_jit or ignore the return value")
+                    todo!("implement uninit from_ptr or ignore the return value")
                 }
                 CoreTypeConcrete::Enum(info) => {
                     let tag_layout = crate::utils::get_integer_layout(match info.variants.len() {
@@ -653,7 +653,7 @@ impl Value {
                     let payload_ptr =
                         NonNull::new(ptr.as_ptr().byte_add(tag_layout.extend(payload_layout)?.1))
                             .unwrap();
-                    let payload = Self::from_jit(payload_ptr, &info.variants[tag_value], registry)?;
+                    let payload = Self::from_ptr(payload_ptr, &info.variants[tag_value], registry)?;
 
                     Self::Enum {
                         tag: tag_value,
@@ -675,7 +675,7 @@ impl Value {
                         };
                         layout = Some(new_layout);
 
-                        members.push(Self::from_jit(
+                        members.push(Self::from_ptr(
                             NonNull::new(ptr.as_ptr().byte_add(offset)).unwrap(),
                             member_ty,
                             registry,
@@ -699,7 +699,7 @@ impl Value {
                     let mut output_map = HashMap::with_capacity(inner.len());
                     for (key, val_ptr) in inner.iter() {
                         let key = Felt::from_bytes_le(key);
-                        output_map.insert(key, Self::from_jit(val_ptr.cast(), &info.ty, registry)?);
+                        output_map.insert(key, Self::from_ptr(val_ptr.cast(), &info.ty, registry)?);
                         libc::free(val_ptr.as_ptr());
                     }
 
@@ -719,7 +719,7 @@ impl Value {
                 | CoreTypeConcrete::EcOp(_)
                 | CoreTypeConcrete::GasBuiltin(_)
                 | CoreTypeConcrete::SegmentArena(_) => {
-                    unimplemented!("handled before: {:?}", type_id)
+                    unreachable!("handled before: {:?}", type_id)
                 }
                 // Does it make sense for programs to return this? Should it be implemented
                 CoreTypeConcrete::StarkNet(selector) => match selector {
@@ -733,7 +733,7 @@ impl Value {
                         Self::Felt252(data)
                     }
                     StarkNetTypeConcrete::System(_) => {
-                        unimplemented!("should be handled before")
+                        unreachable!("should be handled before")
                     }
                     StarkNetTypeConcrete::Secp256Point(info) => {
                         let data = ptr.cast::<[[u128; 2]; 2]>().as_ref();
@@ -748,8 +748,8 @@ impl Value {
                     }
                     StarkNetTypeConcrete::Sha256StateHandle(_) => todo!(),
                 },
-                CoreTypeConcrete::Span(_) => todo!("implement span from_jit"),
-                CoreTypeConcrete::Snapshot(info) => Self::from_jit(ptr, &info.ty, registry)?,
+                CoreTypeConcrete::Span(_) => todo!("implement span from_ptr"),
+                CoreTypeConcrete::Snapshot(info) => Self::from_ptr(ptr, &info.ty, registry)?,
                 CoreTypeConcrete::Bytes31(_) => {
                     let data = *ptr.cast::<[u8; 31]>().as_ref();
                     Self::Bytes31(data)
@@ -953,7 +953,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Felt252(Felt::from(42))
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<[u32; 8]>()
                     .as_ptr()
@@ -964,7 +964,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Felt252(Felt::MAX)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<[u32; 8]>()
                     .as_ptr()
@@ -976,7 +976,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Felt252(Felt::MAX + Felt::ONE)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<[u32; 8]>()
                     .as_ptr()
@@ -994,7 +994,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Uint8(9)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<u8>()
                     .as_ptr()
@@ -1012,7 +1012,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Uint16(17)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<u16>()
                     .as_ptr()
@@ -1030,7 +1030,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Uint32(33)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<u32>()
                     .as_ptr()
@@ -1048,7 +1048,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Uint64(65)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<u64>()
                     .as_ptr()
@@ -1066,7 +1066,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Uint128(129)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<u128>()
                     .as_ptr()
@@ -1084,7 +1084,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Sint8(-9)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<i8>()
                     .as_ptr()
@@ -1102,7 +1102,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Sint16(-17)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<i16>()
                     .as_ptr()
@@ -1120,7 +1120,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Sint32(-33)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<i32>()
                     .as_ptr()
@@ -1138,7 +1138,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Sint64(-65)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<i64>()
                     .as_ptr()
@@ -1156,7 +1156,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::Sint128(-129)
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<i128>()
                     .as_ptr()
@@ -1176,7 +1176,7 @@ mod test {
         assert_eq!(
             unsafe {
                 *Value::EcPoint(Felt::from(1234), Felt::from(4321))
-                    .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                    .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                     .unwrap()
                     .cast::<[[u32; 8]; 2]>()
                     .as_ptr()
@@ -1201,7 +1201,7 @@ mod test {
                     Felt::from(3333),
                     Felt::from(4444),
                 )
-                .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+                .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
                 .unwrap()
                 .cast::<[[u32; 8]; 4]>()
                 .as_ptr()
@@ -1234,7 +1234,7 @@ mod test {
             value: Box::new(Value::Uint8(10)),
             debug_name: None,
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
 
         // Assertion to verify that the value returned by to_jit is not NULL
         assert!(result.is_ok());
@@ -1263,7 +1263,7 @@ mod test {
                         upper: BigInt::from(510),
                     },
                 }
-                .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id)
+                .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id)
                 .unwrap()
                 .cast::<[u32; 8]>()
                 .as_ptr()
@@ -1293,7 +1293,7 @@ mod test {
                 upper: BigInt::from(10),
             },
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
 
         assert!(matches!(
             result,
@@ -1322,7 +1322,7 @@ mod test {
                 upper: BigInt::from(510),
             },
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
 
         assert!(matches!(
             result,
@@ -1351,7 +1351,7 @@ mod test {
                 upper: BigInt::from(510),
             },
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
 
         assert!(matches!(
             result,
@@ -1380,7 +1380,7 @@ mod test {
                 upper: BigInt::from(10),
             },
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
 
         assert!(matches!(
             result,
@@ -1408,7 +1408,7 @@ mod test {
             value: Box::new(Value::Uint8(10)),
             debug_name: None,
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
     }
 
     #[test]
@@ -1428,7 +1428,7 @@ mod test {
             value: Box::new(Value::Uint8(10)),
             debug_name: None,
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[1].id);
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[1].id);
     }
 
     #[test]
@@ -1454,7 +1454,7 @@ mod test {
             }),
             debug_name: None,
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
         .unwrap_err(); // Unwrapping the error
 
         // Matching the error result to verify the error type and message.
@@ -1492,7 +1492,7 @@ mod test {
             fields: vec![Value::from(2u32)],
             debug_name: None,
         }
-        .to_jit(&Bump::new(), &registry, &program.type_declarations[0].id)
+        .to_ptr(&Bump::new(), &registry, &program.type_declarations[0].id)
         .unwrap_err(); // Unwrapping the error
 
         // Matching the error result to verify the error type and message.


### PR DESCRIPTION
This PR updates cairo to 2.8.4, adds some release docs and updates the version to alpha.3 to prepare for another release.

It also removes a possible panic in case linking fails and renames from_jit and to_jit to from_ptr and to_ptr
