### PR TITLE
Add blockifier tests to the ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,70 @@ jobs:
       - name: test-cairo
         run: make test-cairo
 
+  tests-sequencer:
+    name: test (linux, amd64)
+    runs-on: ubuntu-24.04
+    env:
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
+      RUST_LOG: cairo_native=debug,cairo_native_test=debug
+    steps:
+      - name: Checkout Native
+        uses: actions/checkout@v4
+        with:
+          path: cairo_native
+      - name: Checkout Sequencer
+        uses: actions/checkout@v4
+        with:
+          repository: lambdaclass/sequencer
+          path: sequencer
+          ref: 998a3d6fa88b349785b2f81dbe42292c246e1917 # replay-v2.12.0-dev.0
+
+      - name: check and free hdd space left
+        run: |
+          echo "Listing 20 largest packages"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 20
+          df -h
+          sudo apt-get update
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^temurin-.*'
+          sudo apt-get remove -y azure-cli microsoft-edge-stable google-chrome-stable firefox mono-devel
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          df -h
+          echo "Removing large directories"
+          # deleting 15GB
+          sudo rm -rf /usr/share/dotnet/
+          sudo rm -rf /usr/local/lib/android
+          df -h
+      - name: Setup rust env
+        uses: dtolnay/rust-toolchain@1.84.1
+      - name: Retreive cached dependecies
+        uses: Swatinem/rust-cache@v2
+      - name: add llvm deb repository
+        uses: myci-actions/add-deb-repo@11
+        with:
+          repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          repo-name: llvm-repo
+          keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - run: sudo apt-get update && sudo apt-get upgrade -y
+      - name: Install LLVM
+        run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
+      - name: Patch replay dependencies
+        run: |
+          # Updates native dependency to local path
+          new_path='"..\/cairo_native"'
+          sed -i'' -r "s/^cairo-native = .*/cairo-native.path = $new_path/" Cargo.toml
+
+          git diff
+      - name: Run blockifier tests
+        run: |
+          cd ../sequencer
+          cargo test -p blockifier --features cairo_native
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04


### PR DESCRIPTION
We've recently had an issue when running blockifier's tests with native. This PR adds those to the ci so as to have that checked (Only for linux). 


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
