### PR TITLE
Pin cairo-lang to 2.10.0-rc0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,13 +58,13 @@ normal = ["aquamarine"]
 [dependencies]
 aquamarine = "0.6.0"
 bumpalo = "3.16.0"
-cairo-lang-compiler = "2.10.0-rc.0"
-cairo-lang-defs = "2.10.0-rc.0"
-cairo-lang-filesystem = "2.10.0-rc.0"
-cairo-lang-runner = "2.10.0-rc.0"
-cairo-lang-semantic = "2.10.0-rc.0"
-cairo-lang-sierra = "2.10.0-rc.0"
-cairo-lang-sierra-generator = "2.10.0-rc.0"
+cairo-lang-compiler = "=2.10.0-rc.0"
+cairo-lang-defs = "=2.10.0-rc.0"
+cairo-lang-filesystem = "=2.10.0-rc.0"
+cairo-lang-runner = "=2.10.0-rc.0"
+cairo-lang-semantic = "=2.10.0-rc.0"
+cairo-lang-sierra = "=2.10.0-rc.0"
+cairo-lang-sierra-generator = "=2.10.0-rc.0"
 educe = "0.5.11" # can't update until https://github.com/magiclen/educe/issues/27
 itertools = "0.13.0"
 lazy_static = "1.5"
@@ -86,11 +86,11 @@ utf8_iter = "1.0.4"
 
 
 # CLI dependencies
-cairo-lang-sierra-ap-change = "2.10.0-rc.0"
-cairo-lang-sierra-gas = "2.10.0-rc.0"
-cairo-lang-starknet = "2.10.0-rc.0"
-cairo-lang-utils = "2.10.0-rc.0"
-cairo-lang-starknet-classes = "2.10.0-rc.0"
+cairo-lang-sierra-ap-change = "=2.10.0-rc.0"
+cairo-lang-sierra-gas = "=2.10.0-rc.0"
+cairo-lang-starknet = "=2.10.0-rc.0"
+cairo-lang-utils = "=2.10.0-rc.0"
+cairo-lang-starknet-classes = "=2.10.0-rc.0"
 cairo-native-runtime = { version = "0.2.8", path = "runtime", optional = true }
 clap = { version = "4.5.23", features = ["derive"], optional = true }
 libloading = "0.8.6"
@@ -101,7 +101,7 @@ tracing-subscriber = { version = "0.3.19", features = [
 ], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "1.0", optional = true }
-cairo-lang-test-plugin = { version = "2.10.0-rc.0", optional = true }
+cairo-lang-test-plugin = { version = "=2.10.0-rc.0", optional = true }
 colored = { version = "2.1.0", optional = true }
 # needed to interface with cairo-lang-*
 keccak = "0.1.5"
@@ -120,7 +120,7 @@ num-integer = "0.1.46"
 
 [dev-dependencies]
 cairo-vm = { version = "2.0.0-rc3", features = ["cairo-1-hints"] }
-cairo-lang-semantic = { version = "2.10.0-rc.0", features = ["testing"] }
+cairo-lang-semantic = { version = "=2.10.0-rc.0", features = ["testing"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.11.0"
 pretty_assertions_sorted = "1.2.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,7 +15,7 @@ starknet-types-core = { version = "0.1.7", default-features = false, features = 
     "serde",
     "hash",
 ] }
-cairo-lang-sierra-gas = "2.10.0-rc.0"
+cairo-lang-sierra-gas = "=2.10.0-rc.0"
 starknet-curve = "0.5.1"
 lazy_static = "1.5.0"
 rand = "0.8.5"


### PR DESCRIPTION
Avoids updating `cairo-lang` to 2.10.0-rc1. We need to adapt Native to that new version first. 