### PR TITLE
minor gas fix

### DIFF
--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -105,7 +105,7 @@ pub fn build_withdraw_gas<'ctx, 'this>(
         context,
         is_enough,
         [0, 1],
-        [&[range_check, resulting_gas]; 2],
+        [&[range_check, resulting_gas], &[range_check, current_gas]],
         location,
     ));
 
@@ -148,7 +148,7 @@ pub fn build_builtin_withdraw_gas<'ctx, 'this>(
         context,
         is_enough,
         [0, 1],
-        [&[range_check, resulting_gas]; 2],
+        [&[range_check, resulting_gas], &[range_check, current_gas]],
         location,
     ));
 


### PR DESCRIPTION
This applies a libfunc gas fix i found in https://github.com/lambdaclass/cairo_native/pull/875
but is separate from the builtin costs rework.

The bug was that when the withdraw gas fails, on the failure branch it returned the substracted gas, but it should return the non substracted gas


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
