### PR TITLE
Bump Rust to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Bump Rust to 1.85

Closes #1114 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
