### PR TITLE
Resolve `CAIRO_NATIVE_RUNTIME_LIBRARY` relative path

### DIFF
--- a/docs/execution_walkthrough.md
+++ b/docs/execution_walkthrough.md
@@ -206,7 +206,7 @@ Builtin stats: BuiltinStats { bitwise: 1, ec_op: 0, range_check: 1, pedersen: 0,
 ## The Cairo Native runtime
 Sometimes we need to use stuff that would be too complicated or error-prone to implement in MLIR, but that we have readily available from Rust. That's when we use the runtime library.
 
-When using the JIT it'll be automatically linked (if compiled with support for it, which is enabled by default). If using the AOT, the `CAIRO_NATIVE_RUNTIME_LIBDIR` environment variable will have to be modified to point to the directory that contains `libcairo_native_runtime.a`, which is built and placed in said folder by `make build`.
+When using the JIT it'll be automatically linked (if compiled with support for it, which is enabled by default). If using the AOT, the `CAIRO_NATIVE_RUNTIME_LIBRARY` environment variable will have to be modified to point to the `libcairo_native_runtime.a` file, which is built and placed in said folder by `make build`.
 
 Although it's implemented in Rust, its functions use the C ABI and have Rust's name mangling disabled. This means that to the extern observer it's technically indistinguishible from a library written in C. By doing this we're making the functions callable from MLIR.
 

--- a/scripts/bench-hyperfine.sh
+++ b/scripts/bench-hyperfine.sh
@@ -90,7 +90,7 @@ run_bench() {
         -o "$OUTPUT_DIR/$base_name-march-native" \
         >> /dev/stderr
 
-    CAIRO_NATIVE_RUNTIME_LIBDIR="$ROOT_DIR/target/release" hyperfine \
+     hyperfine \
         --warmup 3 \
         --export-markdown "$OUTPUT_DIR/$base_name.md" \
         --export-json "$OUTPUT_DIR/$base_name.json" \

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -239,7 +239,7 @@ pub fn object_to_shared_lib(object: &[u8], output_filename: &Path) -> Result<()>
             )
         }
     } else {
-        String::from("libcario_native_runtime.a")
+        String::from("libcairo_native_runtime.a")
     };
 
     let args: Vec<Cow<'static, str>> = {


### PR DESCRIPTION
Simple PR to resolve the `CAIRO_NATIVE_RUNTIME_LIBRARY` when it is a relative path so that it can work better with STARKNET approach to global vars (e.g. doing "./native_runtime.a") will turn into "/usr/somewhere/over/the/rainbow/native_runtime.a".

Looking forward to hear your thoughts!


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
