### PR TITLE
Implement qm31_pack, qm31_const, qm31_is_zero

### DIFF
--- a/program.cairo
+++ b/program.cairo
@@ -1,0 +1,5 @@
+use core::qm31::{QM31Trait, m31, qm31};
+
+fn main() -> qm31 {
+    return QM31Trait::new(1, 2, 3, 4);
+}

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -157,7 +157,7 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     let abi_ptr = unsafe { *abi_ptr.cast::<NonNull<()>>().as_ref() };
                     abi_ptr.as_ptr().to_bytes(buffer, find_dict_drop_override)?;
                 } else {
-                    match (info.variants.len().next_power_of_two().trailing_zeros() + 7) / 8 {
+                    match (info.variants.len().next_power_of_two().trailing_zeros() + 7).div_ceil(8) {
                         0 => {}
                         _ => (*tag as u64).to_bytes(buffer, find_dict_drop_override)?,
                     }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -157,7 +157,8 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     let abi_ptr = unsafe { *abi_ptr.cast::<NonNull<()>>().as_ref() };
                     abi_ptr.as_ptr().to_bytes(buffer, find_dict_drop_override)?;
                 } else {
-                    match (info.variants.len().next_power_of_two().trailing_zeros() + 7).div_ceil(8) {
+                    match (info.variants.len().next_power_of_two().trailing_zeros() + 7).div_ceil(8)
+                    {
                         0 => {}
                         _ => (*tag as u64).to_bytes(buffer, find_dict_drop_override)?,
                     }

--- a/src/bin/utils/mod.rs
+++ b/src/bin/utils/mod.rs
@@ -182,6 +182,7 @@ fn jitvalue_to_felt(value: &Value) -> Vec<Felt> {
         }
         Value::Null => vec![0.into()],
         Value::IntRange { x, y } => [jitvalue_to_felt(x), jitvalue_to_felt(y)].concat(),
+        Value::QM31(value) => dbg!(vec![Felt::from(value)]),
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -672,8 +672,8 @@ fn parse_result(
 
                 #[cfg(target_arch = "aarch64")]
                 {
-                    use num_traits::FromBytes;
                     use num_bigint::BigUint;
+                    use num_traits::FromBytes;
 
                     let limb0 = ret_registers[0].to_le_bytes();
                     let limb1 = ret_registers[1].to_le_bytes();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -664,6 +664,12 @@ fn parse_result(
         CoreTypeConcrete::QM31(_) => Ok(match return_ptr {
             Some(value) => Value::from_ptr(value, type_id, registry, true)?,
             None => {
+                #[cfg(target_arch = "x86_64")]
+                // Since x86_64's return values hold at most two different 64bit registers,
+                // everything bigger than u128 will be returned by memory, therefore making
+                // this branch is unreachable on that architecture.
+                return Err(Error::ParseAttributeError);
+
                 #[cfg(target_arch = "aarch64")]
                 {
                     let limb0 = ret_registers[0].to_le_bytes();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -28,8 +28,8 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use libc::c_void;
-use num_bigint::{BigInt, BigUint};
-use num_traits::{FromBytes, One};
+use num_bigint::BigInt;
+use num_traits::One;
 use std::{alloc::Layout, arch::global_asm, ptr::NonNull};
 
 mod aot;
@@ -672,6 +672,9 @@ fn parse_result(
 
                 #[cfg(target_arch = "aarch64")]
                 {
+                    use num_traits::FromBytes;
+                    use num_bigint::BigUint;
+
                     let limb0 = ret_registers[0].to_le_bytes();
                     let limb1 = ret_registers[1].to_le_bytes();
                     //only use the first 16 bytes

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -664,7 +664,8 @@ fn parse_result(
         CoreTypeConcrete::QM31(_) => Ok(match return_ptr {
             Some(value) => Value::from_ptr(value, type_id, registry, true)?,
             None => {
-                #[cfg(target_arch = "aarch64")] {
+                #[cfg(target_arch = "aarch64")]
+                {
                     let limb0 = ret_registers[0].to_le_bytes();
                     let limb1 = ret_registers[1].to_le_bytes();
                     //only use the first 16 bytes

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -2,21 +2,28 @@ use cairo_lang_sierra::{
     extensions::{
         core::{CoreLibfunc, CoreType},
         lib_func::SignatureOnlyConcreteLibfunc,
-        qm31::{QM31BinaryOpConcreteLibfunc, QM31Concrete, QM31ConstConcreteLibfunc},
+        qm31::{
+            QM31BinaryOpConcreteLibfunc, QM31BinaryOperator, QM31Concrete, QM31ConstConcreteLibfunc,
+        },
     },
     program_registry::ProgramRegistry,
 };
 use melior::{
-    ir::{Block, Location},
+    dialect::arith::{self, CmpiPredicate},
+    ir::{r#type::IntegerType, Block, BlockLike, Location},
     Context,
 };
+use num_bigint::BigInt;
 
-use crate::{error::Result, metadata::MetadataStorage};
+use crate::{error::Result, metadata::MetadataStorage, utils::BlockExt};
 
 use super::LibfuncHelper;
 
-const M31_SIZE: u32 = 36;
-const M31_MAX: u64 = 1 << M31_SIZE;
+// An M31 is the quarter part of a QM31, is a 36-bit integer
+// whose 5 least significant bits are 0s.
+const M31_SIZE: u8 = 36;
+const M31_MAX: u128 = 1 << M31_SIZE;
+const QM31_PRIME: u128 = (1 << 31) - 1;
 
 /// Select and call the correct libfunc builder function from the selector.
 pub fn build<'ctx, 'this>(
@@ -33,13 +40,13 @@ pub fn build<'ctx, 'this>(
             build_qm31_pack(context, registry, entry, location, helper, metadata, info)
         }
         QM31Concrete::Unpack(info) => {
-            build_qm31_unpack(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_unpack");
         }
         QM31Concrete::Const(info) => {
             build_qm31_const(context, registry, entry, location, helper, metadata, info)
         }
         QM31Concrete::FromM31(info) => {
-            build_qm31_from_m31(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_from_m31");
         }
         QM31Concrete::IsZero(info) => {
             build_qm31_is_zero(context, registry, entry, location, helper, metadata, info)
@@ -50,80 +57,143 @@ pub fn build<'ctx, 'this>(
     }
 }
 
-/// Select and call the correct libfunc builder function from the selector.
 pub fn build_qm31_pack<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
+    _metadata: &mut MetadataStorage,
+    _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
+    let i144_ty = IntegerType::new(context, 144).into();
+    let m31_max = entry.const_int(context, location, M31_MAX, 144)?;
+
+    let m31_0 = entry.arg(0)?;
+    let m31_1 = entry.arg(1)?;
+    let m31_2 = entry.arg(2)?;
+    let m31_3 = entry.arg(3)?;
+
+    // Extend every limb to 144 bits
+    let m31_0 = entry.extui(m31_0, i144_ty, location)?;
+    let m31_1 = entry.extui(m31_1, i144_ty, location)?;
+    let m31_2 = entry.extui(m31_2, i144_ty, location)?;
+
+    // We first crate the qm31 with its most significant bits
+    let qm31 = entry.extui(m31_3, i144_ty, location)?;
+
+    let qm31 = entry.shli(qm31, m31_max, location)?;
+    let qm31 = entry.addi(qm31, m31_2, location)?;
+
+    let qm31 = entry.shli(qm31, m31_max, location)?;
+    let qm31 = entry.addi(qm31, m31_1, location)?;
+
+    let qm31 = entry.shli(qm31, m31_max, location)?;
+    let qm31 = entry.addi(qm31, m31_0, location)?;
+
+    entry.append_operation(helper.br(0, &[qm31], location));
+
     Ok(())
 }
 
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_unpack<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
 pub fn build_qm31_const<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
+    _metadata: &mut MetadataStorage,
     info: &QM31ConstConcreteLibfunc,
 ) -> Result<()> {
+    let mut qm31 = BigInt::from(info.w3);
+    qm31 <<= M31_MAX;
+    qm31 += BigInt::from(info.w2);
+    qm31 <<= M31_MAX;
+    qm31 = BigInt::from(info.w1);
+    qm31 <<= M31_MAX;
+    qm31 = BigInt::from(info.w0);
+
+    let qm31 = entry.const_int(context, location, qm31, 144)?;
+
+    entry.append_operation(helper.br(0, &[qm31], location));
+
     Ok(())
 }
 
-/// Select and call the correct libfunc builder function from the selector.
-pub fn build_qm31_from_m31<'ctx, 'this>(
-    context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
-) -> Result<()> {
-    Ok(())
-}
-
-/// Select and call the correct libfunc builder function from the selector.
 pub fn build_qm31_is_zero<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
-    info: &SignatureOnlyConcreteLibfunc,
+    _metadata: &mut MetadataStorage,
+    _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
+    let value = entry.arg(0)?;
+    let k0 = entry.const_int(context, location, 0, 144)?;
+
+    let is_zero = entry.cmpi(context, CmpiPredicate::Eq, value, k0, location)?;
+
+    entry.append_operation(helper.cond_br(context, is_zero, [0, 1], [&[], &[value]], location));
+
     Ok(())
 }
 
-/// Select and call the correct libfunc builder function from the selector.
 pub fn build_qm31_bin_operation<'ctx, 'this>(
     context: &'ctx Context,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     entry: &'this Block<'ctx>,
     location: Location<'ctx>,
     helper: &LibfuncHelper<'ctx, 'this>,
-    metadata: &mut MetadataStorage,
+    _metadata: &mut MetadataStorage,
     info: &QM31BinaryOpConcreteLibfunc,
 ) -> Result<()> {
+    let i144_ty = IntegerType::new(context, 144).into();
+
+    let lhs = entry.arg(0)?;
+    let rhs = entry.arg(1)?;
+
+    let result = match info.operator {
+        QM31BinaryOperator::Add => todo!(),
+        QM31BinaryOperator::Sub => {
+            let lhs = entry.extui(lhs, i144_ty, location)?;
+            let rhs = entry.extui(rhs, i144_ty, location)?;
+            let result = entry.append_op_result(arith::subi(lhs, rhs, location))?;
+
+            let qm31_prime =
+                entry.const_int_from_type(context, location, QM31_PRIME.clone(), i144_ty)?;
+            let result_mod = entry.addi(result, qm31_prime, location)?;
+            let is_out_of_range = entry.cmpi(context, CmpiPredicate::Ult, lhs, rhs, location)?;
+
+            entry.append_op_result(arith::select(is_out_of_range, result_mod, result, location))?
+        }
+        QM31BinaryOperator::Mul => todo!(),
+        QM31BinaryOperator::Div => todo!(),
+    };
+
+    entry.append_operation(helper.br(0, &[result], location));
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::test::{load_cairo, run_program};
+
+    #[test]
+    fn test_qm31_pack() {
+        let program = load_cairo! {
+            use core::qm31::{QM31Trait, m31, qm31};
+
+            extern fn qm31_const<
+                const W0: m31, const W1: m31, const W2: m31, const W3: m31,
+            >() -> qm31 nopanic;
+
+            fn run_test() {
+                assert!(QM31Trait::new(1, 2, 3, 4) == qm31_const::<1, 2, 3, 4>());
+            }
+        };
+
+        run_program(&program, "run_test", &[]);
+    }
 }

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -20,8 +20,6 @@ use super::LibfuncHelper;
 // An M31 is the quarter part of a QM31, is a 36-bit integer
 // whose 5 least significant bits are 0s.
 const M31_SIZE: u8 = 36;
-const M31_MAX: u128 = 1 << M31_SIZE;
-const QM31_PRIME: u128 = (1 << 31) - 1;
 
 /// Select and call the correct libfunc builder function from the selector.
 pub fn build<'ctx, 'this>(
@@ -37,19 +35,19 @@ pub fn build<'ctx, 'this>(
         QM31Concrete::Pack(info) => {
             build_qm31_pack(context, registry, entry, location, helper, metadata, info)
         }
-        QM31Concrete::Unpack(info) => {
+        QM31Concrete::Unpack(_) => {
             todo!("impl qm31_unpack");
         }
         QM31Concrete::Const(info) => {
             build_qm31_const(context, registry, entry, location, helper, metadata, info)
         }
-        QM31Concrete::FromM31(info) => {
+        QM31Concrete::FromM31(_) => {
             todo!("impl qm31_from_m31");
         }
         QM31Concrete::IsZero(info) => {
             build_qm31_is_zero(context, registry, entry, location, helper, metadata, info)
         }
-        QM31Concrete::BinaryOperation(info) => {
+        QM31Concrete::BinaryOperation(_) => {
             todo!("impl qm31_bin_op");
         }
     }

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -52,7 +52,7 @@ pub fn build<'ctx, 'this>(
             build_qm31_is_zero(context, registry, entry, location, helper, metadata, info)
         }
         QM31Concrete::BinaryOperation(info) => {
-            build_qm31_bin_operation(context, registry, entry, location, helper, metadata, info)
+            todo!("impl qm31_bin_op");
         }
     }
 }
@@ -135,43 +135,6 @@ pub fn build_qm31_is_zero<'ctx, 'this>(
     let is_zero = entry.cmpi(context, CmpiPredicate::Eq, value, k0, location)?;
 
     entry.append_operation(helper.cond_br(context, is_zero, [0, 1], [&[], &[value]], location));
-
-    Ok(())
-}
-
-pub fn build_qm31_bin_operation<'ctx, 'this>(
-    context: &'ctx Context,
-    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    entry: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    helper: &LibfuncHelper<'ctx, 'this>,
-    _metadata: &mut MetadataStorage,
-    info: &QM31BinaryOpConcreteLibfunc,
-) -> Result<()> {
-    let i144_ty = IntegerType::new(context, 144).into();
-
-    let lhs = entry.arg(0)?;
-    let rhs = entry.arg(1)?;
-
-    let result = match info.operator {
-        QM31BinaryOperator::Add => todo!(),
-        QM31BinaryOperator::Sub => {
-            let lhs = entry.extui(lhs, i144_ty, location)?;
-            let rhs = entry.extui(rhs, i144_ty, location)?;
-            let result = entry.append_op_result(arith::subi(lhs, rhs, location))?;
-
-            let qm31_prime =
-                entry.const_int_from_type(context, location, QM31_PRIME.clone(), i144_ty)?;
-            let result_mod = entry.addi(result, qm31_prime, location)?;
-            let is_out_of_range = entry.cmpi(context, CmpiPredicate::Ult, lhs, rhs, location)?;
-
-            entry.append_op_result(arith::select(is_out_of_range, result_mod, result, location))?
-        }
-        QM31BinaryOperator::Mul => todo!(),
-        QM31BinaryOperator::Div => todo!(),
-    };
-
-    entry.append_operation(helper.br(0, &[result], location));
 
     Ok(())
 }

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -139,8 +139,6 @@ pub fn build_qm31_is_zero<'ctx, 'this>(
 mod tests {
     use num_bigint::BigUint;
     use num_traits::Num;
-
-    use super::BigInt;
     use crate::{
         utils::test::{load_cairo, run_program},
         Value,

--- a/src/libfuncs/qm31.rs
+++ b/src/libfuncs/qm31.rs
@@ -137,12 +137,12 @@ pub fn build_qm31_is_zero<'ctx, 'this>(
 
 #[cfg(test)]
 mod tests {
-    use num_bigint::BigUint;
-    use num_traits::Num;
     use crate::{
         utils::test::{load_cairo, run_program},
         Value,
     };
+    use num_bigint::BigUint;
+    use num_traits::Num;
 
     #[test]
     fn test_qm31_pack() {

--- a/src/values.rs
+++ b/src/values.rs
@@ -66,6 +66,7 @@ pub enum Value {
         #[educe(PartialEq(ignore))]
         debug_name: Option<String>,
     },
+    QM31(BigUint),
     Uint8(u8),
     Uint16(u16),
     Uint32(u32),
@@ -582,6 +583,7 @@ impl Value {
                         )
                     }
                 }
+                Self::QM31(_) => native_panic!("implement to_ptr for QM31"),
             }
         })
     }
@@ -999,7 +1001,9 @@ impl Value {
                     }
                 }
                 CoreTypeConcrete::Blake(_) => native_panic!("Implement from_ptr for Blake type"),
-                CoreTypeConcrete::QM31(_) => native_panic!("Implement from_ptr for QM31 type"),
+                CoreTypeConcrete::QM31(_) => Value::QM31(BigUint::from(BigUint::from_bytes_le(
+                    slice::from_raw_parts(ptr.cast::<u8>().as_ptr(), 1),
+                ))),
             }
         })
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -1001,9 +1001,9 @@ impl Value {
                     }
                 }
                 CoreTypeConcrete::Blake(_) => native_panic!("Implement from_ptr for Blake type"),
-                CoreTypeConcrete::QM31(_) => Value::QM31(BigUint::from(BigUint::from_bytes_le(
+                CoreTypeConcrete::QM31(_) => Value::QM31(BigUint::from_bytes_le(
                     slice::from_raw_parts(ptr.cast::<u8>().as_ptr(), 1),
-                ))),
+                )),
             }
         })
     }


### PR DESCRIPTION
This PR implements libfuncs qm31_pack, qm31_const, qm31_is_zero:

```cairo
/// Returns a new `qm31` composed of the given parts (qm31_pack).
fn new(w0: m31, w1: m31, w2: m31, w3: m31) -> qm31;

/// Returns a `qm31` given its values as constants.
pub extern fn qm31_const<
    const W0: m31, const W1: m31, const W2: m31, const W3: m31,
>() -> qm31 nopanic;

extern fn qm31_is_zero(a: qm31) -> core::internal::OptionRev<NonZero<qm31>> nopanic;
```


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
