### PR TITLE
Remove panics from libfuncs directory

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -946,7 +946,7 @@ fn build_pop<'ctx, 'this, const CONSUME: bool, const REVERSE: bool>(
         if CONSUME {
             metadata
                 .get::<DropOverridesMeta>()
-                .unwrap()
+                .to_native_assert_error("drop overrides metadata should be available")?
                 .invoke_override(context, error_block, location, self_ty, array_obj)?;
         } else {
             branch_values.push(array_obj);
@@ -1061,7 +1061,7 @@ pub fn build_get<'ctx, 'this>(
         // Drop the input array.
         metadata
             .get::<DropOverridesMeta>()
-            .unwrap()
+            .to_native_assert_error("drop overrides metadata should be available")?
             .invoke_override(
                 context,
                 valid_block,
@@ -1076,7 +1076,7 @@ pub fn build_get<'ctx, 'this>(
     {
         metadata
             .get::<DropOverridesMeta>()
-            .unwrap()
+            .to_native_assert_error("drop overrides metadata should be available")?
             .invoke_override(
                 context,
                 error_block,
@@ -1192,7 +1192,7 @@ pub fn build_len<'ctx, 'this>(
 
     metadata
         .get::<DropOverridesMeta>()
-        .unwrap()
+        .to_native_assert_error("drop overrides metadata should be available")?
         .invoke_override(
             context,
             entry,

--- a/src/libfuncs/bool.rs
+++ b/src/libfuncs/bool.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{panic::ToNativeAssertError, Result},
     metadata::MetadataStorage,
     types::TypeBuilder,
     utils::{BlockExt, ProgramRegistryExt},
@@ -94,7 +94,7 @@ fn build_bool_binary<'ctx, 'this>(
     let enum_ty = registry.get_type(&info.param_signatures()[0].ty)?;
     let tag_bits = enum_ty
         .variants()
-        .expect("bool is a enum and has variants")
+        .to_native_assert_error("bool is a enum and has variants")?
         .len()
         .next_power_of_two()
         .trailing_zeros();
@@ -143,7 +143,7 @@ pub fn build_bool_not<'ctx, 'this>(
     let enum_ty = registry.get_type(&info.param_signatures()[0].ty)?;
     let tag_bits = enum_ty
         .variants()
-        .expect("bool is a enum and has variants")
+        .to_native_assert_error("bool is a enum and has variants")?
         .len()
         .next_power_of_two()
         .trailing_zeros();
@@ -192,7 +192,7 @@ pub fn build_bool_to_felt252<'ctx, 'this>(
 
     let tag_bits = enum_ty
         .variants()
-        .expect("bool is a enum and has variants")
+        .to_native_assert_error("bool is a enum and has variants")?
         .len()
         .next_power_of_two()
         .trailing_zeros();

--- a/src/libfuncs/debug.rs
+++ b/src/libfuncs/debug.rs
@@ -11,7 +11,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::{Error, Result},
+    error::{panic::ToNativeAssertError, Error, Result},
     metadata::{
         drop_overrides::DropOverridesMeta, runtime_bindings::RuntimeBindingsMeta, MetadataStorage,
     },
@@ -82,7 +82,7 @@ pub fn build_print<'ctx>(
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     let values_len = entry.append_op_result(arith::subi(values_end, values_start, location))?;
 

--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -145,13 +145,7 @@ pub fn build_enum_value<'ctx, 'this>(
             let tag_val = entry
                 .append_operation(arith::constant(
                     context,
-                    IntegerAttribute::new(
-                        tag_ty,
-                        variant_index
-                            .try_into()
-                            .expect("couldnt convert index to i64"),
-                    )
-                    .into(),
+                    IntegerAttribute::new(tag_ty, variant_index.try_into()?).into(),
                     location,
                 ))
                 .result(0)?
@@ -425,7 +419,7 @@ pub fn build_snapshot_match<'ctx, 'this>(
         .get::<EnumSnapshotVariantsMeta>()
         .ok_or(Error::MissingMetadata)?
         .get_variants(&info.param_signatures()[0].ty)
-        .expect("enum should always have variants")
+        .to_native_assert_error("enum should always have variants")?
         .clone();
     match variant_ids.len() {
         0 => {

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{panic::ToNativeAssertError, Result},
     metadata::{
         felt252_dict::Felt252DictOverrides, runtime_bindings::RuntimeBindingsMeta, MetadataStorage,
     },
@@ -112,7 +112,7 @@ pub fn build_new<'ctx, 'this>(
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
     let dict_ptr = runtime_bindings.dict_new(
         context,
         helper,
@@ -143,7 +143,7 @@ pub fn build_squash<'ctx, 'this>(
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     let gas_refund = runtime_bindings
         .dict_gas_refund(context, helper, entry, dict_ptr, location)?

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -2,7 +2,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::{Error, Result},
+    error::{panic::ToNativeAssertError, Error, Result},
     metadata::{gas::GasCost, runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     native_panic,
     utils::{BlockExt, GepIndex},
@@ -91,7 +91,7 @@ pub fn build_withdraw_gas<'ctx, 'this>(
 
     let gas_cost = metadata
         .get::<GasCost>()
-        .expect("withdraw_gas should always have a gas cost")
+        .to_native_assert_error("withdraw_gas should always have a gas cost")?
         .clone();
 
     let u64_type: melior::ir::Type = IntegerType::new(context, 64).into();
@@ -172,7 +172,7 @@ pub fn build_redeposit_gas<'ctx, 'this>(
 
     let gas_cost = metadata
         .get::<GasCost>()
-        .expect("redeposit_gas should always have a gas cost")
+        .to_native_assert_error("redeposit_gas should always have a gas cost")?
         .clone();
 
     let u64_type: melior::ir::Type = IntegerType::new(context, 64).into();
@@ -247,7 +247,7 @@ pub fn build_builtin_withdraw_gas<'ctx, 'this>(
 
     let gas_cost = metadata
         .get::<GasCost>()
-        .expect("builtin_withdraw_gas should always have a gas cost")
+        .to_native_assert_error("builtin_withdraw_gas should always have a gas cost")?
         .clone();
 
     let u64_type: melior::ir::Type = IntegerType::new(context, 64).into();

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -880,8 +880,7 @@ fn build_wide_mul<'ctx, 'this>(
 
     let ext_fn = if registry
         .get_type(&info.signature.param_signatures[0].ty)?
-        .integer_range(registry)
-        .unwrap()
+        .integer_range(registry)?
         .lower
         .is_zero()
     {

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -3,7 +3,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{panic::ToNativeAssertError, Result},
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt},
 };
@@ -49,7 +49,7 @@ pub fn build_pedersen<'ctx>(
 ) -> Result<()> {
     metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     let pedersen_builtin =
         super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
@@ -83,7 +83,7 @@ pub fn build_pedersen<'ctx>(
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     runtime_bindings
         .libfunc_pedersen(context, helper, entry, dst_ptr, lhs_ptr, rhs_ptr, location)?;

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -3,7 +3,7 @@
 
 use super::LibfuncHelper;
 use crate::{
-    error::Result,
+    error::{panic::ToNativeAssertError, Result},
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt},
 };
@@ -50,7 +50,7 @@ pub fn build_hades_permutation<'ctx>(
 ) -> Result<()> {
     metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     let poseidon_builtin =
         super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
@@ -91,7 +91,7 @@ pub fn build_hades_permutation<'ctx>(
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
-        .expect("Runtime library not available.");
+        .to_native_assert_error("runtime library should be available")?;
 
     runtime_bindings
         .libfunc_hades_permutation(context, helper, entry, op0_ptr, op1_ptr, op2_ptr, location)?;

--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -145,7 +145,9 @@ pub fn build<'ctx, 'this>(
         }
         #[cfg(not(feature = "with-cheatcode"))]
         StarkNetConcreteLibfunc::Testing(TestingConcreteLibfunc::Cheatcode(_)) => {
-            unimplemented!("feature 'with-cheatcode' is required to compile with cheatcode syscall")
+            crate::native_panic!(
+                "feature 'with-cheatcode' is required to compile with cheatcode syscall"
+            )
         }
     }
 }


### PR DESCRIPTION
This PR removes all panics in the libfuncs directory, by replacing it with native asserts.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
