### PR TITLE
Fix `array_snapshot_pop_front` CoW clones.

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1075,6 +1075,7 @@ fn build_pop<'ctx, 'this, const CONSUME: bool, const REVERSE: bool>(
                     block.const_int(context, location, elem_layout.pad_to_align().size(), 64)?;
                 match metadata.get::<DupOverridesMeta>() {
                     Some(dup_overrides_meta) if dup_overrides_meta.is_overriden(elem_ty) => {
+                        // TODO: If extract_len is 1 there is no need for the for loop.
                         block.append_operation(scf::r#for(
                             k0,
                             value_size,
@@ -1159,7 +1160,7 @@ fn build_pop<'ctx, 'this, const CONSUME: bool, const REVERSE: bool>(
                     )?;
 
                     let data_ptr = if REVERSE {
-                        data_ptr
+                        array_ptr
                     } else {
                         let offset = block.append_op_result(arith::extui(
                             extract_len_value,


### PR DESCRIPTION
Array clones caused by an invocation of `array_snapshot_pop_front` over shared arrays were cloning data from an incorrect pointer.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
