### PR TITLE
Move panicking testing utilities to test module

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1304,10 +1304,7 @@ fn is_shared<'ctx, 'this>(
 #[cfg(test)]
 mod test {
     use crate::{
-        utils::{
-            felt252_str,
-            test::{jit_enum, jit_panic, jit_struct, load_cairo, run_program},
-        },
+        utils::test::{felt252_str, jit_enum, jit_panic, jit_struct, load_cairo, run_program},
         values::Value,
     };
     use pretty_assertions_sorted::assert_eq;

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -1087,9 +1087,8 @@ fn build_array_slice<'ctx>(
 mod test {
 
     use crate::{
-        utils::{
-            felt252_str,
-            test::{jit_enum, jit_panic, jit_struct, load_cairo, run_program_assert_output},
+        utils::test::{
+            felt252_str, jit_enum, jit_panic, jit_struct, load_cairo, run_program_assert_output,
         },
         values::Value,
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -252,17 +252,6 @@ pub fn felt252_bigint(value: impl Into<BigInt>) -> Felt {
     value.as_ref().into()
 }
 
-/// Parse a short string into a felt that can be used in the cairo-native input.
-pub fn felt252_short_str(value: &str) -> Felt {
-    let values: Vec<_> = value
-        .chars()
-        .filter_map(|c| c.is_ascii().then_some(c as u8))
-        .collect();
-
-    assert!(values.len() < 32, "A felt can't longer than 32 bytes");
-    Felt::from_bytes_be_slice(&values)
-}
-
 /// Creates the execution engine, with all symbols registered.
 pub fn create_engine(
     module: &Module,
@@ -488,6 +477,17 @@ pub mod test {
         };
 
         value.into()
+    }
+
+    /// Parse a short string into a felt that can be used in the cairo-native input.
+    pub fn felt252_short_str(value: &str) -> Felt {
+        let values: Vec<_> = value
+            .chars()
+            .filter_map(|c| c.is_ascii().then_some(c as u8))
+            .collect();
+
+        assert!(values.len() < 32, "A felt can't longer than 32 bytes");
+        Felt::from_bytes_be_slice(&values)
     }
 
     pub(crate) fn load_cairo_str(program_str: &str) -> (String, Program) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -241,20 +241,6 @@ pub fn find_function_id<'a>(program: &'a Program, function_name: &str) -> Option
         .map(|func| &func.id)
 }
 
-/// Parse a numeric string into felt, wrapping negatives around the prime modulo.
-pub fn felt252_str(value: &str) -> Felt {
-    let value = value
-        .parse::<BigInt>()
-        .expect("value must be a digit number");
-
-    let value = match value.sign() {
-        Sign::Minus => &*PRIME - value.magnitude(),
-        _ => value.magnitude().clone(),
-    };
-
-    value.into()
-}
-
 /// Parse any type that can be a bigint to a felt that can be used in the cairo-native input.
 pub fn felt252_bigint(value: impl Into<BigInt>) -> Felt {
     let value: BigInt = value.into();
@@ -489,6 +475,20 @@ pub mod test {
     pub(crate) use jit_enum;
     pub(crate) use jit_panic;
     pub(crate) use jit_struct;
+
+    /// Parse a numeric string into felt, wrapping negatives around the prime modulo.
+    pub(crate) fn felt252_str(value: &str) -> Felt {
+        let value = value
+            .parse::<BigInt>()
+            .expect("value must be a digit number");
+
+        let value = match value.sign() {
+            Sign::Minus => &*PRIME - value.magnitude(),
+            _ => value.magnitude().clone(),
+        };
+
+        value.into()
+    }
 
     pub(crate) fn load_cairo_str(program_str: &str) -> (String, Program) {
         compile_program(program_str, RootDatabase::default())


### PR DESCRIPTION
Some functions that could panic were only used in tests, but were available to the whole project. This PR moves the functions to ensure that they are only used in tests.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
