### PR TITLE
v0.4.1: Prepare for Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-native"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-native"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A compiler to convert Cairo's IR Sierra code to MLIR and execute it."

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ often so use it at your own risk. 🚧
 
 For versions under `1.0` `cargo` doesn't comply with
 [semver](https://semver.org/), so we advise to pin the version you
-use. This can be done by adding `cairo-native = "0.4.0"` to your Cargo.toml
+use. This can be done by adding `cairo-native = "0.4.1"` to your Cargo.toml
 
 ## Getting Started
 


### PR DESCRIPTION
Bumps the crate version to 0.4.1, to make a bugfix release.