### PR TITLE
Fix dictionary clones.

### DIFF
--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -191,7 +191,7 @@ pub fn build_finalize<'ctx, 'this>(
 
 #[cfg(test)]
 mod test {
-    use crate::utils::test::{jit_dict, load_cairo, run_program_assert_output};
+    use crate::utils::test::{jit_dict, load_cairo, run_program, run_program_assert_output};
 
     #[test]
     fn run_dict_insert() {
@@ -278,5 +278,24 @@ mod test {
         );
 
         run_program_assert_output(&program, "run_test", &[], 1345432_u32.into());
+    }
+
+    #[test]
+    fn run_dict_clone_ptr_update() {
+        let program = load_cairo!(
+            use core::dict::Felt252Dict;
+
+            fn run_test() {
+                let mut dict: Felt252Dict<u64> = Default::default();
+
+                let snapshot = @dict;
+                dict.insert(1, 1);
+                drop(snapshot);
+
+                dict.insert(2, 2);
+            }
+        );
+
+        run_program(&program, "run_test", &[]);
     }
 }

--- a/src/libfuncs/felt252_dict_entry.rs
+++ b/src/libfuncs/felt252_dict_entry.rs
@@ -88,7 +88,7 @@ pub fn build_get<'ctx, 'this>(
             .alloca1(context, location, key_ty, key_layout.align())?;
     entry.store(context, location, entry_key_ptr, entry_key)?;
 
-    let (is_present, value_ptr) = metadata
+    let (dict_ptr, is_present, value_ptr) = metadata
         .get_mut::<RuntimeBindingsMeta>()
         .ok_or(Error::MissingMetadata)?
         .dict_get(context, helper, entry, dict_ptr, entry_key_ptr, location)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -866,7 +866,7 @@ mod tests {
 
     #[test]
     fn test_dict() {
-        let dict = unsafe {
+        let mut dict = unsafe {
             cairo_native__dict_new(
                 size_of::<u64>() as u64,
                 align_of::<u64>() as u64,
@@ -879,14 +879,14 @@ mod tests {
         let mut ptr = ptr::null_mut::<u64>();
 
         assert_eq!(
-            unsafe { cairo_native__dict_get(dict, &key, (&raw mut ptr).cast()) },
+            unsafe { cairo_native__dict_get(&mut dict, &key, (&raw mut ptr).cast()) },
             0,
         );
         assert!(!ptr.is_null());
         unsafe { *ptr = 24 };
 
         assert_eq!(
-            unsafe { cairo_native__dict_get(dict, &key, (&raw mut ptr).cast()) },
+            unsafe { cairo_native__dict_get(&mut dict, &key, (&raw mut ptr).cast()) },
             1,
         );
         assert!(!ptr.is_null());
@@ -896,11 +896,11 @@ mod tests {
         let refund = unsafe { cairo_native__dict_gas_refund(dict) };
         assert_eq!(refund, 4050);
 
-        let cloned_dict = unsafe { cairo_native__dict_dup(&*dict) };
+        let mut cloned_dict = unsafe { cairo_native__dict_dup(dict) };
         unsafe { cairo_native__dict_drop(dict) };
 
         assert_eq!(
-            unsafe { cairo_native__dict_get(cloned_dict, &key, (&raw mut ptr).cast()) },
+            unsafe { cairo_native__dict_get(&mut cloned_dict, &key, (&raw mut ptr).cast()) },
             1,
         );
         assert!(!ptr.is_null());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -303,11 +303,11 @@ pub unsafe extern "C" fn cairo_native__dict_dup(dict_ptr: *const FeltDict) -> *c
 /// This function is intended to be called from MLIR, deals with pointers, and is therefore
 /// definitely unsafe to use manually.
 pub unsafe extern "C" fn cairo_native__dict_get(
-    dict: *const FeltDict,
+    dict_ptr: *mut *const FeltDict,
     key: &[u8; 32],
     value_ptr: *mut *mut c_void,
 ) -> c_int {
-    let mut dict_rc = Rc::from_raw(dict);
+    let mut dict_rc = Rc::from_raw(dict_ptr.read());
     let dict = Rc::make_mut(&mut dict_rc);
 
     let num_mappings = dict.mappings.len();
@@ -340,7 +340,7 @@ pub unsafe extern "C" fn cairo_native__dict_get(
         .cast();
 
     dict.count += 1;
-    forget(dict_rc);
+    dict_ptr.write(Rc::into_raw(dict_rc));
 
     is_present as c_int
 }


### PR DESCRIPTION
There was a bug in the dictionaries that caused the cloned pointer (when it had to be cloned) to not be updated, ending up with accesses to dangling pointers. This PR fixes that bug.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
