### PR TITLE
Add entry point info to AotContractExecutor

### DIFF
--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: lambdaclass/starknet-replay
-          ref: 08aa133b11e1e319036354c9acd8270483c844b5
+          ref: 53542995b1671b6cc16bdf87b0b5a10a6fd801a4
           path: replay
 
       - name: Install Starknet Replay deps

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,9 @@ pub enum Error {
     #[error("missing BuiltinCosts global symbol, should never happen, this is a bug")]
     MissingBuiltinCostsSymbol,
 
+    #[error("selector not found in the AotContractExecutor mappings")]
+    SelectorNotFound,
+
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -446,7 +446,7 @@ pub fn run_native_starknet_aot_contract(
     )
     .unwrap();
     native_executor
-        .run(selector, args, u128::MAX.into(), None, handler)
+        .run(Felt::from(selector), args, u128::MAX.into(), None, handler)
         .expect("failed to execute the given contract")
 }
 

--- a/tests/tests/starknet/keccak.rs
+++ b/tests/tests/starknet/keccak.rs
@@ -43,8 +43,8 @@ fn keccak_test() {
     assert_eq!(result.return_values, vec![1.into()]);
 
     let result_aot_ct = run_native_starknet_aot_contract(
-        &program,
-        entry_point.function_idx,
+        contract,
+        &entry_point.selector,
         &[],
         &mut StubSyscallHandler::default(),
     );


### PR DESCRIPTION
This also allows us to filter out methods that are not contract entry points, making the JSON file significantly smaller.


Depends on #875 

Fixes #885

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
