### PR TITLE
Remove panic in compiler.rs

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -131,7 +131,7 @@ pub fn compile(
 ) -> Result<(), Error> {
     if let Ok(x) = std::env::var("NATIVE_DEBUG_DUMP") {
         if x == "1" || x == "true" {
-            std::fs::write("program.sierra", program.to_string()).expect("failed to dump sierra");
+            std::fs::write("program.sierra", program.to_string())?;
         }
     }
 
@@ -902,11 +902,13 @@ fn compile_func(
             ),
             (
                 Identifier::new(context, "linkage"),
-                Attribute::parse(context, "#llvm.linkage<private>").unwrap(),
+                Attribute::parse(context, "#llvm.linkage<private>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "CConv"),
-                Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                Attribute::parse(context, "#llvm.cconv<fastcc>")
+                    .expect("hardcoded attribute is valid"),
             ),
         ],
         Location::fused(
@@ -1333,7 +1335,8 @@ fn generate_entry_point_wrapper<'c>(
                 ),
                 (
                     Identifier::new(context, "CConv"),
-                    Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                    Attribute::parse(context, "#llvm.cconv<fastcc>")
+                        .expect("hardcoded attribute is valid"),
                 ),
             ])
             .add_operands(&args)
@@ -1367,11 +1370,13 @@ fn generate_entry_point_wrapper<'c>(
             ),
             (
                 Identifier::new(context, "llvm.linkage"),
-                Attribute::parse(context, "#llvm.linkage<private>").unwrap(),
+                Attribute::parse(context, "#llvm.linkage<private>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "llvm.CConv"),
-                Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                Attribute::parse(context, "#llvm.cconv<fastcc>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "llvm.emit_c_interface"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,10 @@ impl std::error::Error for NativeAssertError {}
 pub enum NativeAssertErrorKind {
     #[error("statement index already present in block")]
     DuplicatedStatementIndex,
+    #[error("tail recursion metadata already inserted")]
+    DuplicatedTailRecursionMetadata,
+    #[error("block should exist")]
+    MissingBlock,
 }
 
 impl NativeAssertError {


### PR DESCRIPTION
Adds a new error type: `NativeAssertError`. It's a replacement for `panic!`, as it collects the backtrace but it doesn't interrupt the flow of the program.

There is a single `todo!` left, but I didn't know how to deal with it. We should take a closer look at it.

There are a few `expect` left, but being such a simple case, I'm not sure is worth handling it.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
