### PR TITLE
Fix dictionary clone implementation

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -159,15 +159,15 @@ pub struct FeltDict {
 impl Clone for FeltDict {
     fn clone(&self) -> Self {
         let mut new_dict = FeltDict {
-            mappings: HashMap::with_capacity(self.mappings.len()),
+            mappings: HashMap::with_capacity(self.mappings.capacity()),
 
             layout: self.layout,
-            elements: if self.mappings.is_empty() {
+            elements: if self.mappings.capacity() == 0 {
                 ptr::null_mut()
             } else {
                 unsafe {
                     alloc(Layout::from_size_align_unchecked(
-                        self.layout.pad_to_align().size() * self.mappings.len(),
+                        self.layout.pad_to_align().size() * self.mappings.capacity(),
                         self.layout.align(),
                     ))
                     .cast()

--- a/tests/tests/dict.rs
+++ b/tests/tests/dict.rs
@@ -19,6 +19,22 @@ lazy_static! {
             dict.get(key)
         }
     };
+    static ref SNAPSHOT_LOOP: (String, Program, SierraCasmRunner) = load_cairo! {
+        use core::dict::Felt252Dict;
+
+        fn run_test() {
+            let mut dict: Felt252Dict<u64> = Default::default();
+
+            for number in 0..50_u64 {
+                let snapshot = @dict;
+
+                let key = number.try_into().unwrap();
+                dict.insert(key, number);
+
+                drop(snapshot)
+            }
+        }
+    };
 }
 
 proptest! {
@@ -47,4 +63,16 @@ proptest! {
             &result_native,
         )?;
     }
+}
+
+#[test]
+fn dict_snapshot_loop() {
+    let program = &SNAPSHOT_LOOP;
+    run_native_program(
+        program,
+        "run_test",
+        &[],
+        Some(DEFAULT_GAS),
+        Option::<DummySyscallHandler>::None,
+    );
 }


### PR DESCRIPTION
The following program was failing because we were creating the allocating data for the dictionary using the original dictionary's length, rather that it's capacity.

```cairo
use core::dict::Felt252Dict;

fn main() {
    let mut dict: Felt252Dict<u64> = Default::default();

    for number in 0..50_u64 {
        let snapshot = @dict;

        let key = number.try_into().unwrap();
        dict.insert(key, number);

        drop(snapshot)
    }
}
```

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
