### PR TITLE
Replace asserts with errors

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -53,7 +53,7 @@ use crate::{
         tail_recursion::TailRecursionMeta,
         MetadataStorage,
     },
-    native_panic,
+    native_assert, native_panic,
     types::TypeBuilder,
     utils::{generate_function_name, BlockExt},
 };
@@ -602,7 +602,7 @@ fn compile_func(
                         &helper,
                         metadata,
                     )?;
-                    assert!(
+                    native_assert!(
                         block.terminator().is_some(),
                         "libfunc {} had no terminator",
                         libfunc_name
@@ -620,9 +620,8 @@ fn compile_func(
                             .iter()
                             .zip(helper.results()?)
                             .map(|(branch_info, result_values)| {
-                                assert_eq!(
-                                    branch_info.results.len(),
-                                    result_values.len(),
+                                native_assert!(
+                                    branch_info.results.len() == result_values.len(),
                                     "Mismatched number of returned values from branch."
                                 );
 
@@ -1053,7 +1052,7 @@ fn generate_function_structure<'c, 'a>(
                                         Entry::Occupied(entry) => entry.into_mut(),
                                         Entry::Vacant(entry) => entry.insert((state.clone(), 0)),
                                     };
-                                assert!(
+                                native_assert!(
                                     prev_state.eq_unordered(&state),
                                     "Branch target states do not match."
                                 );
@@ -1070,7 +1069,7 @@ fn generate_function_structure<'c, 'a>(
                     );
 
                     let (state, types) = edit_state::take_args(state.clone(), var_ids.iter())?;
-                    assert!(
+                    native_assert!(
                         state.is_empty(),
                         "State must be empty after a return statement."
                     );

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -39,6 +39,7 @@ use crate::{
     executor::{invoke_trampoline, BuiltinCostsGuard},
     metadata::{gas::MetadataComputationConfig, runtime_bindings::setup_runtime},
     module::NativeModule,
+    native_assert,
     starknet::{handler::StarknetSyscallHandlerCallbacks, StarknetSyscallHandler},
     types::TypeBuilder,
     utils::{
@@ -551,7 +552,10 @@ impl AotContractExecutor {
 
             unsafe {
                 let array_ptr = array_ptr.byte_sub(refcount_offset);
-                assert_eq!(array_ptr.cast::<u32>().read(), 1);
+                native_assert!(
+                    array_ptr.cast::<u32>().read() == 1,
+                    "return array should have a reference count of 1"
+                );
                 libc_free(array_ptr.as_ptr().cast());
                 libc_free(array_ptr_ptr.cast());
             }

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -7,6 +7,7 @@ use crate::{
         drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
         realloc_bindings::ReallocBindingsMeta, MetadataStorage,
     },
+    native_assert,
     types::array::calc_data_prefix_offset,
     utils::{BlockExt, GepIndex, ProgramRegistryExt},
 };
@@ -787,7 +788,10 @@ fn build_pop<'ctx, 'this, const CONSUME: bool, const REVERSE: bool>(
             let CoreTypeConcrete::Struct(info) = registry.get_type(popped_ty)? else {
                 return Err(Error::SierraAssert(SierraAssertError::BadTypeInfo));
             };
-            debug_assert!(info.members.iter().all(|member_ty| member_ty == ty));
+            native_assert!(
+                info.members.iter().all(|member_ty| member_ty == ty),
+                "output struct type should match the array's type"
+            );
 
             (
                 &signature.param_signatures[1].ty,

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -4,7 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::Result,
     metadata::MetadataStorage,
-    native_panic,
+    native_assert, native_panic,
     types::TypeBuilder,
     utils::{BlockExt, RangeExt, HALF_PRIME, PRIME},
 };
@@ -301,7 +301,7 @@ pub fn build_upcast<'ctx, 'this>(
 
     let src_range = src_ty.integer_range(registry)?;
     let dst_range = dst_ty.integer_range(registry)?;
-    assert!(
+    native_assert!(
         if dst_ty.is_felt252(registry)? {
             let alt_range = Range {
                 lower: BigInt::from_biguint(Sign::Minus, HALF_PRIME.clone()),
@@ -330,10 +330,11 @@ pub fn build_upcast<'ctx, 'this>(
     };
 
     // If the source can be negative, the target type must also contain negatives when upcasting.
-    assert!(
+    native_assert!(
         src_range.lower.sign() != Sign::Minus
             || dst_ty.is_felt252(registry)?
-            || dst_range.lower.sign() == Sign::Minus
+            || dst_range.lower.sign() == Sign::Minus,
+        "if the source range contains negatives, the target range must always contain negatives",
     );
     let is_signed = src_range.lower.sign() == Sign::Minus;
 

--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -7,6 +7,7 @@ use super::LibfuncHelper;
 use crate::{
     error::{Error, Result},
     metadata::{tail_recursion::TailRecursionMeta, MetadataStorage},
+    native_assert,
     types::TypeBuilder,
     utils::{generate_function_name, BlockExt},
 };
@@ -270,7 +271,10 @@ pub fn build<'ctx, 'this>(
                 let mut count = 0;
                 for (idx, type_id) in info.function.signature.ret_types.iter().enumerate() {
                     let type_info = registry.get_type(type_id)?;
-                    assert!(!type_info.is_memory_allocated(registry)?);
+                    native_assert!(
+                        !type_info.is_memory_allocated(registry)?,
+                        "if there is no return pointer, return data must not be memory allocated"
+                    );
 
                     if type_info.is_builtin() && type_info.is_zst(registry)? {
                         results.push(entry.argument(idx)?.into());


### PR DESCRIPTION
Removes asserts in Native by replacing them with errors 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
