### PR TITLE
[2.11.1] Implement blake libfunc

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -33,6 +33,7 @@ use num_bigint::BigInt;
 use std::{cell::Cell, error::Error, ops::Deref};
 
 mod array;
+mod blake;
 mod r#bool;
 mod bounded_int;
 mod r#box;
@@ -179,7 +180,9 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
             Self::IntRange(selector) => self::int_range::build(
                 context, registry, entry, location, helper, metadata, selector,
             ),
-            Self::Blake(_) => native_panic!("Implement blake libfunc"),
+            Self::Blake(selector) => self::blake::build(
+                context, registry, entry, location, helper, metadata, selector,
+            ),
             Self::Mem(selector) => self::mem::build(
                 context, registry, entry, location, helper, metadata, selector,
             ),

--- a/src/libfuncs/blake.rs
+++ b/src/libfuncs/blake.rs
@@ -1,0 +1,120 @@
+use cairo_lang_sierra::{
+    extensions::{
+        blake::BlakeConcreteLibfunc,
+        core::{CoreLibfunc, CoreType},
+        lib_func::SignatureOnlyConcreteLibfunc,
+    },
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    ir::{Block, BlockLike, Location},
+    Context,
+};
+
+use crate::{
+    error::{panic::ToNativeAssertError, Result},
+    metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
+    utils::BlockExt,
+};
+
+use super::LibfuncHelper;
+
+pub fn build<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    selector: &BlakeConcreteLibfunc,
+) -> Result<()> {
+    match selector {
+        BlakeConcreteLibfunc::Blake2sCompress(info) => build_blake_operation(
+            context, registry, entry, location, helper, metadata, info, false,
+        ),
+        BlakeConcreteLibfunc::Blake2sFinalize(info) => build_blake_operation(
+            context, registry, entry, location, helper, metadata, info, true,
+        ),
+    }
+}
+
+/// Performs a blake2s compression.
+///
+/// `bytes_count` is the total amount of bytes hashed after hashing the message.
+/// `finalize` is wether the libfunc call is a finalize or not.
+#[allow(clippy::too_many_arguments)]
+fn build_blake_operation<'ctx, 'this>(
+    context: &'ctx Context,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    _info: &SignatureOnlyConcreteLibfunc,
+    finalize: bool,
+) -> Result<()> {
+    let state_ptr = entry.arg(0)?;
+    let bytes_count = entry.arg(1)?;
+    let message = entry.arg(2)?;
+    let k_finalize = entry.const_int(context, location, finalize, 1)?;
+
+    let runtime_bindings = metadata
+        .get_mut::<RuntimeBindingsMeta>()
+        .to_native_assert_error("runtime library should be available")?;
+
+    runtime_bindings.libfunc_blake_compress(
+        context,
+        helper,
+        entry,
+        state_ptr,
+        message,
+        bytes_count,
+        k_finalize,
+        location,
+    )?;
+
+    entry.append_operation(helper.br(0, &[state_ptr], location));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        utils::test::{jit_struct, load_cairo, run_program},
+        Value,
+    };
+
+    #[test]
+    fn test_blake() {
+        let program = load_cairo!(
+            use core::blake::{blake2s_compress, blake2s_finalize};
+
+            fn run_test() -> [u32; 8] nopanic {
+                let state = BoxTrait::new([0_u32; 8]);
+                let msg = BoxTrait::new([0_u32; 16]);
+                let byte_count = 64_u32;
+
+                let _res = blake2s_compress(state, byte_count, msg).unbox();
+
+                blake2s_finalize(state, byte_count, msg).unbox()
+            }
+        );
+
+        let result = run_program(&program, "run_test", &[]).return_value;
+
+        assert_eq!(
+            result,
+            jit_struct!(
+                Value::Uint32(128291589),
+                Value::Uint32(1454945417),
+                Value::Uint32(3191583614),
+                Value::Uint32(1491889056),
+                Value::Uint32(794023379),
+                Value::Uint32(651000200),
+                Value::Uint32(3725903680),
+                Value::Uint32(1044330286),
+            )
+        );
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::utils::BuiltinCosts;
+use crate::utils::{blake_utils, BuiltinCosts};
 use cairo_lang_sierra_gas::core_libfunc_cost::{
     DICT_SQUASH_REPEATED_ACCESS_COST, DICT_SQUASH_UNIQUE_KEY_COST,
 };
@@ -140,6 +140,24 @@ pub unsafe extern "C" fn cairo_native__libfunc__hades_permutation(
     *op0 = state[0].to_bytes_le();
     *op1 = state[1].to_bytes_le();
     *op2 = state[2].to_bytes_le();
+}
+
+pub unsafe extern "C" fn cairo_native_libfunc_blake_compress(
+    state: &mut [u32; 8],
+    message: &[u32; 16],
+    count_bytes: u32,
+    finalize: bool,
+) {
+    let new_state = blake_utils::blake2s_compress(
+        state,
+        message,
+        count_bytes,
+        0,
+        if finalize { 0xFFFFFFFF } else { 0 },
+        0,
+    );
+
+    *state = new_state;
 }
 
 /// Felt252 type used in cairo native runtime

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,6 +31,7 @@ use std::{alloc::Layout, error::Error, ops::Deref, sync::OnceLock};
 
 pub mod array;
 mod bitwise;
+mod blake;
 mod bounded_int;
 mod r#box;
 mod builtin_costs;
@@ -436,7 +437,13 @@ impl TypeBuilder for CoreTypeConcrete {
                 metadata,
                 WithSelf::new(self_ty, info),
             ),
-            Self::Blake(_) => native_panic!("Build Blake type"),
+            Self::Blake(info) => blake::build(
+                context,
+                module,
+                registry,
+                metadata,
+                WithSelf::new(self_ty, info),
+            ),
         }
     }
 
@@ -543,7 +550,7 @@ impl TypeBuilder for CoreTypeConcrete {
             CoreTypeConcrete::Circuit(info) => circuit::is_complex(info),
 
             CoreTypeConcrete::IntRange(_info) => false,
-            CoreTypeConcrete::Blake(_info) => native_panic!("Implement is_complex for Blake type")
+            CoreTypeConcrete::Blake(_) => false,
         })
     }
 
@@ -628,7 +635,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 let type_info = registry.get_type(&info.ty)?;
                 type_info.is_zst(registry)?
             }
-            CoreTypeConcrete::Blake(_info) => native_panic!("Implement is_zst for Blake type"),
+            CoreTypeConcrete::Blake(_) => false,
         })
     }
 
@@ -739,7 +746,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 let inner = registry.get_type(&info.ty)?.layout(registry)?;
                 inner.extend(inner)?.0
             }
-            CoreTypeConcrete::Blake(_info) => native_panic!("Implement layout for Blake type"),
+            CoreTypeConcrete::Blake(_info) => Layout::new::<*mut ()>(),
         }
         .pad_to_align())
     }
@@ -752,9 +759,7 @@ impl TypeBuilder for CoreTypeConcrete {
         // arguments.
         Ok(match self {
             CoreTypeConcrete::IntRange(_) => false,
-            CoreTypeConcrete::Blake(_info) => {
-                native_panic!("Implement is_memory_allocated for Blake type")
-            }
+            CoreTypeConcrete::Blake(_) => false,
             CoreTypeConcrete::Array(_) => false,
             CoreTypeConcrete::Bitwise(_) => false,
             CoreTypeConcrete::Box(_) => false,

--- a/src/types/blake.rs
+++ b/src/types/blake.rs
@@ -1,0 +1,83 @@
+use cairo_lang_sierra::{
+    extensions::{
+        core::{CoreLibfunc, CoreType},
+        types::InfoOnlyConcreteType,
+    },
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    dialect::{func, llvm, ods},
+    ir::{
+        attribute::IntegerAttribute, r#type::IntegerType, Block, BlockLike, Location, Module,
+        Region, Type,
+    },
+    Context,
+};
+
+use crate::{
+    error::Result,
+    metadata::{
+        drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
+        realloc_bindings::ReallocBindingsMeta, MetadataStorage,
+    },
+    utils::BlockExt,
+};
+
+use super::WithSelf;
+
+/// Build the MLIR type.
+///
+/// Check out [the module](self) for more info.
+pub fn build<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    metadata: &mut MetadataStorage,
+    info: WithSelf<InfoOnlyConcreteType>,
+) -> Result<Type<'ctx>> {
+    let location = Location::unknown(context);
+    if metadata.get::<ReallocBindingsMeta>().is_none() {
+        metadata.insert(ReallocBindingsMeta::new(context, module));
+    }
+
+    DupOverridesMeta::register_with(context, module, registry, metadata, info.self_ty(), |_| {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
+
+        let null_ptr =
+            block.append_op_result(llvm::zero(llvm::r#type::pointer(context, 0), location))?;
+        let k32 = block.const_int(context, location, 32, 64)?;
+        let new_ptr = block.append_op_result(ReallocBindingsMeta::realloc(
+            context, null_ptr, k32, location,
+        )?)?;
+
+        block.append_operation(
+            ods::llvm::intr_memcpy_inline(
+                context,
+                new_ptr,
+                block.arg(0)?,
+                IntegerAttribute::new(IntegerType::new(context, 64).into(), 32),
+                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
+                location,
+            )
+            .into(),
+        );
+
+        block.append_operation(func::r#return(&[block.arg(0)?, new_ptr], location));
+        Ok(Some(region))
+    })?;
+    DropOverridesMeta::register_with(context, module, registry, metadata, info.self_ty(), |_| {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
+
+        block.append_operation(ReallocBindingsMeta::free(context, block.arg(0)?, location)?);
+
+        block.append_operation(func::r#return(&[], location));
+        Ok(Some(region))
+    })?;
+
+    // A ptr to a heap (realloc) allocated [u32; 8]
+    Ok(llvm::r#type::pointer(context, 0))
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,6 +30,7 @@ use std::{
 };
 use thiserror::Error;
 
+pub mod blake_utils;
 mod block_ext;
 pub mod mem_tracing;
 mod program_registry_ext;

--- a/src/utils/blake_utils.rs
+++ b/src/utils/blake_utils.rs
@@ -1,0 +1,134 @@
+// This file is completely inspired in LambdaClass' cairo-vm blake compression implementation
+// For more info check: https://github.com/lambdaclass/cairo-vm/blob/main/vm/src/hint_processor/builtin_hint_processor/blake2s_hash.rs#L24
+
+use std::ops::Shl;
+
+pub const IV: [u32; 8] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+const SIGMA: [[usize; 16]; 10] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+    [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+    [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+    [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+    [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+    [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+    [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+    [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+    [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+];
+
+// Rotate right
+fn right_rot(value: u32, n: u32) -> u32 {
+    (value >> n) | ((value & (1_u32.shl(n) - 1)) << (32 - n))
+}
+
+// Mixes two 8-bytes words from the message with the hash state
+fn mix(a: u32, b: u32, c: u32, d: u32, m0: u32, m1: u32) -> (u32, u32, u32, u32) {
+    let a = a.wrapping_add(b).wrapping_add(m0);
+    let d = right_rot(d ^ a, 16);
+    let c = c.wrapping_add(d);
+    let b = right_rot(b ^ c, 12);
+    let a = a.wrapping_add(b).wrapping_add(m1);
+    let d = right_rot(d ^ a, 8);
+    let c = c.wrapping_add(d);
+    let b = right_rot(b ^ c, 7);
+    (a, b, c, d)
+}
+
+// Performs a round of mixing
+fn blake_round(mut state: Vec<u32>, message: &[u32; 16], sigma: [usize; 16]) -> Vec<u32> {
+    (state[0], state[4], state[8], state[12]) = mix(
+        state[0],
+        state[4],
+        state[8],
+        state[12],
+        message[sigma[0]],
+        message[sigma[1]],
+    );
+    (state[1], state[5], state[9], state[13]) = mix(
+        state[1],
+        state[5],
+        state[9],
+        state[13],
+        message[sigma[2]],
+        message[sigma[3]],
+    );
+    (state[2], state[6], state[10], state[14]) = mix(
+        state[2],
+        state[6],
+        state[10],
+        state[14],
+        message[sigma[4]],
+        message[sigma[5]],
+    );
+    (state[3], state[7], state[11], state[15]) = mix(
+        state[3],
+        state[7],
+        state[11],
+        state[15],
+        message[sigma[6]],
+        message[sigma[7]],
+    );
+    (state[0], state[5], state[10], state[15]) = mix(
+        state[0],
+        state[5],
+        state[10],
+        state[15],
+        message[sigma[8]],
+        message[sigma[9]],
+    );
+    (state[1], state[6], state[11], state[12]) = mix(
+        state[1],
+        state[6],
+        state[11],
+        state[12],
+        message[sigma[10]],
+        message[sigma[11]],
+    );
+    (state[2], state[7], state[8], state[13]) = mix(
+        state[2],
+        state[7],
+        state[8],
+        state[13],
+        message[sigma[12]],
+        message[sigma[13]],
+    );
+    (state[3], state[4], state[9], state[14]) = mix(
+        state[3],
+        state[4],
+        state[9],
+        state[14],
+        message[sigma[14]],
+        message[sigma[15]],
+    );
+    state
+}
+
+pub fn blake2s_compress(
+    h: &[u32; 8],
+    message: &[u32; 16],
+    t0: u32,
+    t1: u32,
+    f0: u32,
+    f1: u32,
+) -> [u32; 8] {
+    let mut state = h.to_vec();
+    state.extend(&IV[0..4]);
+    state.extend(&vec![
+        (IV[4] ^ t0),
+        (IV[5] ^ t1),
+        (IV[6] ^ f0),
+        (IV[7] ^ f1),
+    ]);
+    for sigma_list in SIGMA {
+        state = blake_round(state, message, sigma_list);
+    }
+    let mut new_state = [0; 8];
+    for i in 0..8 {
+        new_state[i] = h[i] ^ state[i] ^ state[8 + i];
+    }
+    new_state
+}


### PR DESCRIPTION
This PR implements both blake related libfuncs

Closes #1148, #1149

```cairo
/// The blake2s compress function, which takes a state, a byte count, and a message, and returns a
/// new state.
/// `byte_count` should be the total number of bytes hashed after hashing the current `msg`.
pub extern fn blake2s_compress(
    state: Blake2sState, byte_count: u32, msg: Blake2sInput,
) -> Blake2sState nopanic;


/// Similar to `blake2s_compress`, but used for the final block of the message.
pub extern fn blake2s_finalize(
    state: Blake2sState, byte_count: u32, msg: Blake2sInput,
) -> Blake2sState nopanic;

```


## Checklist
- [X] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
