### PR TITLE
Fix felt252 and enum deserialization bugs.

### DIFF
--- a/.github/workflows/bench-hyperfine.yml
+++ b/.github/workflows/bench-hyperfine.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^temurin-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h
@@ -124,7 +124,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^temurin-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
       MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
       LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
       TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
-      RUSTUP_TOOLCHAIN: nightly # udeps needs nightly
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -102,10 +101,8 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
-      - name: "Download and run cargo-udeps"
-        run: |
-          wget -O - -c https://github.com/est31/cargo-udeps/releases/download/v0.1.50/cargo-udeps-v0.1.50-x86_64-unknown-linux-gnu.tar.gz | tar -xz
-          cargo-udeps-*/cargo-udeps udeps --all-targets --all-features
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
 
   test:
     name: test (linux, amd64)
@@ -127,7 +124,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^temurin-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h
@@ -218,7 +215,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^temurin-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h
@@ -333,7 +330,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^temurin-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -955,7 +955,6 @@ dependencies = [
  "bumpalo",
  "cairo-lang-compiler",
  "cairo-lang-defs",
- "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-runner",
  "cairo-lang-semantic",
@@ -1012,7 +1011,6 @@ dependencies = [
  "cairo-lang-sierra-gas",
  "itertools 0.13.0",
  "lazy_static",
- "libc",
  "num-traits 0.2.19",
  "rand",
  "starknet-curve 0.5.1",
@@ -1082,9 +1080,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "jobserver",
  "libc",
@@ -1156,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1166,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1470,18 +1468,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1491,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.79",
@@ -2133,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3486,7 +3484,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ecbc9175dd38627cd01d546e7b41c9a115e5773f4c98f64e2185c81ec5f45ab"
 dependencies = [
- "bindgen 0.69.4",
+ "bindgen 0.69.5",
  "cc",
  "paste",
  "thiserror",
@@ -3899,9 +3897,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3910,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -3925,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3935,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3948,15 +3946,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ cairo-lang-filesystem = "2.8.4"
 cairo-lang-semantic = "2.8.4"
 cairo-lang-sierra = "2.8.4"
 cairo-lang-sierra-generator = "2.8.4"
-cairo-lang-diagnostics = "2.8.4"
 educe = "0.5.11" # can't update until https://github.com/magiclen/educe/issues/27
 itertools = "0.13.0"
 lazy_static = "1.5"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,6 @@ starknet-types-core = { version = "0.1.7", default-features = false, features = 
     "std", "serde", "hash"
 ] }
 cairo-lang-sierra-gas = "2.8.4"
-libc = "0.2"
 starknet-curve = "0.5.1"
 lazy_static = "1.5.0"
 rand = "0.8.5"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,7 +44,8 @@ pub unsafe extern "C" fn cairo_native__libfunc__debug__print(
     let mut items = Vec::with_capacity(len as usize);
 
     for i in 0..len as usize {
-        let data = *data.add(i);
+        let mut data = *data.add(i);
+        data[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
         let value = Felt::from_bytes_le(&data);
         items.push(value);
@@ -76,22 +77,24 @@ pub unsafe extern "C" fn cairo_native__libfunc__debug__print(
 /// definitely unsafe to use manually.
 #[no_mangle]
 pub unsafe extern "C" fn cairo_native__libfunc__pedersen(
-    dst: *mut u8,
-    lhs: *const u8,
-    rhs: *const u8,
+    dst: &mut [u8; 32],
+    lhs: &[u8; 32],
+    rhs: &[u8; 32],
 ) {
     // Extract arrays from the pointers.
-    let dst = slice::from_raw_parts_mut(dst, 32);
-    let lhs = slice::from_raw_parts(lhs, 32);
-    let rhs = slice::from_raw_parts(rhs, 32);
+    let mut lhs = *lhs;
+    let mut rhs = *rhs;
+
+    lhs[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    rhs[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
     // Convert to FieldElement.
-    let lhs = Felt::from_bytes_le_slice(lhs);
-    let rhs = Felt::from_bytes_le_slice(rhs);
+    let lhs = Felt::from_bytes_le(&lhs);
+    let rhs = Felt::from_bytes_le(&rhs);
 
     // Compute pedersen hash and copy the result into `dst`.
     let res = starknet_types_core::hash::Pedersen::hash(&lhs, &rhs);
-    dst.copy_from_slice(&res.to_bytes_le());
+    *dst = res.to_bytes_le();
 }
 
 /// Compute `hades_permutation(op0, op1, op2)` and replace the operands with the results.
@@ -108,29 +111,28 @@ pub unsafe extern "C" fn cairo_native__libfunc__pedersen(
 /// definitely unsafe to use manually.
 #[no_mangle]
 pub unsafe extern "C" fn cairo_native__libfunc__hades_permutation(
-    op0: *mut u8,
-    op1: *mut u8,
-    op2: *mut u8,
+    op0: &mut [u8; 32],
+    op1: &mut [u8; 32],
+    op2: &mut [u8; 32],
 ) {
-    // Extract arrays from the pointers.
-    let op0 = slice::from_raw_parts_mut(op0, 32);
-    let op1 = slice::from_raw_parts_mut(op1, 32);
-    let op2 = slice::from_raw_parts_mut(op2, 32);
+    op0[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    op1[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    op2[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
     // Convert to FieldElement.
     let mut state = [
-        Felt::from_bytes_le_slice(op0),
-        Felt::from_bytes_le_slice(op1),
-        Felt::from_bytes_le_slice(op2),
+        Felt::from_bytes_le(op0),
+        Felt::from_bytes_le(op1),
+        Felt::from_bytes_le(op2),
     ];
 
     // Compute Poseidon permutation.
     starknet_types_core::hash::Poseidon::hades_permutation(&mut state);
 
     // Write back the results.
-    op0.copy_from_slice(&state[0].to_bytes_le());
-    op1.copy_from_slice(&state[1].to_bytes_le());
-    op2.copy_from_slice(&state[2].to_bytes_le());
+    *op0 = state[0].to_bytes_le();
+    *op1 = state[1].to_bytes_le();
+    *op2 = state[2].to_bytes_le();
 }
 
 /// Felt252 type used in cairo native runtime
@@ -230,8 +232,11 @@ pub unsafe extern "C" fn cairo_native__dict_get(
     dict: &mut FeltDict,
     key: &[u8; 32],
 ) -> *mut c_void {
+    let mut key = *key;
+    key[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
     dict.count += 1;
-    dict.inner.entry(*key).or_insert(std::ptr::null_mut()) as *mut _ as *mut c_void
+    dict.inner.entry(key).or_insert(std::ptr::null_mut()) as *mut _ as *mut c_void
 }
 
 /// Compute the total gas refund for the dictionary at squash time.
@@ -260,6 +265,7 @@ pub unsafe extern "C" fn cairo_native__dict_gas_refund(ptr: *const FeltDict) -> 
 pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_point_from_x_nz(
     point_ptr: &mut [[u8; 32]; 2],
 ) -> bool {
+    point_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
     let x = Felt::from_bytes_le(&point_ptr[0]);
 
     // https://github.com/starkware-libs/cairo/blob/aaad921bba52e729dc24ece07fab2edf09ccfa15/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L63
@@ -276,7 +282,7 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_point_from_x_nz(
 
     match AffinePoint::new(x, y) {
         Ok(point) => {
-            point_ptr.as_mut()[1].copy_from_slice(&point.y().to_bytes_le());
+            point_ptr[1] = point.y().to_bytes_le();
             true
         }
         Err(_) => false,
@@ -297,13 +303,16 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_point_from_x_nz(
 pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_point_try_new_nz(
     point_ptr: &mut [[u8; 32]; 2],
 ) -> bool {
+    point_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    point_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
     let x = Felt::from_bytes_le(&point_ptr[0]);
     let y = Felt::from_bytes_le(&point_ptr[1]);
 
     match AffinePoint::new(x, y) {
         Ok(point) => {
-            point_ptr[0].copy_from_slice(&point.x().to_bytes_le());
-            point_ptr[1].copy_from_slice(&point.y().to_bytes_le());
+            point_ptr[0] = point.x().to_bytes_le();
+            point_ptr[1] = point.y().to_bytes_le();
             true
         }
         Err(_) => false,
@@ -333,10 +342,10 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_init(state_ptr: &mu
     // We already made sure its a valid point.
     let state = AffinePoint::new_unchecked(random_x, random_y);
 
-    state_ptr[0].copy_from_slice(&state.x().to_bytes_le());
-    state_ptr[1].copy_from_slice(&state.y().to_bytes_le());
-    state_ptr[2].copy_from_slice(&state.x().to_bytes_le());
-    state_ptr[3].copy_from_slice(&state.y().to_bytes_le());
+    state_ptr[0] = state.x().to_bytes_le();
+    state_ptr[1] = state.y().to_bytes_le();
+    state_ptr[2] = state_ptr[0];
+    state_ptr[3] = state_ptr[1];
 }
 
 /// Compute `ec_state_add(state, point)` and store the state back.
@@ -354,6 +363,13 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add(
     state_ptr: &mut [[u8; 32]; 4],
     point_ptr: &[[u8; 32]; 2],
 ) {
+    state_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    state_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
+    let mut point_ptr = *point_ptr;
+    point_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    point_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
     // We use unchecked methods because the inputs must already be valid points.
     let mut state = ProjectivePoint::from_affine_unchecked(
         Felt::from_bytes_le(&state_ptr[0]),
@@ -367,8 +383,8 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add(
     state += &point;
     let state = state.to_affine().unwrap();
 
-    state_ptr[0].copy_from_slice(&state.x().to_bytes_le());
-    state_ptr[1].copy_from_slice(&state.y().to_bytes_le());
+    state_ptr[0] = state.x().to_bytes_le();
+    state_ptr[1] = state.y().to_bytes_le();
 }
 
 /// Compute `ec_state_add_mul(state, scalar, point)` and store the state back.
@@ -387,6 +403,16 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add_mul(
     scalar_ptr: &[u8; 32],
     point_ptr: &[[u8; 32]; 2],
 ) {
+    state_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    state_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
+    let mut point_ptr = *point_ptr;
+    point_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    point_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
+    let scalar_ptr = *scalar_ptr;
+    scalar_ptr[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
     // Here the points should already be checked as valid, so we can use unchecked.
     let mut state = ProjectivePoint::from_affine_unchecked(
         Felt::from_bytes_le(&state_ptr[0]),
@@ -401,8 +427,8 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add_mul(
     state += &point.mul(scalar);
     let state = state.to_affine().unwrap();
 
-    state_ptr[0].copy_from_slice(&state.x().to_bytes_le());
-    state_ptr[1].copy_from_slice(&state.y().to_bytes_le());
+    state_ptr[0] = state.x().to_bytes_le();
+    state_ptr[1] = state.y().to_bytes_le();
 }
 
 /// Compute `ec_state_try_finalize_nz(state)` and store the result.
@@ -420,6 +446,12 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_try_finalize_nz(
     point_ptr: &mut [[u8; 32]; 2],
     state_ptr: &[[u8; 32]; 4],
 ) -> bool {
+    let mut state_ptr = *state_ptr;
+    state_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    state_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    state_ptr[2][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+    state_ptr[3][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
     // We use unchecked methods because the inputs must already be valid points.
     let state = ProjectivePoint::from_affine_unchecked(
         Felt::from_bytes_le(&state_ptr[0]),
@@ -436,8 +468,8 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_try_finalize_nz(
         let point = &state - &random;
         let point = point.to_affine().unwrap();
 
-        point_ptr[0].copy_from_slice(&point.x().to_bytes_le());
-        point_ptr[1].copy_from_slice(&point.y().to_bytes_le());
+        point_ptr[0] = point.x().to_bytes_le();
+        point_ptr[1] = point.y().to_bytes_le();
 
         true
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,7 +13,7 @@ use starknet_types_core::{
     felt::Felt,
     hash::StarkHash,
 };
-use std::{collections::HashMap, ffi::c_void, fs::File, io::Write, os::fd::FromRawFd, slice};
+use std::{collections::HashMap, ffi::c_void, fs::File, io::Write, os::fd::FromRawFd};
 use std::{ops::Mul, vec::IntoIter};
 
 lazy_static! {
@@ -410,7 +410,7 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add_mul(
     point_ptr[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
     point_ptr[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
-    let scalar_ptr = *scalar_ptr;
+    let mut scalar_ptr = *scalar_ptr;
     scalar_ptr[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
     // Here the points should already be checked as valid, so we can use unchecked.
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn cairo_native__libfunc__ec__ec_state_add_mul(
         Felt::from_bytes_le(&point_ptr[0]),
         Felt::from_bytes_le(&point_ptr[1]),
     );
-    let scalar = Felt::from_bytes_le(scalar_ptr);
+    let scalar = Felt::from_bytes_le(&scalar_ptr);
 
     state += &point.mul(scalar);
     let state = state.to_affine().unwrap();

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -355,7 +355,7 @@ impl AotContractExecutor {
         };
 
         let tag = *unsafe { enum_ptr.cast::<u8>().as_ref() } as usize;
-        let tag &= 0x01; // Filter out bits that are not part of the enum's tag.
+        let tag = tag & 0x01; // Filter out bits that are not part of the enum's tag.
 
         // layout of both enum variants, both are a array of felts
         let value_layout = unsafe { Layout::from_size_align_unchecked(24, 8) };

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -355,6 +355,8 @@ impl AotContractExecutor {
         };
 
         let tag = *unsafe { enum_ptr.cast::<u8>().as_ref() } as usize;
+        let tag &= 0x01; // Filter out bits that are not part of the enum's tag.
+
         // layout of both enum variants, both are a array of felts
         let value_layout = unsafe { Layout::from_size_align_unchecked(24, 8) };
         let value_ptr = unsafe {
@@ -382,7 +384,8 @@ impl AotContractExecutor {
         for i in 0..num_elems {
             // safe to create a NonNull because if the array has elements, the data_ptr can't be null.
             let cur_elem_ptr = NonNull::new(unsafe { data_ptr.byte_add(elem_stride * i) }).unwrap();
-            let data = unsafe { cur_elem_ptr.cast::<[u8; 32]>().as_ref() };
+            let data = unsafe { cur_elem_ptr.cast::<[u8; 32]>().as_mut() };
+            data[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
             let data = Felt::from_bytes_le_slice(data);
 
             array_value.push(data);

--- a/src/values.rs
+++ b/src/values.rs
@@ -577,10 +577,18 @@ impl Value {
                 CoreTypeConcrete::EcPoint(_) => {
                     let data = ptr.cast::<[[u8; 32]; 2]>().as_ref();
 
+                    data[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+                    data[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
                     Self::EcPoint(Felt::from_bytes_le(&data[0]), Felt::from_bytes_le(&data[1]))
                 }
                 CoreTypeConcrete::EcState(_) => {
                     let data = ptr.cast::<[[u8; 32]; 4]>().as_ref();
+
+                    data[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+                    data[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+                    data[2][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+                    data[3][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
 
                     Self::EcState(
                         Felt::from_bytes_le(&data[0]),
@@ -590,7 +598,8 @@ impl Value {
                     )
                 }
                 CoreTypeConcrete::Felt252(_) => {
-                    let data = ptr.cast::<[u8; 32]>().as_ref();
+                    let data = ptr.cast::<[u8; 32]>().as_mut();
+                    data[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
                     let data = Felt::from_bytes_le_slice(data);
                     Self::Felt252(data)
                 }
@@ -645,6 +654,12 @@ impl Value {
                         },
                     };
 
+                    // Filter out bits that are not part of the enum's tag.
+                    let tag_value = tag_value
+                        & 1usize
+                            .wrapping_shl(info.variants.len().next_power_of_two().trailing_zeros())
+                            .wrapping_sub(1);
+
                     let payload_ty = registry.get_type(&info.variants[tag_value])?;
                     let payload_layout = payload_ty.layout(registry)?;
 
@@ -695,21 +710,23 @@ impl Value {
                     );
 
                     let mut output_map = HashMap::with_capacity(inner.len());
-                    for (key, val_ptr) in inner.iter() {
+                    for (mut key, val_ptr) in inner.into_iter() {
                         if val_ptr.is_null() {
                             continue;
                         }
 
-                        let key = Felt::from_bytes_le(key);
+                        key[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
+
+                        let key = Felt::from_bytes_le(&key);
                         output_map.insert(
                             key,
                             Self::from_ptr(
-                                NonNull::new(*val_ptr).unwrap().cast(),
+                                NonNull::new(val_ptr).unwrap().cast(),
                                 &info.ty,
                                 registry,
                             )?,
                         );
-                        libc_free(*val_ptr);
+                        libc_free(val_ptr);
                     }
 
                     Self::Felt252Dict {
@@ -737,7 +754,8 @@ impl Value {
                     | StarkNetTypeConcrete::StorageBaseAddress(_)
                     | StarkNetTypeConcrete::StorageAddress(_) => {
                         // felt values
-                        let data = ptr.cast::<[u8; 32]>().as_ref();
+                        let data = ptr.cast::<[u8; 32]>().as_mut();
+                        data[31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
                         let data = Felt::from_bytes_le(data);
                         Self::Felt252(data)
                     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -575,7 +575,7 @@ impl Value {
                     value
                 }
                 CoreTypeConcrete::EcPoint(_) => {
-                    let data = ptr.cast::<[[u8; 32]; 2]>().as_ref();
+                    let data = ptr.cast::<[[u8; 32]; 2]>().as_mut();
 
                     data[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
                     data[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
@@ -583,7 +583,7 @@ impl Value {
                     Self::EcPoint(Felt::from_bytes_le(&data[0]), Felt::from_bytes_le(&data[1]))
                 }
                 CoreTypeConcrete::EcState(_) => {
-                    let data = ptr.cast::<[[u8; 32]; 4]>().as_ref();
+                    let data = ptr.cast::<[[u8; 32]; 4]>().as_mut();
 
                     data[0][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).
                     data[1][31] &= 0x0F; // Filter out first 4 bits (they're outside an i252).


### PR DESCRIPTION
Some types, including at least `felt252` and most enum's tags, have a deserialization bug where the bytes that are not part of the type in MLIR are also parsed as part of the value in Rust. This PR filters out those bits.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
