### PR TITLE
Improves documentation on unreachable panics

### DIFF
--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -406,10 +406,10 @@ fn build_drop<'ctx>(
 pub fn calc_data_prefix_offset(layout: Layout) -> usize {
     get_integer_layout(32)
         .extend(get_integer_layout(32))
-        .expect("creating a layout of two i32 will never fail")
+        .expect("creating a layout of two i32 should never fail")
         .0
         .align_to(layout.align())
-        .expect("only fails if size is greater than approximately ISIZE::MAX")
+        .expect("layout size rounded up to the next multiple of layout alignment should never be greater than ISIZE::MAX")
         .pad_to_align()
         .size()
 }

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -406,10 +406,10 @@ fn build_drop<'ctx>(
 pub fn calc_data_prefix_offset(layout: Layout) -> usize {
     get_integer_layout(32)
         .extend(get_integer_layout(32))
-        .unwrap()
+        .expect("creating a layout of two i32 will never fail")
         .0
         .align_to(layout.align())
-        .unwrap()
+        .expect("only fails if size is greater than approximately ISIZE::MAX")
         .pad_to_align()
         .size()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -176,7 +176,7 @@ pub fn get_integer_layout(width: u32) -> Layout {
     } else {
         // According to the docs this should never return an error.
         Layout::from_size_align((width as usize).next_multiple_of(8) >> 3, 16)
-            .expect("only fails if size is greater than approximately ISIZE::MAX")
+        .expect("layout size rounded up to the next multiple of 16 should never be greater than ISIZE::MAX")
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -176,7 +176,7 @@ pub fn get_integer_layout(width: u32) -> Layout {
     } else {
         // According to the docs this should never return an error.
         Layout::from_size_align((width as usize).next_multiple_of(8) >> 3, 16)
-            .expect("only fails if size is greater than ISIZE::MAX")
+            .expect("only fails if size is greater than approximately ISIZE::MAX")
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -176,7 +176,7 @@ pub fn get_integer_layout(width: u32) -> Layout {
     } else {
         // According to the docs this should never return an error.
         Layout::from_size_align((width as usize).next_multiple_of(8) >> 3, 16)
-        .expect("layout size rounded up to the next multiple of 16 should never be greater than ISIZE::MAX")
+            .expect("layout size rounded up to the next multiple of 16 should never be greater than ISIZE::MAX")
     }
 }
 


### PR DESCRIPTION
Change unwrap to expect in some unreachable panics, explaining why they will never fail.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
