### PR TITLE
Implement qm31 libfuncs

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -57,6 +57,7 @@ mod mem;
 mod nullable;
 mod pedersen;
 mod poseidon;
+mod qm31;
 mod starknet;
 mod r#struct;
 mod uint256;
@@ -243,7 +244,9 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
                 metadata,
                 &info.signature.param_signatures,
             ),
-            Self::QM31(_) => native_panic!("Implement QM31 libfunc"),
+            Self::QM31(selector) => self::qm31::build(
+                context, registry, entry, location, helper, metadata, selector,
+            ),
         }
     }
 

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -1,0 +1,126 @@
+use cairo_lang_sierra::{
+    extensions::{
+        core::{CoreLibfunc, CoreType},
+        lib_func::SignatureOnlyConcreteLibfunc,
+        qm31::{QM31BinaryOpConcreteLibfunc, QM31Concrete, QM31ConstConcreteLibfunc},
+    },
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    ir::{Block, Location},
+    Context,
+};
+
+use crate::{error::Result, metadata::MetadataStorage};
+
+use super::LibfuncHelper;
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    selector: &QM31Concrete,
+) -> Result<()> {
+    match selector {
+        QM31Concrete::Pack(info) => {
+            build_qm31_pack(context, registry, entry, location, helper, metadata, info)
+        }
+        QM31Concrete::Unpack(info) => {
+            build_qm31_unpack(context, registry, entry, location, helper, metadata, info)
+        }
+        QM31Concrete::Const(info) => {
+            build_qm31_const(context, registry, entry, location, helper, metadata, info)
+        }
+        QM31Concrete::FromM31(info) => {
+            build_qm31_from_m31(context, registry, entry, location, helper, metadata, info)
+        }
+        QM31Concrete::IsZero(info) => {
+            build_qm31_is_zero(context, registry, entry, location, helper, metadata, info)
+        }
+        QM31Concrete::BinaryOperation(info) => {
+            build_qm31_bin_operation(context, registry, entry, location, helper, metadata, info)
+        }
+    }
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_pack<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_unpack<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_const<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &QM31ConstConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_from_m31<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_is_zero<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &SignatureOnlyConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Select and call the correct libfunc builder function from the selector.
+pub fn build_qm31_bin_operation<'ctx, 'this>(
+    context: &'ctx Context,
+    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    entry: &'this Block<'ctx>,
+    location: Location<'ctx>,
+    helper: &LibfuncHelper<'ctx, 'this>,
+    metadata: &mut MetadataStorage,
+    info: &QM31BinaryOpConcreteLibfunc,
+) -> Result<()> {
+    Ok(())
+}

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -34,7 +34,6 @@ pub fn build<'ctx, 'this>(
         }
         QM31Concrete::Unpack(info) => {
             todo!("impl qm31_unpack");
-
         }
         QM31Concrete::Const(info) => {
             todo!("impl qm31_const");

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -30,100 +30,23 @@ pub fn build<'ctx, 'this>(
 ) -> Result<()> {
     match selector {
         QM31Concrete::Pack(info) => {
-            build_qm31_pack(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_pack");
         }
         QM31Concrete::Unpack(info) => {
-            build_qm31_unpack(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_unpack");
+
         }
         QM31Concrete::Const(info) => {
-            build_qm31_const(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_const");
         }
         QM31Concrete::FromM31(info) => {
-            build_qm31_from_m31(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_from_m31");
         }
         QM31Concrete::IsZero(info) => {
-            build_qm31_is_zero(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_is_zero");
         }
         QM31Concrete::BinaryOperation(info) => {
-            build_qm31_bin_operation(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_binary_operation");
         }
     }
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_pack<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_unpack<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_const<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &QM31ConstConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_from_m31<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_is_zero<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_bin_operation<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &QM31BinaryOpConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
 }

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -15,6 +15,9 @@ use crate::{error::Result, metadata::MetadataStorage};
 
 use super::LibfuncHelper;
 
+const M31_SIZE: u32 = 36;
+const M31_MAX: u64 = 1 << M31_SIZE;
+
 /// Select and call the correct libfunc builder function from the selector.
 pub fn build<'ctx, 'this>(
     context: &'ctx Context,

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,6 +50,7 @@ mod non_zero;
 mod nullable;
 mod pedersen;
 mod poseidon;
+mod qm31;
 mod range_check;
 mod segment_arena;
 mod snapshot;
@@ -437,7 +438,13 @@ impl TypeBuilder for CoreTypeConcrete {
                 WithSelf::new(self_ty, info),
             ),
             Self::Blake(_) => native_panic!("Build Blake type"),
-            CoreTypeConcrete::QM31(_) => native_panic!("Build QM31 type"),
+            CoreTypeConcrete::QM31(info) => self::qm31::build(
+                context,
+                module,
+                registry,
+                metadata,
+                WithSelf::new(self_ty, info),
+            ),
         }
     }
 
@@ -545,7 +552,7 @@ impl TypeBuilder for CoreTypeConcrete {
 
             CoreTypeConcrete::IntRange(_info) => false,
             CoreTypeConcrete::Blake(_info) => native_panic!("Implement is_complex for Blake type"),
-            CoreTypeConcrete::QM31(_info) => native_panic!("Implement is_complex for QM31 type"),
+            CoreTypeConcrete::QM31(_info) => false,
         })
     }
 
@@ -631,7 +638,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 type_info.is_zst(registry)?
             }
             CoreTypeConcrete::Blake(_info) => native_panic!("Implement is_zst for Blake type"),
-            CoreTypeConcrete::QM31(_info) => native_panic!("Implement is_zst for QM31 type"),
+            CoreTypeConcrete::QM31(_info) => false,
         })
     }
 
@@ -743,7 +750,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 inner.extend(inner)?.0
             }
             CoreTypeConcrete::Blake(_info) => native_panic!("Implement layout for Blake type"),
-            CoreTypeConcrete::QM31(_info) => native_panic!("Implement layout for QM31 type"),
+            CoreTypeConcrete::QM31(_info) => get_integer_layout(124),
         }
         .pad_to_align())
     }
@@ -834,7 +841,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 .is_memory_allocated(registry)?,
             CoreTypeConcrete::Coupon(_) => false,
             CoreTypeConcrete::Circuit(_) => false,
-            CoreTypeConcrete::QM31(_) => native_panic!("Implement is_memory_allocated for QM31"),
+            CoreTypeConcrete::QM31(_) => false,
         })
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -750,7 +750,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 inner.extend(inner)?.0
             }
             CoreTypeConcrete::Blake(_info) => native_panic!("Implement layout for Blake type"),
-            CoreTypeConcrete::QM31(_info) => get_integer_layout(124),
+            CoreTypeConcrete::QM31(_info) => get_integer_layout(128),
         }
         .pad_to_align())
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -750,7 +750,7 @@ impl TypeBuilder for CoreTypeConcrete {
                 inner.extend(inner)?.0
             }
             CoreTypeConcrete::Blake(_info) => native_panic!("Implement layout for Blake type"),
-            CoreTypeConcrete::QM31(_info) => get_integer_layout(128),
+            CoreTypeConcrete::QM31(_) => get_integer_layout(144),
         }
         .pad_to_align())
     }

--- a/src/types/qm31.rs
+++ b/src/types/qm31.rs
@@ -1,0 +1,28 @@
+use cairo_lang_sierra::{
+    extensions::{
+        core::{CoreLibfunc, CoreType},
+        types::InfoOnlyConcreteType,
+    },
+    program_registry::ProgramRegistry,
+};
+use melior::{
+    ir::{r#type::IntegerType, Module, Type},
+    Context,
+};
+
+use crate::{error::Result, metadata::MetadataStorage};
+
+use super::WithSelf;
+
+/// Build the MLIR type.
+///
+/// Check out [the module](self) for more info.
+pub fn build<'ctx>(
+    context: &'ctx Context,
+    _module: &Module<'ctx>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _metadata: &mut MetadataStorage,
+    _info: WithSelf<InfoOnlyConcreteType>,
+) -> Result<Type<'ctx>> {
+    Ok(IntegerType::new(context, 124).into())
+}

--- a/src/types/qm31.rs
+++ b/src/types/qm31.rs
@@ -24,5 +24,5 @@ pub fn build<'ctx>(
     _metadata: &mut MetadataStorage,
     _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    Ok(IntegerType::new(context, 124).into())
+    Ok(IntegerType::new(context, 128).into())
 }

--- a/src/types/qm31.rs
+++ b/src/types/qm31.rs
@@ -24,5 +24,5 @@ pub fn build<'ctx>(
     _metadata: &mut MetadataStorage,
     _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    Ok(IntegerType::new(context, 128).into())
+    Ok(IntegerType::new(context, 144).into())
 }


### PR DESCRIPTION
This PR implements libfuncs related to QM31. 
Libfuncs to implement: 
- [ ] `QM31Concrete::Pack`
- [ ] `QM31Concrete::Unpack`
- [ ] `QM31Concrete::Const`
- [ ] `QM31Concrete::FromM31`
- [ ] `QM31Concrete::IsZero`
- [ ] `QM31Concrete::BinaryOperation`



## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
