### PR TITLE
Fix gas diffs.

### DIFF
--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -163,8 +163,8 @@ impl AotContractExecutor {
                         )
                     })
                     .collect(),
-                linear_gas_solver: true,
-                linear_ap_change_solver: true,
+                linear_gas_solver: false,
+                linear_ap_change_solver: false,
             }),
         )?;
 


### PR DESCRIPTION
The `linear_gas_solver` and `linear_ap_change_solver` fields should only be set to `true` when the Sierra version is at least `1.4`.

Source: https://github.com/starkware-libs/cairo/blob/71d6052dd167ff9435873d30c52b5b0d10116b71/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs#L412-L422

> TODO: Provide a way to specifiy the sierra version at `AotContractExecutor::new()`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
