### PR TITLE
Remove dictionary CoW mechanism

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -30,13 +30,7 @@ pub trait AbiArgument {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<()>;
 }
 
@@ -74,18 +68,16 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<()> {
         match (self.value, self.info) {
             (value, CoreTypeConcrete::Box(info)) => {
-                let ptr =
-                    value.to_ptr(self.arena, self.registry, self.type_id, find_dict_overrides)?;
+                let ptr = value.to_ptr(
+                    self.arena,
+                    self.registry,
+                    self.type_id,
+                    find_dict_drop_override,
+                )?;
 
                 let layout = self.registry.get_type(&info.ty)?.layout(self.registry)?;
                 let heap_ptr = unsafe {
@@ -94,17 +86,17 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     heap_ptr
                 };
 
-                heap_ptr.to_bytes(buffer, find_dict_overrides)?;
+                heap_ptr.to_bytes(buffer, find_dict_drop_override)?;
             }
             (value, CoreTypeConcrete::Nullable(info)) => {
                 if matches!(value, Value::Null) {
-                    null::<()>().to_bytes(buffer, find_dict_overrides)?;
+                    null::<()>().to_bytes(buffer, find_dict_drop_override)?;
                 } else {
                     let ptr = value.to_ptr(
                         self.arena,
                         self.registry,
                         self.type_id,
-                        find_dict_overrides,
+                        find_dict_drop_override,
                     )?;
 
                     let layout = self.registry.get_type(&info.ty)?.layout(self.registry)?;
@@ -114,12 +106,12 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                         heap_ptr
                     };
 
-                    heap_ptr.to_bytes(buffer, find_dict_overrides)?;
+                    heap_ptr.to_bytes(buffer, find_dict_drop_override)?;
                 }
             }
             (value, CoreTypeConcrete::NonZero(info) | CoreTypeConcrete::Snapshot(info)) => self
                 .map(value, &info.ty)?
-                .to_bytes(buffer, find_dict_overrides)?,
+                .to_bytes(buffer, find_dict_drop_override)?,
 
             (Value::Array(_), CoreTypeConcrete::Array(_)) => {
                 // TODO: Assert that `info.ty` matches all the values' types.
@@ -128,30 +120,30 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     self.arena,
                     self.registry,
                     self.type_id,
-                    find_dict_overrides,
+                    find_dict_drop_override,
                 )?;
                 let abi = unsafe { abi_ptr.cast::<ArrayAbi<()>>().as_ref() };
 
-                abi.ptr.to_bytes(buffer, find_dict_overrides)?;
-                abi.since.to_bytes(buffer, find_dict_overrides)?;
-                abi.until.to_bytes(buffer, find_dict_overrides)?;
-                abi.capacity.to_bytes(buffer, find_dict_overrides)?;
+                abi.ptr.to_bytes(buffer, find_dict_drop_override)?;
+                abi.since.to_bytes(buffer, find_dict_drop_override)?;
+                abi.until.to_bytes(buffer, find_dict_drop_override)?;
+                abi.capacity.to_bytes(buffer, find_dict_drop_override)?;
             }
             (Value::BoundedInt { .. }, CoreTypeConcrete::BoundedInt(_)) => {
                 native_panic!("todo: implement AbiArgument for Value::BoundedInt case")
             }
             (Value::Bytes31(value), CoreTypeConcrete::Bytes31(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::EcPoint(x, y), CoreTypeConcrete::EcPoint(_)) => {
-                x.to_bytes(buffer, find_dict_overrides)?;
-                y.to_bytes(buffer, find_dict_overrides)?;
+                x.to_bytes(buffer, find_dict_drop_override)?;
+                y.to_bytes(buffer, find_dict_drop_override)?;
             }
             (Value::EcState(x, y, x0, y0), CoreTypeConcrete::EcState(_)) => {
-                x.to_bytes(buffer, find_dict_overrides)?;
-                y.to_bytes(buffer, find_dict_overrides)?;
-                x0.to_bytes(buffer, find_dict_overrides)?;
-                y0.to_bytes(buffer, find_dict_overrides)?;
+                x.to_bytes(buffer, find_dict_drop_override)?;
+                y.to_bytes(buffer, find_dict_drop_override)?;
+                x0.to_bytes(buffer, find_dict_drop_override)?;
+                y0.to_bytes(buffer, find_dict_drop_override)?;
             }
             (Value::Enum { tag, value, .. }, CoreTypeConcrete::Enum(info)) => {
                 if self.info.is_memory_allocated(self.registry)? {
@@ -159,19 +151,19 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                         self.arena,
                         self.registry,
                         self.type_id,
-                        find_dict_overrides,
+                        find_dict_drop_override,
                     )?;
 
                     let abi_ptr = unsafe { *abi_ptr.cast::<NonNull<()>>().as_ref() };
-                    abi_ptr.as_ptr().to_bytes(buffer, find_dict_overrides)?;
+                    abi_ptr.as_ptr().to_bytes(buffer, find_dict_drop_override)?;
                 } else {
                     match (info.variants.len().next_power_of_two().trailing_zeros() + 7) / 8 {
                         0 => {}
-                        _ => (*tag as u64).to_bytes(buffer, find_dict_overrides)?,
+                        _ => (*tag as u64).to_bytes(buffer, find_dict_drop_override)?,
                     }
 
                     self.map(value, &info.variants[*tag])?
-                        .to_bytes(buffer, find_dict_overrides)?;
+                        .to_bytes(buffer, find_dict_drop_override)?;
                 }
             }
             (
@@ -183,14 +175,19 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     | StarkNetTypeConcrete::StorageAddress(_)
                     | StarkNetTypeConcrete::StorageBaseAddress(_),
                 ),
-            ) => value.to_bytes(buffer, find_dict_overrides)?,
+            ) => value.to_bytes(buffer, find_dict_drop_override)?,
             (Value::Felt252Dict { .. }, CoreTypeConcrete::Felt252Dict(_)) => {
                 // TODO: Assert that `info.ty` matches all the values' types.
 
                 self.value
-                    .to_ptr(self.arena, self.registry, self.type_id, find_dict_overrides)?
+                    .to_ptr(
+                        self.arena,
+                        self.registry,
+                        self.type_id,
+                        find_dict_drop_override,
+                    )?
                     .as_ptr()
-                    .to_bytes(buffer, find_dict_overrides)?
+                    .to_bytes(buffer, find_dict_drop_override)?
             }
             (
                 Value::Secp256K1Point(Secp256k1Point { x, y, is_infinity }),
@@ -204,46 +201,46 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     Secp256PointTypeConcrete::R1(_),
                 )),
             ) => {
-                x.to_bytes(buffer, find_dict_overrides)?;
-                y.to_bytes(buffer, find_dict_overrides)?;
-                is_infinity.to_bytes(buffer, find_dict_overrides)?;
+                x.to_bytes(buffer, find_dict_drop_override)?;
+                y.to_bytes(buffer, find_dict_drop_override)?;
+                is_infinity.to_bytes(buffer, find_dict_drop_override)?;
             }
             (Value::Sint128(value), CoreTypeConcrete::Sint128(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Sint16(value), CoreTypeConcrete::Sint16(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Sint32(value), CoreTypeConcrete::Sint32(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Sint64(value), CoreTypeConcrete::Sint64(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Sint8(value), CoreTypeConcrete::Sint8(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Struct { fields, .. }, CoreTypeConcrete::Struct(info)) => {
                 fields
                     .iter()
                     .zip(&info.members)
                     .map(|(value, type_id)| self.map(value, type_id))
-                    .try_for_each(|wrapper| wrapper?.to_bytes(buffer, find_dict_overrides))?;
+                    .try_for_each(|wrapper| wrapper?.to_bytes(buffer, find_dict_drop_override))?;
             }
             (Value::Uint128(value), CoreTypeConcrete::Uint128(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Uint16(value), CoreTypeConcrete::Uint16(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Uint32(value), CoreTypeConcrete::Uint32(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Uint64(value), CoreTypeConcrete::Uint64(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             (Value::Uint8(value), CoreTypeConcrete::Uint8(_)) => {
-                value.to_bytes(buffer, find_dict_overrides)?
+                value.to_bytes(buffer, find_dict_drop_override)?
             }
             _ => native_panic!(
                 "todo: abi argument unimplemented for ({:?}, {:?})",

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -24,13 +24,7 @@ impl AbiArgument for bool {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -46,13 +40,7 @@ impl AbiArgument for u8 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -68,13 +56,7 @@ impl AbiArgument for i8 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -90,13 +72,7 @@ impl AbiArgument for u16 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -112,13 +88,7 @@ impl AbiArgument for i16 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -134,13 +104,7 @@ impl AbiArgument for u32 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -156,13 +120,7 @@ impl AbiArgument for i32 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() < 64 {
             buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
@@ -178,13 +136,7 @@ impl AbiArgument for u64 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 64 {
             align_to(buffer, get_integer_layout(64).align());
@@ -198,13 +150,7 @@ impl AbiArgument for i64 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 64 {
             align_to(buffer, get_integer_layout(64).align());
@@ -218,13 +164,7 @@ impl AbiArgument for u128 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 56 {
             align_to(buffer, get_integer_layout(128).align());
@@ -238,13 +178,7 @@ impl AbiArgument for i128 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 56 {
             align_to(buffer, get_integer_layout(128).align());
@@ -258,13 +192,7 @@ impl AbiArgument for Felt {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 56 {
             align_to(buffer, get_integer_layout(252).align());
@@ -278,16 +206,10 @@ impl AbiArgument for U256 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        self.lo.to_bytes(buffer, find_dict_overrides)?;
-        self.hi.to_bytes(buffer, find_dict_overrides)
+        self.lo.to_bytes(buffer, find_dict_drop_override)?;
+        self.hi.to_bytes(buffer, find_dict_drop_override)
     }
 }
 
@@ -295,13 +217,7 @@ impl AbiArgument for [u8; 31] {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         // The `bytes31` type is treated as a 248-bit integer, therefore it follows the same
         // splitting rules as them.
@@ -318,15 +234,9 @@ impl<T> AbiArgument for *const T {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_overrides)
+        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_drop_override)
     }
 }
 
@@ -334,15 +244,9 @@ impl<T> AbiArgument for *mut T {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_overrides)
+        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_drop_override)
     }
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -24,13 +24,7 @@ impl AbiArgument for bool {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -41,13 +35,7 @@ impl AbiArgument for u8 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -58,13 +46,7 @@ impl AbiArgument for i8 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -75,13 +57,7 @@ impl AbiArgument for u16 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -92,13 +68,7 @@ impl AbiArgument for i16 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -109,13 +79,7 @@ impl AbiArgument for u32 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -126,13 +90,7 @@ impl AbiArgument for i32 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&(*self as u64).to_ne_bytes());
         Ok(())
@@ -143,13 +101,7 @@ impl AbiArgument for u64 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&self.to_ne_bytes());
         Ok(())
@@ -160,13 +112,7 @@ impl AbiArgument for i64 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         buffer.extend_from_slice(&self.to_ne_bytes());
         Ok(())
@@ -177,13 +123,7 @@ impl AbiArgument for u128 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 40 {
             align_to(buffer, get_integer_layout(128).align());
@@ -198,13 +138,7 @@ impl AbiArgument for i128 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 40 {
             align_to(buffer, get_integer_layout(128).align());
@@ -219,13 +153,7 @@ impl AbiArgument for Felt {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         if buffer.len() >= 40 {
             align_to(buffer, get_integer_layout(252).align());
@@ -240,16 +168,10 @@ impl AbiArgument for U256 {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        self.lo.to_bytes(buffer, find_dict_overrides)?;
-        self.hi.to_bytes(buffer, find_dict_overrides)
+        self.lo.to_bytes(buffer, find_dict_drop_override)?;
+        self.hi.to_bytes(buffer, find_dict_drop_override)
     }
 }
 
@@ -257,13 +179,7 @@ impl AbiArgument for [u8; 31] {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        _find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        _find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
         // The `bytes31` type is treated as a 248-bit integer, therefore it follows the same
         // splitting rules as them.
@@ -282,15 +198,9 @@ impl<T> AbiArgument for *const T {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_overrides)
+        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_drop_override)
     }
 }
 
@@ -298,15 +208,9 @@ impl<T> AbiArgument for *mut T {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<(), Error> {
-        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_overrides)
+        <u64 as AbiArgument>::to_bytes(&(*self as u64), buffer, find_dict_drop_override)
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -72,13 +72,7 @@ fn invoke_dynamic(
     args: &[Value],
     gas: u64,
     mut syscall_handler: Option<impl StarknetSyscallHandler>,
-    find_dict_overrides: impl Copy
-        + Fn(
-            &ConcreteTypeId,
-        ) -> (
-            Option<extern "C" fn(*mut c_void, *mut c_void)>,
-            Option<extern "C" fn(*mut c_void)>,
-        ),
+    find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
 ) -> Result<ExecutionResult, Error> {
     tracing::info!("Invoking function with signature: {function_signature:?}.");
     let arena = Bump::new();
@@ -192,7 +186,7 @@ fn invoke_dynamic(
                 arena: &arena,
                 registry,
             }
-            .to_bytes(&mut invoke_data, find_dict_overrides)?,
+            .to_bytes(&mut invoke_data, find_dict_drop_override)?,
         }
     }
 

--- a/src/metadata/felt252_dict.rs
+++ b/src/metadata/felt252_dict.rs
@@ -1,4 +1,4 @@
-use super::{drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta, MetadataStorage};
+use super::{drop_overrides::DropOverridesMeta, MetadataStorage};
 use crate::{
     error::{Error, Result},
     utils::{BlockExt, ProgramRegistryExt},
@@ -20,86 +20,12 @@ use std::collections::{hash_map::Entry, HashMap};
 
 #[derive(Clone, Debug, Default)]
 pub struct Felt252DictOverrides {
-    dup_overrides: HashMap<ConcreteTypeId, String>,
     drop_overrides: HashMap<ConcreteTypeId, String>,
 }
 
 impl Felt252DictOverrides {
-    pub fn get_dup_fn(&self, type_id: &ConcreteTypeId) -> Option<&str> {
-        self.dup_overrides.get(type_id).map(String::as_str)
-    }
-
     pub fn get_drop_fn(&self, type_id: &ConcreteTypeId) -> Option<&str> {
         self.drop_overrides.get(type_id).map(String::as_str)
-    }
-
-    pub fn build_dup_fn<'ctx>(
-        &mut self,
-        context: &'ctx Context,
-        module: &Module<'ctx>,
-        registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-        metadata: &mut MetadataStorage,
-        type_id: &ConcreteTypeId,
-    ) -> Result<Option<FlatSymbolRefAttribute<'ctx>>> {
-        let location = Location::unknown(context);
-
-        let inner_ty = registry.build_type(context, module, metadata, type_id)?;
-        Ok(match metadata.get::<DupOverridesMeta>() {
-            Some(dup_overrides_meta) if dup_overrides_meta.is_overriden(type_id) => {
-                let dup_fn_symbol = format!("dup${}$item", type_id.id);
-                let flat_symbol_ref = FlatSymbolRefAttribute::new(context, &dup_fn_symbol);
-
-                if let Entry::Vacant(entry) = self.dup_overrides.entry(type_id.clone()) {
-                    let dup_fn_symbol = entry.insert(dup_fn_symbol);
-
-                    let region = Region::new();
-                    let entry = region.append_block(Block::new(&[
-                        (llvm::r#type::pointer(context, 0), location),
-                        (llvm::r#type::pointer(context, 0), location),
-                    ]));
-
-                    let source_ptr = entry.arg(0)?;
-                    let target_ptr = entry.arg(1)?;
-
-                    let value = entry.load(context, location, source_ptr, inner_ty)?;
-                    let values = dup_overrides_meta
-                        .invoke_override(context, &entry, location, type_id, value)?;
-                    entry.store(context, location, source_ptr, values.0)?;
-                    entry.store(context, location, target_ptr, values.1)?;
-
-                    entry.append_operation(llvm::r#return(None, location));
-
-                    module.body().append_operation(llvm::func(
-                        context,
-                        StringAttribute::new(context, dup_fn_symbol),
-                        TypeAttribute::new(llvm::r#type::function(
-                            llvm::r#type::void(context),
-                            &[
-                                llvm::r#type::pointer(context, 0),
-                                llvm::r#type::pointer(context, 0),
-                            ],
-                            false,
-                        )),
-                        region,
-                        &[
-                            (
-                                Identifier::new(context, "sym_visibility"),
-                                StringAttribute::new(context, "public").into(),
-                            ),
-                            (
-                                Identifier::new(context, "linkage"),
-                                Attribute::parse(context, "#llvm.linkage<private>")
-                                    .ok_or(Error::ParseAttributeError)?,
-                            ),
-                        ],
-                        location,
-                    ));
-                }
-
-                Some(flat_symbol_ref)
-            }
-            _ => None,
-        })
     }
 
     pub fn build_drop_fn<'ctx>(

--- a/src/metadata/runtime_bindings.rs
+++ b/src/metadata/runtime_bindings.rs
@@ -437,7 +437,6 @@ impl RuntimeBindingsMeta {
         module: &Module,
         block: &'a Block<'c>,
         location: Location<'c>,
-        dup_fn: Option<Value<'c, 'a>>,
         drop_fn: Option<Value<'c, 'a>>,
         layout: Layout,
     ) -> Result<Value<'c, 'a>>
@@ -451,12 +450,6 @@ impl RuntimeBindingsMeta {
         let size = block.const_int_from_type(context, location, layout.size(), i64_ty)?;
         let align = block.const_int_from_type(context, location, layout.align(), i64_ty)?;
 
-        let dup_fn = match dup_fn {
-            Some(x) => x,
-            None => {
-                block.append_op_result(llvm::zero(llvm::r#type::pointer(context, 0), location))?
-            }
-        };
         let drop_fn = match drop_fn {
             Some(x) => x,
             None => {
@@ -467,7 +460,7 @@ impl RuntimeBindingsMeta {
         block.append_op_result(
             OperationBuilder::new("llvm.call", location)
                 .add_operands(&[function])
-                .add_operands(&[size, align, dup_fn, drop_fn])
+                .add_operands(&[size, align, drop_fn])
                 .add_results(&[llvm::r#type::pointer(context, 0)])
                 .build()?,
         )

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -150,7 +150,6 @@ pub struct FeltDict {
     pub layout: Layout,
     pub elements: *mut (),
 
-    pub dup_fn: Option<extern "C" fn(*mut c_void, *mut c_void)>,
     pub drop_fn: Option<extern "C" fn(*mut c_void)>,
 
     pub count: u64,
@@ -194,7 +193,6 @@ impl Drop for FeltDict {
 pub unsafe extern "C" fn cairo_native__dict_new(
     size: u64,
     align: u64,
-    dup_fn: Option<extern "C" fn(*mut c_void, *mut c_void)>,
     drop_fn: Option<extern "C" fn(*mut c_void)>,
 ) -> *const FeltDict {
     Rc::into_raw(Rc::new(FeltDict {
@@ -203,7 +201,6 @@ pub unsafe extern "C" fn cairo_native__dict_new(
         layout: Layout::from_size_align_unchecked(size as usize, align as usize),
         elements: ptr::null_mut(),
 
-        dup_fn,
         drop_fn,
 
         count: 0,
@@ -815,12 +812,7 @@ mod tests {
     #[test]
     fn test_dict() {
         let mut dict = unsafe {
-            cairo_native__dict_new(
-                size_of::<u64>() as u64,
-                align_of::<u64>() as u64,
-                None,
-                None,
-            )
+            cairo_native__dict_new(size_of::<u64>() as u64, align_of::<u64>() as u64, None)
         };
 
         let key = Felt::ONE.to_bytes_le();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -250,6 +250,10 @@ pub unsafe extern "C" fn cairo_native__dict_get(
     value_ptr: *mut *mut c_void,
 ) -> c_int {
     let dict_rc = Rc::from_raw(dict_ptr.read());
+
+    // there may me multiple reference to the same dictionary (snapshots), but
+    // as snapshots cannot access the inner dictionary, then it is safe to modify it
+    // without cloning it.
     let dict = Rc::as_ptr(&dict_rc)
         .cast_mut()
         .as_mut()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,8 +307,11 @@ pub unsafe extern "C" fn cairo_native__dict_get(
     key: &[u8; 32],
     value_ptr: *mut *mut c_void,
 ) -> c_int {
-    let mut dict_rc = Rc::from_raw(dict_ptr.read());
-    let dict = Rc::make_mut(&mut dict_rc);
+    let dict_rc = Rc::from_raw(dict_ptr.read());
+    let dict = Rc::as_ptr(&dict_rc)
+        .cast_mut()
+        .as_mut()
+        .expect("rc inner pointer should never be null");
 
     let num_mappings = dict.mappings.len();
     let has_capacity = num_mappings != dict.mappings.capacity();

--- a/src/types/felt252_dict.rs
+++ b/src/types/felt252_dict.rs
@@ -85,14 +85,6 @@ fn build_dup<'ctx>(
 
     let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
 
-    {
-        let mut dict_overrides = metadata
-            .remove::<Felt252DictOverrides>()
-            .unwrap_or_default();
-        dict_overrides.build_dup_fn(context, module, registry, metadata, &info.ty)?;
-        metadata.insert(dict_overrides);
-    }
-
     let region = Region::new();
     let entry = region.append_block(Block::new(&[(value_ty, location)]));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,21 +87,18 @@ impl crate::arch::AbiArgument for BuiltinCosts {
     fn to_bytes(
         &self,
         buffer: &mut Vec<u8>,
-        find_dict_overrides: impl Copy
+        find_dict_drop_override: impl Copy
             + Fn(
                 &cairo_lang_sierra::ids::ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void)>,
-                Option<extern "C" fn(*mut std::ffi::c_void)>,
-            ),
+            ) -> Option<extern "C" fn(*mut std::ffi::c_void)>,
     ) -> crate::error::Result<()> {
-        self.r#const.to_bytes(buffer, find_dict_overrides)?;
-        self.pedersen.to_bytes(buffer, find_dict_overrides)?;
-        self.bitwise.to_bytes(buffer, find_dict_overrides)?;
-        self.ecop.to_bytes(buffer, find_dict_overrides)?;
-        self.poseidon.to_bytes(buffer, find_dict_overrides)?;
-        self.add_mod.to_bytes(buffer, find_dict_overrides)?;
-        self.mul_mod.to_bytes(buffer, find_dict_overrides)?;
+        self.r#const.to_bytes(buffer, find_dict_drop_override)?;
+        self.pedersen.to_bytes(buffer, find_dict_drop_override)?;
+        self.bitwise.to_bytes(buffer, find_dict_drop_override)?;
+        self.ecop.to_bytes(buffer, find_dict_drop_override)?;
+        self.poseidon.to_bytes(buffer, find_dict_drop_override)?;
+        self.add_mod.to_bytes(buffer, find_dict_drop_override)?;
+        self.mul_mod.to_bytes(buffer, find_dict_drop_override)?;
 
         Ok(())
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -165,13 +165,7 @@ impl Value {
         arena: &Bump,
         registry: &ProgramRegistry<CoreType, CoreLibfunc>,
         type_id: &ConcreteTypeId,
-        find_dict_overrides: impl Copy
-            + Fn(
-                &ConcreteTypeId,
-            ) -> (
-                Option<extern "C" fn(*mut c_void, *mut c_void)>,
-                Option<extern "C" fn(*mut c_void)>,
-            ),
+        find_dict_drop_override: impl Copy + Fn(&ConcreteTypeId) -> Option<extern "C" fn(*mut c_void)>,
     ) -> Result<NonNull<()>, Error> {
         let ty = registry.get_type(type_id)?;
 
@@ -247,7 +241,7 @@ impl Value {
                         // Write the data.
                         for (idx, elem) in data.iter().enumerate() {
                             let elem =
-                                elem.to_ptr(arena, registry, &info.ty, find_dict_overrides)?;
+                                elem.to_ptr(arena, registry, &info.ty, find_dict_drop_override)?;
 
                             std::ptr::copy_nonoverlapping(
                                 elem.cast::<u8>().as_ptr(),
@@ -319,7 +313,7 @@ impl Value {
                                 arena,
                                 registry,
                                 member_type_id,
-                                find_dict_overrides,
+                                find_dict_drop_override,
                             )?;
                             data.push((
                                 member_layout,
@@ -366,8 +360,12 @@ impl Value {
                         native_assert!(*tag < info.variants.len(), "Variant index out of range.");
 
                         let payload_type_id = &info.variants[*tag];
-                        let payload =
-                            value.to_ptr(arena, registry, payload_type_id, find_dict_overrides)?;
+                        let payload = value.to_ptr(
+                            arena,
+                            registry,
+                            payload_type_id,
+                            find_dict_drop_override,
+                        )?;
 
                         let (layout, tag_layout, variant_layouts) =
                             crate::types::r#enum::get_layout_for_variants(
@@ -406,10 +404,10 @@ impl Value {
                         let elem_ty = registry.get_type(&info.ty)?;
                         let elem_layout = elem_ty.layout(registry)?.pad_to_align();
 
-                        // We need `find_dict_overrides` to obtain the function pointers of the dup and drop
-                        // implementations (if any) for the value type. This is required to be able to clone and drop
+                        // We need `find_dict_drop_override` to obtain the function pointers of drop
+                        // implementations (if any) for the value type. This is required to be able to drop
                         // the dictionary automatically when their reference count drops to zero.
-                        let (dup_fn, drop_fn) = find_dict_overrides(&info.ty);
+                        let drop_fn = find_dict_drop_override(&info.ty);
                         let mut value_map = FeltDict {
                             mappings: HashMap::with_capacity(map.len()),
 
@@ -424,7 +422,6 @@ impl Value {
                                 .cast()
                             },
 
-                            dup_fn,
                             drop_fn,
 
                             count: 0,
@@ -435,7 +432,7 @@ impl Value {
                         for (key, value) in map.iter() {
                             let key = key.to_bytes_le();
                             let value =
-                                value.to_ptr(arena, registry, &info.ty, find_dict_overrides)?;
+                                value.to_ptr(arena, registry, &info.ty, find_dict_drop_override)?;
 
                             let index = value_map.mappings.len();
                             value_map.mappings.insert(key, index);
@@ -558,11 +555,11 @@ impl Value {
                         let inner = registry.get_type(&info.ty)?;
                         let inner_layout = inner.layout(registry)?;
 
-                        let x_ptr = x.to_ptr(arena, registry, &info.ty, find_dict_overrides)?;
+                        let x_ptr = x.to_ptr(arena, registry, &info.ty, find_dict_drop_override)?;
 
                         let (struct_layout, y_offset) = inner_layout.extend(inner_layout)?;
 
-                        let y_ptr = y.to_ptr(arena, registry, &info.ty, find_dict_overrides)?;
+                        let y_ptr = y.to_ptr(arena, registry, &info.ty, find_dict_drop_override)?;
 
                         let ptr = arena.alloc_layout(struct_layout.pad_to_align()).as_ptr();
 


### PR DESCRIPTION
Depends on #1132

We found that dictionaries where unnecessarily cloned when modifying dictionaries that had snapshots. This could be avoided as dictionary snapshots are useless and thus do not need its internal representation to be inmutable.

The following code would waste a lot of memory:
```cairo
use core::dict::Felt252Dict;

fn main() {
    let mut dict: Felt252Dict<u64> = Default::default();

    for number in 0..100_u64 {
        let snapshot = @dict;

        let key = number.try_into().unwrap();
        dict.insert(key, number);

        drop(snapshot)
    }
}
```

The easiest way to implement this is by removing the clone mechanism, but keep the reference counter.

## Summary

- Remove the CoW mechanism: [d4c1aed](https://github.com/lambdaclass/cairo_native/commit/d4c1aed607accdc69a5dd7720a6001c84175ebbd) - this is the only commit required to fix the unnecessary clones, the following commits remove now unused code.
- Remove the dict Clone implementation: [d779e90](https://github.com/lambdaclass/cairo_native/pull/1130/commits/d779e90941248d343d63a3e38b3e121944a4f0ed)
- Remove dup_fn field from dict: [e924424](https://github.com/lambdaclass/cairo_native/pull/1130/commits/e9244244be097a9967bc336d4d2eae928f744157) - this includes modifying the dict_overrides_closure to only return the drop function pointer, as the dup function pointer is no longer used.
- Adapt compiler to new signature: [f7d11aa](https://github.com/lambdaclass/cairo_native/pull/1130/commits/f7d11aa95b52114ad2a69cf7deb9e7a393965dd2)
- Remove dup_fn field from Felt252DictOverrides: [d168591](https://github.com/lambdaclass/cairo_native/pull/1130/commits/d168591549980f1fb9c66aa0d611a1cb31a001c2)

## Next Steps

As the function `cairo_native__dict_get` no longer clones the dictionary, then there is no need to receive a double pointer to the dictionary (we don't need to modify the pointer). We could revert back the changes at: https://github.com/lambdaclass/cairo_native/pull/1121

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
