### PR TITLE
Fix process block bug

### DIFF
--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -1750,7 +1750,8 @@ pub(crate) mod handler {
             state: *mut [u32; 8],
             block: &[u32; 16],
         ) {
-            let result = ptr.sha256_process_block(unsafe { &mut *state }, block, gas);
+            let state_ref = unsafe { state.as_mut().unwrap() };
+            let result = ptr.sha256_process_block(state_ref, block, gas);
 
             *result_ptr = match result {
                 Ok(x) => SyscallResultAbi {


### PR DESCRIPTION
Fixes https://github.com/lambdaclass/cairo_native/issues/845, in conjunction with https://github.com/lambdaclass/sequencer/pull/11.

`wrap_sha256_process_block` syscall should modify the received state with the new state, but instead of doing this, it copies the value and modifies the copied version, leaving the old state untouched.

This PR fixes it.

All transactions mentioned in the issue are now working correctly.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
