### PR TITLE
Remove panics in libfuncs

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -613,6 +613,7 @@ fn compile_func(
                             .iter()
                             .zip(helper.results())
                             .map(|(branch_info, result_values)| {
+                                let result_values = result_values?;
                                 assert_eq!(
                                     branch_info.results.len(),
                                     result_values.len(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,9 @@ pub enum Error {
     #[error("cairo const data mismatch")]
     ConstDataMismatch,
 
+    #[error("unexpected cairo type found")]
+    UnexpectedCoreTypeConcrete,
+
     #[error("expected an integer-like type")]
     IntegerLikeTypeExpected,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use cairo_lang_sierra::{
     edit_state::EditStateError, ids::ConcreteTypeId, program_registry::ProgramRegistryError,
 };
 use num_bigint::BigInt;
+use panic::NativeAssertError;
 use std::{alloc::LayoutError, num::TryFromIntError};
 use thiserror::Error;
 
@@ -46,6 +47,9 @@ pub enum Error {
     SierraAssert(#[from] SierraAssertError),
 
     #[error(transparent)]
+    NativeAssert(#[from] NativeAssertError),
+
+    #[error(transparent)]
     Compiler(#[from] CompilerError),
 
     #[error(transparent)]
@@ -62,9 +66,6 @@ pub enum Error {
 
     #[error("cairo const data mismatch")]
     ConstDataMismatch,
-
-    #[error("unexpected cairo type found")]
-    UnexpectedCoreTypeConcrete,
 
     #[error("expected an integer-like type")]
     IntegerLikeTypeExpected,
@@ -120,6 +121,94 @@ pub enum CompilerError {
         value: Box<BigInt>,
         range: Box<(BigInt, BigInt)>,
     },
+}
+
+/// In Cairo Native we want to avoid the use of panic, even in situation where
+/// it *should* never happen. The downside of this is that we lose:
+/// - Possible compiler opitimizations
+/// - Stack backtrace on error
+///
+/// This modules aims to avoid panics while still obtaining a stack backtrace on eventual errors.
+pub mod panic {
+    use super::{Error, Result};
+    use std::{
+        backtrace::{Backtrace, BacktraceStatus},
+        panic::Location,
+    };
+
+    /// `NativeAssertError` acts as a non-panicking alternative to Rust's panic.
+    /// When the error is created the backtrace or location is captured, which
+    /// is useful for debugging.
+    #[derive(Debug)]
+    pub struct NativeAssertError {
+        msg: String,
+        info: BacktraceOrLocation,
+    }
+
+    impl std::error::Error for NativeAssertError {}
+
+    impl NativeAssertError {
+        pub fn new(msg: String) -> Self {
+            let backtrace = Backtrace::capture();
+            let info = if let BacktraceStatus::Captured = backtrace.status() {
+                BacktraceOrLocation::Backtrace(backtrace)
+            } else {
+                BacktraceOrLocation::Location(std::panic::Location::caller())
+            };
+
+            Self { msg, info }
+        }
+    }
+
+    /// Extension trait used to easly convert `Result`s and `Option`s to `NativeAssertError`
+    pub trait ToNativeAssertError<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T>;
+    }
+
+    impl<T> ToNativeAssertError<T> for Option<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T> {
+            self.ok_or_else(|| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
+        }
+    }
+
+    impl<T> ToNativeAssertError<T> for Result<T> {
+        fn to_native_assert_error(self, msg: &str) -> Result<T> {
+            self.map_err(|_| Error::NativeAssert(NativeAssertError::new(msg.to_string())))
+        }
+    }
+
+    /// Macro that mimicks the behaviour of `panic!`.
+    /// It should only be used inside of a function that returns Result<T, cairo_native::error::Error>
+    #[macro_export]
+    macro_rules! native_panic {
+        ($($arg:tt)*) => {
+            return Err($crate::error::Error::NativeAssert(
+                $crate::error::panic::NativeAssertError::new(format!($($arg)*)),
+            ))
+        };
+    }
+
+    /// If `RUST_BACKTRACE` env var is not set, then the backtrace won't be captured.
+    /// In that case, only the location is saved, which is better than nothing.
+    #[derive(Debug)]
+    enum BacktraceOrLocation {
+        Backtrace(Backtrace),
+        Location(&'static Location<'static>),
+    }
+
+    impl std::fmt::Display for NativeAssertError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            writeln!(f, "{}", &self.msg)?;
+            match &self.info {
+                BacktraceOrLocation::Backtrace(backtrace) => {
+                    writeln!(f, "Stack backtrace:\n{}", backtrace)
+                }
+                BacktraceOrLocation::Location(location) => {
+                    writeln!(f, "Location: {}", location)
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -188,6 +188,15 @@ pub mod panic {
         };
     }
 
+    #[macro_export]
+    macro_rules! native_assert {
+        ($cond:expr, $($arg:tt)*) => {
+            if !($cond) {
+                $crate::native_panic!($($arg)*);
+            }
+        };
+    }
+
     /// If `RUST_BACKTRACE` env var is not set, then the backtrace won't be captured.
     /// In that case, only the location is saved, which is better than nothing.
     #[derive(Debug)]

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -2,7 +2,11 @@
 //!
 //! Contains libfunc generation stuff (aka. the actual instructions).
 
-use crate::{error::Error as CoreLibfuncBuilderError, metadata::MetadataStorage, utils::BlockExt};
+use crate::{
+    error::{panic::ToNativeAssertError, Error as CoreLibfuncBuilderError, Result as NativeResult},
+    metadata::MetadataStorage,
+    utils::BlockExt,
+};
 use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::core::{CoreConcreteLibfunc, CoreLibfunc, CoreType},
@@ -270,14 +274,14 @@ where
     'this: 'ctx,
 {
     #[doc(hidden)]
-    pub(crate) fn results(self) -> impl Iterator<Item = Vec<Value<'ctx, 'this>>> {
+    pub(crate) fn results(self) -> impl Iterator<Item = NativeResult<Vec<Value<'ctx, 'this>>>> {
         self.results.into_iter().enumerate().map(|(branch_idx, x)| {
             x.into_iter()
                 .enumerate()
                 .map(|(arg_idx, x)| {
-                    x.into_inner().unwrap_or_else(|| {
-                        panic!("Argument #{arg_idx} of branch {branch_idx} doesn't have a value.")
-                    })
+                    x.into_inner().to_native_assert_error(
+                        "Argument #{arg_idx} of branch {branch_idx} doesn't have a value.",
+                    )
                 })
                 .collect()
         })

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -279,9 +279,9 @@ where
             x.into_iter()
                 .enumerate()
                 .map(|(arg_idx, x)| {
-                    x.into_inner().to_native_assert_error(
-                       &format!("Argument #{arg_idx} of branch {branch_idx} doesn't have a value."),
-                    )
+                    x.into_inner().to_native_assert_error(&format!(
+                        "Argument #{arg_idx} of branch {branch_idx} doesn't have a value."
+                    ))
                 })
                 .collect()
         })

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -275,12 +275,12 @@ where
 {
     #[doc(hidden)]
     pub(crate) fn results(self) -> impl Iterator<Item = NativeResult<Vec<Value<'ctx, 'this>>>> {
-        self.results.into_iter().enumerate().map(|(_, x)| {
+        self.results.into_iter().enumerate().map(|(branch_idx, x)| {
             x.into_iter()
                 .enumerate()
-                .map(|(_, x)| {
+                .map(|(arg_idx, x)| {
                     x.into_inner().to_native_assert_error(
-                        "Argument #{arg_idx} of branch {branch_idx} doesn't have a value.",
+                       &format!("Argument #{arg_idx} of branch {branch_idx} doesn't have a value."),
                     )
                 })
                 .collect()

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -275,10 +275,10 @@ where
 {
     #[doc(hidden)]
     pub(crate) fn results(self) -> impl Iterator<Item = NativeResult<Vec<Value<'ctx, 'this>>>> {
-        self.results.into_iter().enumerate().map(|(branch_idx, x)| {
+        self.results.into_iter().enumerate().map(|(_, x)| {
             x.into_iter()
                 .enumerate()
-                .map(|(arg_idx, x)| {
+                .map(|(_, x)| {
                     x.into_inner().to_native_assert_error(
                         "Argument #{arg_idx} of branch {branch_idx} doesn't have a value.",
                     )

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1486,9 +1486,13 @@ pub fn build_tuple_from_span<'ctx, 'this>(
         CoreTypeConcrete::Array(info) => (&info.ty, registry.get_type(&info.ty)?),
         CoreTypeConcrete::Snapshot(info) => match registry.get_type(&info.ty)? {
             CoreTypeConcrete::Array(info) => (&info.ty, registry.get_type(&info.ty)?),
-            _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Array or Snapshot"),
+            _ => native_panic!(
+                "matched an unexpected CoreTypeConcrete that is not a Array or Snapshot"
+            ),
         },
-        _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Array or Snapshot"),
+        _ => {
+            native_panic!("matched an unexpected CoreTypeConcrete that is not a Array or Snapshot")
+        }
     };
     let elem_layout = elem_ty.layout(registry)?;
 

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -9,7 +9,7 @@ use crate::{
     metadata::{
         drop_overrides::DropOverridesMeta, realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
-    native_panic,
+    native_assert, native_panic,
     types::TypeBuilder,
     utils::{BlockExt, GepIndex, ProgramRegistryExt},
 };
@@ -1512,9 +1512,10 @@ pub fn build_tuple_from_span<'ctx, 'this>(
             .fields()
             .to_native_assert_error("missing filed")?;
 
-        if !fields.iter().all(|f| f.id == elem_id.id) {
-            native_panic!("all the elements of the array must have the same type");
-        }
+        native_assert!(
+            fields.iter().all(|f| f.id == elem_id.id),
+            "all the elements of the array must have the same type"
+        );
 
         (
             entry.const_int(context, location, fields.len(), 32)?,

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1325,6 +1325,8 @@ pub fn build_slice<'ctx, 'this>(
             &info.signature.param_signatures[1].ty,
         )?;
 
+        // The following operation will because an array always has a drop implementation,
+        // which at this point is always inserted thanks to the `build_type()` just above.
         metadata
             .get::<DropOverridesMeta>()
             .ok_or(Error::MissingMetadata)?
@@ -1484,9 +1486,9 @@ pub fn build_tuple_from_span<'ctx, 'this>(
         CoreTypeConcrete::Array(info) => (&info.ty, registry.get_type(&info.ty)?),
         CoreTypeConcrete::Snapshot(info) => match registry.get_type(&info.ty)? {
             CoreTypeConcrete::Array(info) => (&info.ty, registry.get_type(&info.ty)?),
-            _ => native_panic!("unexpected CoreTypeConcrete found"),
+            _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Array or Snapshot"),
         },
-        _ => native_panic!("unexpected CoreTypeConcrete found"),
+        _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Array or Snapshot"),
     };
     let elem_layout = elem_ty.layout(registry)?;
 
@@ -1510,7 +1512,7 @@ pub fn build_tuple_from_span<'ctx, 'this>(
         let fields = registry
             .get_type(&info.ty)?
             .fields()
-            .to_native_assert_error("missing filed")?;
+            .to_native_assert_error("missing field")?;
 
         native_assert!(
             fields.iter().all(|f| f.id == elem_id.id),
@@ -1654,6 +1656,8 @@ pub fn build_tuple_from_span<'ctx, 'this>(
             &info.signature.param_signatures[0].ty,
         )?;
 
+        // The following operation will because an array always has a drop implementation,
+        // which at this point is always inserted thanks to the `build_type()` just above.
         metadata
             .get::<DropOverridesMeta>()
             .ok_or(Error::MissingMetadata)?

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1511,7 +1511,10 @@ pub fn build_tuple_from_span<'ctx, 'this>(
             .get_type(&info.ty)?
             .fields()
             .to_native_assert_error("missing filed")?;
-        assert!(fields.iter().all(|f| f.id == elem_id.id));
+
+        if !fields.iter().all(|f| f.id == elem_id.id) {
+            native_panic!("all the elements of the array must have the same type");
+        }
 
         (
             entry.const_int(context, location, fields.len(), 32)?,

--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -4,7 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::Result,
     metadata::MetadataStorage,
-    native_panic,
+    native_assert, native_panic,
     types::TypeBuilder,
     utils::{BlockExt, RangeExt},
 };
@@ -115,12 +115,14 @@ fn build_add<'ctx, 'this>(
     let compute_ty = IntegerType::new(context, compute_range.offset_bit_width()).into();
 
     // Zero-extend operands into the computation range.
-    if !compute_range.offset_bit_width() >= lhs_width {
-        native_panic!("the lhs_range bit_width must be less or equal than the compute_range");
-    }
-    if !compute_range.offset_bit_width() >= rhs_width {
-        native_panic!("the rhs_range bit_width must be less or equal than the compute_range");
-    }
+    assert!(
+        compute_range.offset_bit_width() >= lhs_width,
+        "the lhs_range bit_width must be less or equal than the compute_range"
+    );
+    assert!(
+        compute_range.offset_bit_width() >= rhs_width,
+        "the rhs_range bit_width must be less or equal than the compute_range"
+    );
 
     let lhs_value = if compute_range.offset_bit_width() > lhs_width {
         if lhs_range.lower.sign() != Sign::Minus || lhs_ty.is_bounded_int(registry)? {
@@ -241,12 +243,14 @@ fn build_sub<'ctx, 'this>(
     let compute_ty = IntegerType::new(context, compute_range.offset_bit_width()).into();
 
     // Zero-extend operands into the computation range.
-    if !compute_range.offset_bit_width() >= lhs_width {
-        native_panic!("the lhs_range bit_width must be less or equal than the compute_range");
-    }
-    if !compute_range.offset_bit_width() >= rhs_width {
-        native_panic!("the rhs_range bit_width must be less or equal than the compute_range");
-    }
+    assert!(
+        compute_range.offset_bit_width() >= lhs_width,
+        "the lhs_range bit_width must be less or equal than the compute_range"
+    );
+    assert!(
+        compute_range.offset_bit_width() >= rhs_width,
+        "the rhs_range bit_width must be less or equal than the compute_range"
+    );
 
     let lhs_value = if compute_range.offset_bit_width() > lhs_width {
         if lhs_range.lower.sign() != Sign::Minus || lhs_ty.is_bounded_int(registry)? {
@@ -368,12 +372,14 @@ fn build_mul<'ctx, 'this>(
     let compute_ty = IntegerType::new(context, compute_range.zero_based_bit_width()).into();
 
     // Zero-extend operands into the computation range.
-    if !compute_range.offset_bit_width() >= lhs_width {
-        native_panic!("the lhs_range bit_width must be less or equal than the compute_range");
-    }
-    if !compute_range.offset_bit_width() >= rhs_width {
-        native_panic!("the rhs_range bit_width must be less or equal than the compute_range");
-    }
+    assert!(
+        compute_range.offset_bit_width() >= lhs_width,
+        "the lhs_range bit_width must be less or equal than the compute_range"
+    );
+    assert!(
+        compute_range.offset_bit_width() >= rhs_width,
+        "the rhs_range bit_width must be less or equal than the compute_range"
+    );
 
     let lhs_value = if compute_range.zero_based_bit_width() > lhs_width {
         if lhs_range.lower.sign() != Sign::Minus || lhs_ty.is_bounded_int(registry)? {
@@ -494,12 +500,14 @@ fn build_divrem<'ctx, 'this>(
     let compute_ty = IntegerType::new(context, compute_range.zero_based_bit_width()).into();
 
     // Zero-extend operands into the computation range.
-    if !compute_range.offset_bit_width() >= lhs_width {
-        native_panic!("the lhs_range bit_width must be less or equal than the compute_range");
-    }
-    if !compute_range.offset_bit_width() >= rhs_width {
-        native_panic!("the rhs_range bit_width must be less or equal than the compute_range");
-    }
+    assert!(
+        compute_range.offset_bit_width() >= lhs_width,
+        "the lhs_range bit_width must be less or equal than the compute_range"
+    );
+    assert!(
+        compute_range.offset_bit_width() >= rhs_width,
+        "the rhs_range bit_width must be less or equal than the compute_range"
+    );
 
     let lhs_value = if compute_range.zero_based_bit_width() > lhs_width {
         if lhs_range.lower.sign() != Sign::Minus || lhs_ty.is_bounded_int(registry)? {
@@ -708,9 +716,10 @@ fn build_is_zero<'ctx, 'this>(
     let src_ty = registry.get_type(&info.signature.param_signatures[0].ty)?;
     let src_range = src_ty.integer_range(registry)?;
 
-    if !(src_range.lower <= BigInt::ZERO && BigInt::ZERO < src_range.upper) {
-        native_panic!("value can never be zero")
-    }
+    native_assert!(
+        src_range.lower <= BigInt::ZERO && BigInt::ZERO < src_range.upper,
+        "value can never be zero"
+    );
 
     let k0 = entry.const_int_from_type(context, location, 0, src_value.r#type())?;
     let src_is_zero = entry.append_op_result(arith::cmpi(
@@ -747,9 +756,10 @@ fn build_wrap_non_zero<'ctx, 'this>(
         .get_type(&info.signature.param_signatures[0].ty)?
         .integer_range(registry)?;
 
-    if !(src_range.lower > BigInt::ZERO || BigInt::ZERO >= src_range.upper) {
-        native_panic!("value must not be zero")
-    }
+    assert!(
+        src_range.lower > BigInt::ZERO || BigInt::ZERO >= src_range.upper,
+        "value must not be zero"
+    );
 
     entry.append_operation(helper.br(0, &[src_value], location));
     Ok(())

--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -4,7 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::Result,
     metadata::MetadataStorage,
-    native_assert, native_panic,
+    native_assert,
     types::TypeBuilder,
     utils::{BlockExt, RangeExt},
 };

--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -2,7 +2,11 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result, metadata::MetadataStorage, native_panic, types::TypeBuilder, utils::{BlockExt, RangeExt}
+    error::Result,
+    metadata::MetadataStorage,
+    native_panic,
+    types::TypeBuilder,
+    utils::{BlockExt, RangeExt},
 };
 use cairo_lang_sierra::{
     extensions::{
@@ -744,7 +748,7 @@ fn build_wrap_non_zero<'ctx, 'this>(
         .integer_range(registry)?;
 
     if !(src_range.lower > BigInt::ZERO || BigInt::ZERO >= src_range.upper) {
-        native_panic!("")
+        native_panic!("value must not be zero")
     }
 
     entry.append_operation(helper.br(0, &[src_value], location));

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -4,6 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::Result,
     metadata::MetadataStorage,
+    native_panic,
     types::TypeBuilder,
     utils::{BlockExt, RangeExt, HALF_PRIME, PRIME},
 };
@@ -246,7 +247,9 @@ pub fn build_downcast<'ctx, 'this>(
             (Some(lower_check), None) => lower_check,
             (None, Some(upper_check)) => upper_check,
             // its always in bounds since dst is larger than src (i.e no bounds checks needed)
-            (None, None) => unreachable!(),
+            (None, None) => {
+                native_panic!("matched an unreachable: no bounds checks are being performed")
+            }
         };
 
         let dst_value = if dst_ty.is_bounded_int(registry)? && dst_range.lower != BigInt::ZERO {

--- a/src/libfuncs/const.rs
+++ b/src/libfuncs/const.rs
@@ -148,7 +148,9 @@ pub fn build_const_type_value<'ctx, 'this>(
 
                         let const_field_type = match &field_type {
                             CoreTypeConcrete::Const(inner) => inner,
-                            _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
+                            _ => native_panic!(
+                                "matched an unexpected CoreTypeConcrete that is not a Const"
+                            ),
                         };
 
                         let field_value = build_const_type_value(
@@ -182,7 +184,9 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let payload_type = registry.get_type(payload_ty)?;
                 let const_payload_type = match payload_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
+                    _ => {
+                        native_panic!("matched an unexpected CoreTypeConcrete that is not a Const")
+                    }
                 };
 
                 let payload_value = build_const_type_value(

--- a/src/libfuncs/const.rs
+++ b/src/libfuncs/const.rs
@@ -66,7 +66,7 @@ pub fn build_const_as_box<'ctx, 'this>(
     // Create constant
     let const_type = match &const_type_outer {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => unreachable!(),
+        _ => return Err(Error::UnexpectedCoreTypeConcrete),
     };
 
     let value = build_const_type_value(
@@ -105,7 +105,7 @@ pub fn build_const_as_immediate<'ctx, 'this>(
 
     let const_type = match &const_ty {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => unreachable!(),
+        _ => return Err(Error::UnexpectedCoreTypeConcrete),
     };
 
     let value = build_const_type_value(
@@ -147,7 +147,7 @@ pub fn build_const_type_value<'ctx, 'this>(
 
                         let const_field_type = match &field_type {
                             CoreTypeConcrete::Const(inner) => inner,
-                            _ => unreachable!(),
+                            _ => return Err(Error::UnexpectedCoreTypeConcrete),
                         };
 
                         let field_value = build_const_type_value(
@@ -181,7 +181,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let payload_type = registry.get_type(payload_ty)?;
                 let const_payload_type = match payload_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => unreachable!(),
+                    _ => return Err(Error::UnexpectedCoreTypeConcrete),
                 };
 
                 let payload_value = build_const_type_value(
@@ -218,7 +218,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let inner_type = registry.get_type(inner)?;
                 let const_inner_type = match inner_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => unreachable!(),
+                    _ => return Err(Error::UnexpectedCoreTypeConcrete),
                 };
 
                 build_const_type_value(

--- a/src/libfuncs/const.rs
+++ b/src/libfuncs/const.rs
@@ -67,7 +67,7 @@ pub fn build_const_as_box<'ctx, 'this>(
     // Create constant
     let const_type = match &const_type_outer {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => native_panic!("unexpected CoreTypeConcrete found"),
+        _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
     };
 
     let value = build_const_type_value(
@@ -106,7 +106,7 @@ pub fn build_const_as_immediate<'ctx, 'this>(
 
     let const_type = match &const_ty {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => native_panic!("unexpected CoreTypeConcrete found"),
+        _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
     };
 
     let value = build_const_type_value(
@@ -148,7 +148,7 @@ pub fn build_const_type_value<'ctx, 'this>(
 
                         let const_field_type = match &field_type {
                             CoreTypeConcrete::Const(inner) => inner,
-                            _ => native_panic!("unexpected CoreTypeConcrete found"),
+                            _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
                         };
 
                         let field_value = build_const_type_value(
@@ -182,7 +182,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let payload_type = registry.get_type(payload_ty)?;
                 let const_payload_type = match payload_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => native_panic!("unexpected CoreTypeConcrete found"),
+                    _ => native_panic!("matched an unexpected CoreTypeConcrete that is not a Const"),
                 };
 
                 let payload_value = build_const_type_value(
@@ -219,7 +219,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let inner_type = registry.get_type(inner)?;
                 let const_inner_type = match inner_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => native_panic!("unexpected CoreTypeConcrete found"),
+                    _ => native_panic!("unreachable: unexpected CoreTypeConcrete found"),
                 };
 
                 build_const_type_value(

--- a/src/libfuncs/const.rs
+++ b/src/libfuncs/const.rs
@@ -5,6 +5,7 @@ use crate::{
     error::{Error, Result},
     libfuncs::{r#enum::build_enum_value, r#struct::build_struct_value},
     metadata::{realloc_bindings::ReallocBindingsMeta, MetadataStorage},
+    native_panic,
     types::TypeBuilder,
     utils::{BlockExt, ProgramRegistryExt, RangeExt, PRIME},
 };
@@ -66,7 +67,7 @@ pub fn build_const_as_box<'ctx, 'this>(
     // Create constant
     let const_type = match &const_type_outer {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => return Err(Error::UnexpectedCoreTypeConcrete),
+        _ => native_panic!("unexpected CoreTypeConcrete found"),
     };
 
     let value = build_const_type_value(
@@ -105,7 +106,7 @@ pub fn build_const_as_immediate<'ctx, 'this>(
 
     let const_type = match &const_ty {
         CoreTypeConcrete::Const(inner) => inner,
-        _ => return Err(Error::UnexpectedCoreTypeConcrete),
+        _ => native_panic!("unexpected CoreTypeConcrete found"),
     };
 
     let value = build_const_type_value(
@@ -147,7 +148,7 @@ pub fn build_const_type_value<'ctx, 'this>(
 
                         let const_field_type = match &field_type {
                             CoreTypeConcrete::Const(inner) => inner,
-                            _ => return Err(Error::UnexpectedCoreTypeConcrete),
+                            _ => native_panic!("unexpected CoreTypeConcrete found"),
                         };
 
                         let field_value = build_const_type_value(
@@ -181,7 +182,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let payload_type = registry.get_type(payload_ty)?;
                 let const_payload_type = match payload_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => return Err(Error::UnexpectedCoreTypeConcrete),
+                    _ => native_panic!("unexpected CoreTypeConcrete found"),
                 };
 
                 let payload_value = build_const_type_value(
@@ -218,7 +219,7 @@ pub fn build_const_type_value<'ctx, 'this>(
                 let inner_type = registry.get_type(inner)?;
                 let const_inner_type = match inner_type {
                     CoreTypeConcrete::Const(inner) => inner,
-                    _ => return Err(Error::UnexpectedCoreTypeConcrete),
+                    _ => native_panic!("unexpected CoreTypeConcrete found"),
                 };
 
                 build_const_type_value(

--- a/src/libfuncs/debug.rs
+++ b/src/libfuncs/debug.rs
@@ -11,7 +11,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{Error, Result},
     metadata::{
         drop_overrides::DropOverridesMeta, runtime_bindings::RuntimeBindingsMeta, MetadataStorage,
     },
@@ -111,7 +111,7 @@ pub fn build_print<'ctx>(
     registry.build_type(context, helper, registry, metadata, input_ty)?;
     metadata
         .get::<DropOverridesMeta>()
-        .unwrap()
+        .ok_or(Error::MissingMetadata)?
         .invoke_override(
             context,
             entry,

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -122,7 +122,7 @@ pub fn build_enum_value<'ctx, 'this>(
         metadata,
         type_info
             .variants()
-            .to_native_assert_error("couldn't get enum's variants")?,
+            .to_native_assert_error("found non-enum type where an enum is required")?,
     )?;
 
     Ok(match variant_tys.len() {
@@ -262,7 +262,7 @@ pub fn build_match<'ctx, 'this>(
 
     let variant_ids = type_info
         .variants()
-        .to_native_assert_error("couldn't get enum's variants")?;
+        .to_native_assert_error("found non-enum type where an enum is required")?;
     match variant_ids.len() {
         0 => {
             // The Cairo compiler will generate an enum match for enums without variants, so this

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{Error,Result},
     metadata::{
         drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
         realloc_bindings::ReallocBindingsMeta, runtime_bindings::RuntimeBindingsMeta,
@@ -83,7 +83,7 @@ pub fn build_get<'ctx, 'this>(
     // Double pointer. Avoid allocating an element on a dict getter.
     let entry_value_ptr_ptr = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .unwrap()
+        .ok_or(Error::MissingMetadata)?
         .dict_get(context, helper, entry, dict_ptr, entry_key_ptr, location)?;
     let entry_value_ptr = entry.load(
         context,

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::{Error,Result},
+    error::{Error, Result},
     metadata::{
         drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
         realloc_bindings::ReallocBindingsMeta, runtime_bindings::RuntimeBindingsMeta,

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -5,7 +5,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{Error, Result},
     metadata::{tail_recursion::TailRecursionMeta, MetadataStorage},
     types::TypeBuilder,
     utils::{generate_function_name, BlockExt},
@@ -197,7 +197,7 @@ pub fn build<'ctx, 'this>(
                     ),
                     (
                         Identifier::new(context, "CConv"),
-                        Attribute::parse(context, "#llvm.cconv<fastcc>").unwrap(),
+                        Attribute::parse(context, "#llvm.cconv<fastcc>").ok_or(Error::ParseAttributeError)?,
                     ),
                 ])
                 .add_operands(&arguments)

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -197,7 +197,8 @@ pub fn build<'ctx, 'this>(
                     ),
                     (
                         Identifier::new(context, "CConv"),
-                        Attribute::parse(context, "#llvm.cconv<fastcc>").ok_or(Error::ParseAttributeError)?,
+                        Attribute::parse(context, "#llvm.cconv<fastcc>")
+                            .ok_or(Error::ParseAttributeError)?,
                     ),
                 ])
                 .add_operands(&arguments)

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -116,7 +116,7 @@ pub fn build_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => native_panic!("matched unexpected CostTokenType"),
+            _ => native_panic!("matched an unexpected CostTokenType which is not being used"),
         };
 
         let cost_count_value =
@@ -200,7 +200,7 @@ pub fn build_builtin_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => native_panic!("matched unexpected CostTokenType"),
+            _ => native_panic!("matched an unexpected CostTokenType which is not being used"),
         };
 
         let cost_count_value =

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -116,7 +116,7 @@ pub fn build_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => native_panic!("unreachable CostTokenType found"),
+            _ => native_panic!("matched unexpected CostTokenType"),
         };
 
         let cost_count_value =
@@ -200,7 +200,7 @@ pub fn build_builtin_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => native_panic!("unreachable CostTokenType found"),
+            _ => native_panic!("matched unexpected CostTokenType"),
         };
 
         let cost_count_value =

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -4,6 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::{Error, Result},
     metadata::{gas::GasCost, runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
+    native_panic,
     utils::{BlockExt, GepIndex},
 };
 use cairo_lang_sierra::{
@@ -115,7 +116,7 @@ pub fn build_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => unreachable!(),
+            _ => native_panic!("unreachable CostTokenType found"),
         };
 
         let cost_count_value =
@@ -199,7 +200,7 @@ pub fn build_builtin_withdraw_gas<'ctx, 'this>(
             CostTokenType::Poseidon => 4,
             CostTokenType::AddMod => 5,
             CostTokenType::MulMod => 6,
-            _ => unreachable!(),
+            _ => native_panic!("unreachable CostTokenType found"),
         };
 
         let cost_count_value =

--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{Error, Result},
     ffi::get_struct_field_type_at,
     metadata::{drop_overrides::DropOverridesMeta, MetadataStorage},
     starknet::handler::StarknetSyscallHandlerCallbacks,
@@ -414,7 +414,7 @@ pub fn build_class_hash_try_from_felt252<'ctx, 'this>(
             context,
             "3618502788666131106986593281521497120414687020801267626233049500247285301248 : i252",
         )
-        .unwrap(),
+        .ok_or(Error::ParseAttributeError)?,
         location,
     ))?;
     let is_in_range = entry.append_op_result(arith::cmpi(
@@ -478,7 +478,7 @@ pub fn build_contract_address_try_from_felt252<'ctx, 'this>(
             context,
             "3618502788666131106986593281521497120414687020801267626233049500247285301248 : i252",
         )
-        .unwrap(),
+        .ok_or(Error::ParseAttributeError)?,
         location,
     ))?;
     let is_in_range = entry.append_op_result(arith::cmpi(
@@ -889,7 +889,7 @@ pub fn build_storage_base_address_from_felt252<'ctx, 'this>(
             context,
             "3618502788666131106986593281521497120414687020801267626233049500247285300992 : i252",
         )
-        .unwrap(),
+        .ok_or(Error::ParseAttributeError)?,
         location,
     ))?;
 
@@ -980,7 +980,7 @@ pub fn build_storage_address_try_from_felt252<'ctx, 'this>(
             context,
             "3618502788666131106986593281521497120414687020801267626233049500247285301248 : i252",
         )
-        .unwrap(),
+        .ok_or(Error::ParseAttributeError)?,
         location,
     ))?;
     let is_in_range = entry.append_op_result(arith::cmpi(
@@ -2781,7 +2781,7 @@ pub fn build_sha256_process_block_syscall<'ctx, 'this>(
     )?;
     metadata
         .get::<DropOverridesMeta>()
-        .unwrap()
+        .ok_or(Error::MissingMetadata)?
         .invoke_override(
             context,
             entry,


### PR DESCRIPTION
- [x] src/libfuncs.rs
- [x] src/libfuncs/array.rs
- [x] src/libfuncs/bool.rs
- [x] src/libfuncs/cast.rs
- [x] src/libfuncs/const.rs
- [x] src/libfuncs/debug.rs
- [x] src/libfuncs/enum.rs
- [x] src/libfuncs/felt252.rs
- [x] src/libfuncs/felt252_dict.rs
- [x] src/libfuncs/felt252_dict_entry.rs
- [x] src/libfuncs/function_call.rs
- [x] src/libfuncs/gas.rs
- [x] src/libfuncs/pedersen.rs
- [x] src/libfuncs/poseidon.rs
- [x] src/libfuncs/starknet.rs
- [x] src/libfuncs/starknet/testing.rs


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
