### PR TITLE
Fix circuit implementation

### DIFF
--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -740,10 +740,10 @@ fn build_u96_limbs_less_than_guarantee_verify<'ctx, 'this>(
 
     let u96 = entry.append_op_result(llvm::undef(u96_type, location))?;
 
-    let kfalse = entry.const_int(context, location, 0, 64)?;
+    let ktrue = entry.const_int(context, location, 1, 64)?;
     entry.append_operation(helper.cond_br(
         context,
-        kfalse,
+        ktrue,
         [0, 1],
         [&[guarantee], &[u96]],
         location,
@@ -766,7 +766,7 @@ fn build_u96_single_limb_less_than_guarantee_verify<'ctx, 'this>(
 ) -> Result<()> {
     let u96_type_id = &info.branch_signatures()[0].vars[0].ty;
     let u96_type = registry.build_type(context, helper, metadata, u96_type_id)?;
-    let u96 = entry.append_op_result(llvm::undef(u96_type, location))?;
+    let u96 = entry.const_int_from_type(context, location, 0, u96_type)?;
 
     entry.append_operation(helper.br(0, &[u96], location));
 

--- a/tests/tests/circuit.rs
+++ b/tests/tests/circuit.rs
@@ -1,0 +1,60 @@
+use crate::common::{compare_outputs, DEFAULT_GAS};
+use crate::common::{load_cairo, run_native_program, run_vm_program};
+use cairo_lang_runner::SierraCasmRunner;
+use cairo_lang_sierra::program::Program;
+use cairo_native::starknet::DummySyscallHandler;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    // Taken from: https://github.com/starkware-libs/sequencer/blob/7ee6f4c8a81def87402c626c9d72a33c74bc3243/crates/blockifier/feature_contracts/cairo1/test_contract.cairo#L656
+    static ref TEST: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::circuit::{
+            CircuitElement, CircuitInput, circuit_add, circuit_sub, circuit_mul, circuit_inverse,
+            EvalCircuitResult, EvalCircuitTrait, u384, CircuitOutputsTrait, CircuitModulus,
+            CircuitInputs, AddInputResultTrait
+        };
+
+        fn test() {
+            let in1 = CircuitElement::<CircuitInput<0>> {};
+            let in2 = CircuitElement::<CircuitInput<1>> {};
+            let add = circuit_add(in1, in2);
+            let inv = circuit_inverse(add);
+            let sub = circuit_sub(inv, in2);
+            let mul = circuit_mul(inv, sub);
+
+            let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+            let outputs = (mul,)
+                .new_inputs()
+                .next([3, 0, 0, 0])
+                .next([6, 0, 0, 0])
+                .done()
+                .eval(modulus)
+                .unwrap();
+
+            assert!(outputs.get_output(mul) == u384 { limb0: 6, limb1: 0, limb2: 0, limb3: 0 });
+        }
+    };
+}
+
+#[test]
+fn circuit() {
+    let program = &TEST;
+
+    let result_vm = run_vm_program(program, "test", vec![], Some(DEFAULT_GAS as usize)).unwrap();
+
+    let result_native = run_native_program(
+        program,
+        "test",
+        &[],
+        Some(DEFAULT_GAS),
+        Option::<DummySyscallHandler>::None,
+    );
+
+    compare_outputs(
+        &program.1,
+        &program.2.find_function("test").unwrap().id,
+        &result_vm,
+        &result_native,
+    )
+    .unwrap();
+}

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod alexandria;
 pub mod arrays;
 pub mod boolean;
 pub mod cases;
+pub mod circuit;
 pub mod compile_library;
 pub mod dict;
 pub mod ec;


### PR DESCRIPTION
We were returning the failing case of a noop libfunc (`build_u96_limbs_less_than_guarantee_verify`). We were returning branch 1, instead of branch 0.

This PR should fix the gas issue in #1076.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
