### PR TITLE
Fix `--no-default-features` library-only builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ build-cli = [
     "dep:tracing-subscriber",
     "dep:anyhow",
     "dep:cairo-lang-test-plugin",
-    "dep:cairo-lang-runner",
     "dep:colored",
 ]
 scarb = ["build-cli", "dep:scarb-ui", "dep:scarb-metadata"]
@@ -62,6 +61,7 @@ bumpalo = "3.16.0"
 cairo-lang-compiler = "2.9.2"
 cairo-lang-defs = "2.9.2"
 cairo-lang-filesystem = "2.9.2"
+cairo-lang-runner = "2.9.2"
 cairo-lang-semantic = "2.9.2"
 cairo-lang-sierra = "2.9.2"
 cairo-lang-sierra-generator = "2.9.2"
@@ -102,7 +102,6 @@ tracing-subscriber = { version = "0.3.19", features = [
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "1.0", optional = true }
 cairo-lang-test-plugin = { version = "2.9.2", optional = true }
-cairo-lang-runner = { version = "2.9.2", optional = true }
 colored = { version = "2.1.0", optional = true }
 # needed to interface with cairo-lang-*
 keccak = "0.1.5"
@@ -121,7 +120,6 @@ num-integer = "0.1.46"
 
 [dev-dependencies]
 cairo-vm = { version = "2.0.0-rc0", features = ["cairo-1-hints"] }
-cairo-lang-runner = "2.9.2"
 cairo-lang-semantic = { version = "2.9.2", features = ["testing"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.11.0"

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -146,12 +146,15 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                 #[cfg(not(feature = "with-runtime"))]
                 native_panic!("enable the `with-runtime` feature to use felt252 dicts");
 
-                // TODO: Assert that `info.ty` matches all the values' types.
+                #[cfg(feature = "with-runtime")]
+                {
+                    // TODO: Assert that `info.ty` matches all the values' types.
 
-                self.value
-                    .to_ptr(self.arena, self.registry, self.type_id)?
-                    .as_ptr()
-                    .to_bytes(buffer)?
+                    self.value
+                        .to_ptr(self.arena, self.registry, self.type_id)?
+                        .as_ptr()
+                        .to_bytes(buffer)?
+                }
             }
             (
                 Value::Secp256K1Point(Secp256k1Point { x, y, is_infinity }),

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,9 @@ pub enum Error {
 
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
+
+    #[error("Failed to parse a Cairo/Sierra program: {0}")]
+    ProgramParser(String),
 }
 
 impl Error {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,7 +167,7 @@ pub fn get_integer_layout(width: u32) -> Layout {
 }
 
 /// Compile a cairo program found at the given path to sierra.
-pub fn cairo_to_sierra(program: &Path) -> anyhow::Result<Arc<Program>> {
+pub fn cairo_to_sierra(program: &Path) -> crate::error::Result<Arc<Program>> {
     if program
         .extension()
         .map(|x| {
@@ -184,14 +184,14 @@ pub fn cairo_to_sierra(program: &Path) -> anyhow::Result<Arc<Program>> {
                 ..Default::default()
             },
         )
-        .map(Arc::new)
+        .map_err(|err| crate::error::Error::ProgramParser(err.to_string()))
     } else {
         let source = std::fs::read_to_string(program)?;
         cairo_lang_sierra::ProgramParser::new()
             .parse(&source)
-            .map_err(|err| anyhow::Error::msg(err.to_string()))
-            .map(Arc::new)
+            .map_err(|err| crate::error::Error::ProgramParser(err.to_string()))
     }
+    .map(Arc::new)
 }
 
 /// Returns the given entry point if present.


### PR DESCRIPTION
A few issues were preventing minimal builds from succeeding:
  - Some binary-only libraries had crept onto the library.
  - We were missing some conditional compilation flags.

All those issues have been fixed.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
