### PR TITLE
Remove panic in utils.rs

### DIFF
--- a/benches/util.rs
+++ b/benches/util.rs
@@ -11,7 +11,7 @@ pub fn prepare_programs(path: &str) -> Vec<(Arc<Program>, String)> {
             let path = e.path();
             match path.extension().map(|x| x.to_str().unwrap()) {
                 Some("cairo") => Some((
-                    cairo_native::utils::cairo_to_sierra(path),
+                    cairo_native::utils::cairo_to_sierra(path).unwrap(),
                     path.display().to_string(),
                 )),
                 _ => None,

--- a/examples/easy_api.rs
+++ b/examples/easy_api.rs
@@ -12,7 +12,7 @@ fn main() {
     let native_context = NativeContext::new();
 
     // Compile the cairo program to sierra.
-    let sierra_program = cairo_to_sierra(program_path);
+    let sierra_program = cairo_to_sierra(program_path).unwrap();
 
     // Compile the sierra program into a MLIR module.
     let native_program = native_context.compile(&sierra_program, false).unwrap();

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -16,7 +16,7 @@ fn main() {
     let program_path = Path::new("programs/echo.cairo");
 
     // Compile the cairo program to sierra.
-    let sierra_program = cairo_native::utils::cairo_to_sierra(program_path);
+    let sierra_program = cairo_native::utils::cairo_to_sierra(program_path).unwrap();
 
     let native_context = NativeContext::new();
 

--- a/src/bin/cairo-native-compile.rs
+++ b/src/bin/cairo-native-compile.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
     check_compiler_path(args.single_file, &args.path)?;
 
     let native_context = NativeContext::new();
-    let sierra_program = cairo_to_sierra(&args.path);
+    let sierra_program = cairo_to_sierra(&args.path).unwrap();
 
     // Compile the sierra program into a MLIR module.
     let native_module = native_context.compile(&sierra_program, false).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,7 +26,6 @@ use std::{
     alloc::Layout,
     borrow::Cow,
     fmt::{self, Display},
-    ops::Neg,
     path::Path,
 };
 use thiserror::Error;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -233,9 +233,10 @@ pub fn felt252_str(value: &str) -> Felt {
     let value = value
         .parse::<BigInt>()
         .expect("value must be a digit number");
-    let value = match value.sign() {
-        Sign::Minus => &*PRIME - value.neg().to_biguint().unwrap(),
-        _ => value.to_biguint().unwrap(),
+
+    let value = match value.to_biguint() {
+        Some(value) => value,
+        None => &*PRIME - value.neg().to_biguint().expect("is always positive"),
     };
 
     value.into()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,14 +21,13 @@ use melior::{
 use num_bigint::{BigInt, BigUint, Sign};
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 use std::{
     alloc::Layout,
     borrow::Cow,
     fmt::{self, Display},
     ops::Neg,
     path::Path,
-    sync::Arc,
 };
 use thiserror::Error;
 
@@ -46,12 +45,12 @@ pub const SHARED_LIBRARY_EXT: &str = "so";
 pub static PRIME: LazyLock<BigUint> = LazyLock::new(|| {
     "3618502788666131213697322783095070105623107215331596699973092056135872020481"
         .parse()
-        .unwrap()
+        .expect("hardcoded prime constant should be valid")
 });
 pub static HALF_PRIME: LazyLock<BigUint> = LazyLock::new(|| {
     "1809251394333065606848661391547535052811553607665798349986546028067936010240"
         .parse()
-        .unwrap()
+        .expect("hardcoded half prime constant should be valid")
 });
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -163,12 +162,13 @@ pub fn get_integer_layout(width: u32) -> Layout {
         Layout::new::<u128>()
     } else {
         // According to the docs this should never return an error.
-        Layout::from_size_align((width as usize).next_multiple_of(8) >> 3, 16).unwrap()
+        Layout::from_size_align((width as usize).next_multiple_of(8) >> 3, 16)
+            .expect("only fails if size is greater than ISIZE::MAX")
     }
 }
 
 /// Compile a cairo program found at the given path to sierra.
-pub fn cairo_to_sierra(program: &Path) -> Arc<Program> {
+pub fn cairo_to_sierra(program: &Path) -> anyhow::Result<Arc<Program>> {
     if program
         .extension()
         .map(|x| {
@@ -185,14 +185,13 @@ pub fn cairo_to_sierra(program: &Path) -> Arc<Program> {
                 ..Default::default()
             },
         )
-        .unwrap()
-        .into()
+        .map(Arc::new)
     } else {
-        let source = std::fs::read_to_string(program).unwrap();
+        let source = std::fs::read_to_string(program)?;
         cairo_lang_sierra::ProgramParser::new()
             .parse(&source)
-            .unwrap()
-            .into()
+            .map_err(|err| anyhow::Error::msg(err.to_string()))
+            .map(Arc::new)
     }
 }
 
@@ -1086,7 +1085,7 @@ pub mod test {
         // Define the path to the cairo program.
         let program_path = Path::new("programs/examples/hello.cairo");
         // Compile the cairo program to sierra.
-        let sierra_program = cairo_to_sierra(program_path);
+        let sierra_program = cairo_to_sierra(program_path).unwrap();
 
         // Define the entry point function for comparison.
         let entry_point = "hello::hello::greet";
@@ -1112,7 +1111,7 @@ pub mod test {
         let file_path = file.path().to_path_buf();
 
         // Compile the cairo program to sierra using the path of the temporary file.
-        let sierra_program = cairo_to_sierra(&file_path);
+        let sierra_program = cairo_to_sierra(&file_path).unwrap();
 
         // Assert that the sierra program has no library function declarations, statements, or functions.
         assert!(sierra_program.libfunc_declarations.is_empty());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -234,9 +234,9 @@ pub fn felt252_str(value: &str) -> Felt {
         .parse::<BigInt>()
         .expect("value must be a digit number");
 
-    let value = match value.to_biguint() {
-        Some(value) => value,
-        None => &*PRIME - value.neg().to_biguint().expect("is always positive"),
+    let value = match value.sign() {
+        Sign::Minus => &*PRIME - value.magnitude(),
+        _ => value.magnitude().clone(),
     };
 
     value.into()


### PR DESCRIPTION
There are some unwraps left, but they are only used in tests.

`get_integer_layout` will never fail, and adding error handling implies changing a lot of files, as it's used throughout the codebase. We can consider changing it later.

The file `utils/mem_tracing.rs` also contains some unreachable, but as it's a debugging feature I don't think it's worth to update it.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
