### PR TITLE
Fix CI Cache: only cache cairo native target

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -97,8 +97,9 @@ jobs:
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "starknet-replay -> target"
-          cache-directories: "cairo_native"
+          workspaces: |
+            starknet-replay
+            cairo_native
 
       - name: Build Cairo Native Runtime Library
         shell: bash

--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "starknet-replay -> target"
-          cache-directories: "cairo_native"
+          workspaces: |
+            starknet-replay
+            cairo_native
 
       - name: Build Cairo Native Runtime Library
         shell: bash


### PR DESCRIPTION
We were caching whole cairo_native directory, instead of the target directory. This implied:
- Sometimes the wrong version was used
- The contracts were being cached


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
