### PR TITLE
Fix into_u96_guarantee not handling other types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -155,6 +155,7 @@ pub mod panic {
     impl std::error::Error for NativeAssertError {}
 
     impl NativeAssertError {
+        #[track_caller]
         pub fn new(msg: String) -> Self {
             let backtrace = Backtrace::capture();
             let info = if BacktraceStatus::Captured == backtrace.status() {

--- a/src/values.rs
+++ b/src/values.rs
@@ -15,6 +15,7 @@ use crate::{
 use bumpalo::Bump;
 use cairo_lang_sierra::{
     extensions::{
+        circuit::CircuitTypeConcrete,
         core::{CoreLibfunc, CoreType, CoreTypeConcrete},
         starknet::{secp256::Secp256PointTypeConcrete, StarknetTypeConcrete},
         utils::Range,
@@ -964,6 +965,23 @@ impl Value {
                     Self::BoundedInt {
                         value: data.into(),
                         range: info.range.clone(),
+                    }
+                }
+                CoreTypeConcrete::Circuit(CircuitTypeConcrete::U96Guarantee(_)) => {
+                    let data = BigInt::from_biguint(
+                        Sign::Plus,
+                        BigUint::from_bytes_le(slice::from_raw_parts(
+                            ptr.cast::<u8>().as_ptr(),
+                            12,
+                        )),
+                    );
+
+                    Self::BoundedInt {
+                        value: data.into(),
+                        range: Range {
+                            lower: BigInt::ZERO,
+                            upper: BigInt::one() << 96,
+                        },
                     }
                 }
                 CoreTypeConcrete::Coupon(_)


### PR DESCRIPTION
This PR fixes `into_u96_guarantee` libfunc so that it handles:

- BoundedInts with non zero lower range
- Smaller data types (like u8)

It used to be a noop because we though it always received an u96.

This PR fixes a bug in some contracts, caused by using an `u8` as input to this libfunc:
- `0x1aa0ae9d42edb490e438b161504f01b885e487f73d146a4d10baf78bb3f155`
- `0xc9e956f41095d8b61d7254e6955521121527ffbaad87c6475b71247aa009d4`

Note: Independly from the bug fix, i added a `#[track_caller]` attribute that was missing. It does not change the fix.
