### PR TITLE
Specify sierra version in Contract Executor

### DIFF
--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: lambdaclass/starknet-replay
           path: starknet-replay
-          ref: 546457d800fd02f080888331aebecc15824bed91
+          ref: 313a19cce2e930cbd644606aa732b6408fcf2246
       # We need native to build the runtime
       - name: Checkout Native
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: lambdaclass/sequencer
           path: sequencer
-          ref: 15d6452d162ad5e3538e673d1e4df5abcff9452f
+          ref: f9b0f034e55c63103c11248b59b7f85da6eaef65
 
       - name: Cache RPC Calls
         uses: actions/cache@v4

--- a/scripts/cmp_state_dumps.sh
+++ b/scripts/cmp_state_dumps.sh
@@ -30,8 +30,8 @@ for vm_dump in state_dumps/vm/*/*.json; do
   block=${block_name//block/}
 
   if ! cmp -s \
-      <(sed '/"reverted": /d' "$native_dump") \
-      <(sed '/"reverted": /d' "$vm_dump")
+      <(sed '/"revert_error": /d' "$native_dump") \
+      <(sed '/"revert_error": /d' "$vm_dump")
   then
     echo "Diff at block $block, tx $tx"
     diffing=$((diffing+1))

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -67,6 +67,7 @@ use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 use std::{
     alloc::Layout,
+    cmp::Ordering,
     collections::{BTreeMap, HashSet},
     ffi::c_void,
     path::{Path, PathBuf},
@@ -153,7 +154,12 @@ impl AotContractExecutor {
             used_function_ids.insert(entry.function_idx as u64);
         }
 
-        let no_eq_solver = sierra_version.minor >= 4;
+        // true if sierra version is at least 1.4
+        let no_eq_solver = match sierra_version.major.cmp(&1) {
+            Ordering::Less => false,
+            Ordering::Equal => sierra_version.minor >= 4,
+            Ordering::Greater => true,
+        };
         let module = native_context.compile(
             sierra_program,
             true,

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -615,7 +615,9 @@ impl Drop for AotContractExecutor {
 mod tests {
     use super::*;
     use crate::{starknet_stub::StubSyscallHandler, utils::test::load_starknet_contract};
-    use cairo_lang_starknet_classes::contract_class::ContractClass;
+    use cairo_lang_starknet_classes::contract_class::{
+        version_id_from_serialized_sierra_program, ContractClass,
+    };
     use rayon::iter::ParallelBridge;
     use rstest::*;
 
@@ -708,10 +710,13 @@ mod tests {
     ) {
         use rayon::iter::ParallelIterator;
 
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&starknet_program.sierra_program).unwrap();
         let executor = Arc::new(
             AotContractExecutor::new(
                 &starknet_program.extract_sierra_program().unwrap(),
                 &starknet_program.entry_points_by_type,
+                sierra_version,
                 optlevel,
             )
             .unwrap(),
@@ -745,9 +750,12 @@ mod tests {
     #[case(OptLevel::None)]
     #[case(OptLevel::Default)]
     fn test_contract_executor(starknet_program: ContractClass, #[case] optlevel: OptLevel) {
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&starknet_program.sierra_program).unwrap();
         let executor = AotContractExecutor::new(
             &starknet_program.extract_sierra_program().unwrap(),
             &starknet_program.entry_points_by_type,
+            sierra_version,
             optlevel,
         )
         .unwrap();
@@ -780,9 +788,13 @@ mod tests {
         starknet_program_factorial: ContractClass,
         #[case] optlevel: OptLevel,
     ) {
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&starknet_program_factorial.sierra_program)
+                .unwrap();
         let executor = AotContractExecutor::new(
             &starknet_program_factorial.extract_sierra_program().unwrap(),
             &starknet_program_factorial.entry_points_by_type,
+            sierra_version,
             optlevel,
         )
         .unwrap();
@@ -816,9 +828,13 @@ mod tests {
         starknet_program_empty: ContractClass,
         #[case] optlevel: OptLevel,
     ) {
+        let (sierra_version, _) =
+            version_id_from_serialized_sierra_program(&starknet_program_empty.sierra_program)
+                .unwrap();
         let executor = AotContractExecutor::new(
             &starknet_program_empty.extract_sierra_program().unwrap(),
             &starknet_program_empty.entry_points_by_type,
+            sierra_version,
             optlevel,
         )
         .unwrap();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -29,7 +29,7 @@ use cairo_lang_starknet::{
 };
 use cairo_lang_starknet_classes::{
     casm_contract_class::{CasmContractClass, ENTRY_POINT_COST},
-    contract_class::ContractClass,
+    contract_class::{version_id_from_serialized_sierra_program, ContractClass},
 };
 use cairo_lang_utils::Upcast;
 use cairo_native::{
@@ -448,9 +448,12 @@ pub fn run_native_starknet_aot_contract(
     args: &[Felt],
     handler: impl StarknetSyscallHandler,
 ) -> ContractExecutionResult {
+    let (sierra_version, _) =
+        version_id_from_serialized_sierra_program(&contract.sierra_program).unwrap();
     let native_executor = AotContractExecutor::new(
         &contract.extract_sierra_program().unwrap(),
         &contract.entry_points_by_type,
+        sierra_version,
         Default::default(),
     )
     .unwrap();


### PR DESCRIPTION
Adds a new argument to `AotContractExecutor::new` that allows for specifying the sierra version. It is used to correctly build the computation metadata.

Closes #1072


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
