### PR TITLE
Remove panic from compiler.rs (2)

### DIFF
--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
     let native_context = NativeContext::new();
 
     // Compile the sierra program into a MLIR module.
-    let native_module = native_context.compile(&sierra_program, false).unwrap();
+    let native_module = native_context.compile(&sierra_program, false)?;
 
     let native_executor: Box<dyn Fn(_, _, _, &mut StubSyscallHandler) -> _> = match args.run_mode {
         RunMode::Aot => {

--- a/src/bin/cairo-native-run.rs
+++ b/src/bin/cairo-native-run.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
     let native_context = NativeContext::new();
 
     // Compile the sierra program into a MLIR module.
-    let native_module = native_context.compile(&sierra_program, false)?;
+    let native_module = native_context.compile(&sierra_program, false).unwrap();
 
     let native_executor: Box<dyn Fn(_, _, _, &mut StubSyscallHandler) -> _> = match args.run_mode {
         RunMode::Aot => {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -906,12 +906,12 @@ fn compile_func(
             (
                 Identifier::new(context, "linkage"),
                 Attribute::parse(context, "#llvm.linkage<private>")
-                    .expect("hardcoded attribute is valid"),
+                    .expect("hardcoded attribute should be valid"),
             ),
             (
                 Identifier::new(context, "CConv"),
                 Attribute::parse(context, "#llvm.cconv<fastcc>")
-                    .expect("hardcoded attribute is valid"),
+                    .expect("hardcoded attribute should be valid"),
             ),
         ],
         Location::fused(
@@ -1339,7 +1339,7 @@ fn generate_entry_point_wrapper<'c>(
                 (
                     Identifier::new(context, "CConv"),
                     Attribute::parse(context, "#llvm.cconv<fastcc>")
-                        .expect("hardcoded attribute is valid"),
+                        .expect("hardcoded attribute should be valid"),
                 ),
             ])
             .add_operands(&args)
@@ -1374,12 +1374,12 @@ fn generate_entry_point_wrapper<'c>(
             (
                 Identifier::new(context, "llvm.linkage"),
                 Attribute::parse(context, "#llvm.linkage<private>")
-                    .expect("hardcoded attribute is valid"),
+                    .expect("hardcoded attribute should be valid"),
             ),
             (
                 Identifier::new(context, "llvm.CConv"),
                 Attribute::parse(context, "#llvm.cconv<fastcc>")
-                    .expect("hardcoded attribute is valid"),
+                    .expect("hardcoded attribute should be valid"),
             ),
             (
                 Identifier::new(context, "llvm.emit_c_interface"),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -906,12 +906,12 @@ fn compile_func(
             (
                 Identifier::new(context, "linkage"),
                 Attribute::parse(context, "#llvm.linkage<private>")
-                    .expect("hardcoded attribute should be valid"),
+                    .ok_or(Error::ParseAttributeError)?,
             ),
             (
                 Identifier::new(context, "CConv"),
                 Attribute::parse(context, "#llvm.cconv<fastcc>")
-                    .expect("hardcoded attribute should be valid"),
+                    .ok_or(Error::ParseAttributeError)?,
             ),
         ],
         Location::fused(
@@ -1339,7 +1339,7 @@ fn generate_entry_point_wrapper<'c>(
                 (
                     Identifier::new(context, "CConv"),
                     Attribute::parse(context, "#llvm.cconv<fastcc>")
-                        .expect("hardcoded attribute should be valid"),
+                        .ok_or(Error::ParseAttributeError)?,
                 ),
             ])
             .add_operands(&args)
@@ -1374,12 +1374,12 @@ fn generate_entry_point_wrapper<'c>(
             (
                 Identifier::new(context, "llvm.linkage"),
                 Attribute::parse(context, "#llvm.linkage<private>")
-                    .expect("hardcoded attribute should be valid"),
+                    .ok_or(Error::ParseAttributeError)?,
             ),
             (
                 Identifier::new(context, "llvm.CConv"),
                 Attribute::parse(context, "#llvm.cconv<fastcc>")
-                    .expect("hardcoded attribute should be valid"),
+                    .ok_or(Error::ParseAttributeError)?,
             ),
             (
                 Identifier::new(context, "llvm.emit_c_interface"),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -46,7 +46,7 @@
 
 use crate::{
     debug::libfunc_to_name,
-    error::{Error, ToNativeExpect},
+    error::{panic::ToNativeExpect, Error},
     libfuncs::{BranchArg, LibfuncBuilder, LibfuncHelper},
     metadata::{
         gas::{GasCost, GasMetadata},

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -46,7 +46,7 @@
 
 use crate::{
     debug::libfunc_to_name,
-    error::{panic::ToNativeAssert, Error},
+    error::{panic::ToNativeAssertError, Error},
     libfuncs::{BranchArg, LibfuncBuilder, LibfuncHelper},
     metadata::{
         gas::{GasCost, GasMetadata},
@@ -587,7 +587,7 @@ fn compile_func(
                                         op0.result(0)?.into(),
                                         &entry_block,
                                     ))
-                                    .to_native_assert(
+                                    .to_native_assert_error(
                                         "tail recursion metadata shouldn't be inserted",
                                     )?;
                             }
@@ -988,7 +988,7 @@ fn generate_function_structure<'c, 'a>(
                     e.insert(Block::new(&[]));
                     blocks
                         .get_mut(&statement_idx.0)
-                        .to_native_assert("block should exist")?
+                        .to_native_assert_error("block should exist")?
                 } else {
                     native_panic!("statement index already present in block")
                 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -587,7 +587,9 @@ fn compile_func(
                                         op0.result(0)?.into(),
                                         &entry_block,
                                     ))
-                                    .native_expect("tail recursion metadata already inserted")?;
+                                    .native_expect(
+                                        "tail recursion metadata shouldn't be inserted",
+                                    )?;
                             }
                         }
                     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -131,7 +131,7 @@ pub fn compile(
 ) -> Result<(), Error> {
     if let Ok(x) = std::env::var("NATIVE_DEBUG_DUMP") {
         if x == "1" || x == "true" {
-            std::fs::write("program.sierra", program.to_string()).expect("failed to dump sierra");
+            std::fs::write("program.sierra", program.to_string())?;
         }
     }
 
@@ -902,11 +902,13 @@ fn compile_func(
             ),
             (
                 Identifier::new(context, "linkage"),
-                Attribute::parse(context, "#llvm.linkage<private>").unwrap(),
+                Attribute::parse(context, "#llvm.linkage<private>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "CConv"),
-                Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                Attribute::parse(context, "#llvm.cconv<fastcc>")
+                    .expect("hardcoded attribute is valid"),
             ),
         ],
         Location::fused(
@@ -1333,7 +1335,8 @@ fn generate_entry_point_wrapper<'c>(
                 ),
                 (
                     Identifier::new(context, "CConv"),
-                    Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                    Attribute::parse(context, "#llvm.cconv<fastcc>")
+                        .expect("hardcoded attribute is valid"),
                 ),
             ])
             .add_operands(&args)
@@ -1367,11 +1370,13 @@ fn generate_entry_point_wrapper<'c>(
             ),
             (
                 Identifier::new(context, "llvm.linkage"),
-                Attribute::parse(context, "#llvm.linkage<private>").unwrap(),
+                Attribute::parse(context, "#llvm.linkage<private>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "llvm.CConv"),
-                Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                Attribute::parse(context, "#llvm.cconv<fastcc>")
+                    .expect("hardcoded attribute is valid"),
             ),
             (
                 Identifier::new(context, "llvm.emit_c_interface"),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -46,7 +46,7 @@
 
 use crate::{
     debug::libfunc_to_name,
-    error::{panic::ToNativeExpect, Error},
+    error::{panic::ToNativeAssert, Error},
     libfuncs::{BranchArg, LibfuncBuilder, LibfuncHelper},
     metadata::{
         gas::{GasCost, GasMetadata},
@@ -587,7 +587,7 @@ fn compile_func(
                                         op0.result(0)?.into(),
                                         &entry_block,
                                     ))
-                                    .native_expect(
+                                    .to_native_assert(
                                         "tail recursion metadata shouldn't be inserted",
                                     )?;
                             }
@@ -988,7 +988,7 @@ fn generate_function_structure<'c, 'a>(
                     e.insert(Block::new(&[]));
                     blocks
                         .get_mut(&statement_idx.0)
-                        .native_expect("block should exist")?
+                        .to_native_assert("block should exist")?
                 } else {
                     native_panic!("statement index already present in block")
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -151,18 +151,18 @@ pub mod panic {
         }
     }
 
-    pub trait ToNativeExpect<T> {
-        fn native_expect(self, msg: &str) -> Result<T>;
+    pub trait ToNativeAssert<T> {
+        fn to_native_assert(self, msg: &str) -> Result<T>;
     }
 
-    impl<T> ToNativeExpect<T> for Option<T> {
-        fn native_expect(self, msg: &str) -> Result<T> {
+    impl<T> ToNativeAssert<T> for Option<T> {
+        fn to_native_assert(self, msg: &str) -> Result<T> {
             self.ok_or_else(|| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
         }
     }
 
-    impl<T> ToNativeExpect<T> for Result<T> {
-        fn native_expect(self, msg: &str) -> Result<T> {
+    impl<T> ToNativeAssert<T> for Result<T> {
+        fn to_native_assert(self, msg: &str) -> Result<T> {
             self.map_err(|_| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,7 @@ pub enum CompilerError {
 /// it *should* never happen. The downside of this is that we lose:
 /// - Possible compiler opitimizations
 /// - Stack backtrace on error
+///
 /// This modules aims to avoid panics while still obtaining a stack backtrace on eventual errors.
 pub mod panic {
     use super::{Error, Result};

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,10 @@ impl std::error::Error for NativeAssertError {}
 pub enum NativeAssertErrorKind {
     #[error("statement index already present in block")]
     DuplicatedStatementIndex,
+    #[error("tail recursion metadata already inserted")]
+    DuplicatedTailRecursionMetadata,
+    #[error("block should exist")]
+    MissingBlock,
 }
 
 impl NativeAssertError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,9 +180,9 @@ pub mod panic {
     /// It should only be used inside of a function that returns Result<T, cairo_native::error::Error>
     #[macro_export]
     macro_rules! native_panic {
-        ($arg:tt) => {
+        ($($arg:tt)*) => {
             return Err($crate::error::Error::NativeAssert(
-                $crate::error::panic::NativeAssertError::new(format!($arg)),
+                $crate::error::panic::NativeAssertError::new(format!($($arg)*)),
             ))
         };
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,18 +161,18 @@ pub mod panic {
     }
 
     /// Extension trait used to easly convert `Result`s and `Option`s to `NativeAssertError`
-    pub trait ToNativeAssert<T> {
-        fn to_native_assert(self, msg: &str) -> Result<T>;
+    pub trait ToNativeAssertError<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T>;
     }
 
-    impl<T> ToNativeAssert<T> for Option<T> {
-        fn to_native_assert(self, msg: &str) -> Result<T> {
+    impl<T> ToNativeAssertError<T> for Option<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T> {
             self.ok_or_else(|| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
         }
     }
 
-    impl<T> ToNativeAssert<T> for Result<T> {
-        fn to_native_assert(self, msg: &str) -> Result<T> {
+    impl<T> ToNativeAssertError<T> for Result<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T> {
             self.map_err(|_| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
         }
     }


### PR DESCRIPTION
Adds a new error type: `NativeAssertError`. It's a replacement for panic!, as it collects the backtrace but it doesn't interrupt the flow of the program.

There is a single `todo!` left, but I didn't know how to deal with it. We should take a closer look at it.

There are a few `expect` left, but being such a simple case, I'm not sure is worth handling it.

Unlike #905, I tried to make this non-panic abstraction as similar as possible to the associated panicking code. The compiler.rs was changed to use the non-panic variants


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
