### PR TITLE
Fix daily run dependencies

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -111,6 +111,21 @@ jobs:
           sed -i'' -r "s/^cairo-native = .*/cairo-native.path = $new_path/" Cargo.toml
 
           git diff
+
+      - name: Patch sequencer dependencies
+        run: |
+          cd ../sequencer
+
+          # Updates native dependency to local path
+          new_path='"..\/cairo_native"'
+          sed -i'' -r "s/^cairo-native = .*/cairo-native.path = $new_path/" Cargo.toml
+
+          # Update native submodule
+          git rm crates/blockifier/cairo_native
+          ln -s ../../../cairo_native/ crates/blockifier/cairo_native
+
+          git diff
+
       - name: Run with Native
         if: ${{ matrix.runner == 'native' }}
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -61,17 +61,24 @@ jobs:
         working-directory: ./starknet-replay
 
     steps:
-      # We checkout replay first, as it's the main repository for this workflow
+      # We checkout replay as it's the main repository for this workflow
       - name: Checkout Replay
         uses: actions/checkout@v4
         with:
           repository: lambdaclass/starknet-replay
           path: starknet-replay
-      # We need native for building the runtime
+      # We need native if we want to run with cairo native main
       - name: Checkout Native
         uses: actions/checkout@v4
         with:
           path: cairo_native
+      # We need sequencer if we want to run with cairo native main
+      - name: Checkout Native
+        uses: actions/checkout@v4
+        with:
+          repository: lambdaclass/sequencer
+          path: sequencer
+          ref: replay
 
       # Install dependencies
       - uses: ./cairo_native/.github/actions/install-linux-deps

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -86,6 +86,10 @@ jobs:
         uses: dtolnay/rust-toolchain@1.83.0
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "starknet-replay -> target"
+          cache-directories: "cairo_native"
+
       - name: Build Cairo Native Runtime Library
         shell: bash
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -97,11 +97,20 @@ jobs:
           make runtime
           echo "CAIRO_NATIVE_RUNTIME_LIBRARY=$(pwd)/libcairo_native_runtime.a" > $GITHUB_ENV
 
-      - name: Patch dependencies
+      - name: Patch replay dependencies
         run: |
-          # Patches native dependency to local path, to use current cairo native version
-          echo -e "\n[patch.crates-io]\ncairo-native = { path = \"../cairo_native\" }" >> Cargo.toml
+          # Updates sequencer dependency to local path
+          name='[[:alnum:]_-]+'
+          sequencer_url='"https:\/\/github.com\/lambdaclass\/sequencer\.git"'
+          rev='"[[:alnum:]]+"'
+          new_path='"..\/sequencer\/crates\/\1"'
+          sed -i'' -r "s/^($name) = \{ git = $sequencer_url, rev = $rev/\1 = { path = $new_path/" Cargo.toml
 
+          # Updates native dependency to local path
+          new_path='"..\/cairo_native"'
+          sed -i'' -r "s/^cairo-native = .*/cairo-native.path = $new_path/" Cargo.toml
+
+          git diff
       - name: Run with Native
         if: ${{ matrix.runner == 'native' }}
         run: |


### PR DESCRIPTION
As the replay and sequencer crates now use Cairo Native tags, we must manually update the dependencies instead of relying on cargo.toml patches. 

We are not currently using latest main on the daily run, only the specified release, as this warning says:
> warning: Patch `cairo-native v0.2.5 (/home/runner/work/cairo_native/cairo_native/cairo_native)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.

With this PR, the daily workflow:
- Clones all the needed repositories
- Updates all dependencies to point to local paths

This PR also updates the CI cache config, as it was not working properly.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
