### PR TITLE
Bump to Cairo v2.12.0-dev.1

### DIFF
--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: lambdaclass/starknet-replay
           path: starknet-replay
-          ref: fa1503dc90a1147f7c20a675f06e286b3f6099a8
+          ref: 135ba7cd5b45fe137b11b7f75654dcd472363033
       # We need native to use the linux deps ci action
       - name: Checkout Native
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: lambdaclass/sequencer
           path: sequencer
-          ref: 22b8050cfb06dc777737fdcce15b43eb5d9c2e9c
+          ref: b61262980394dab0e0a4c4cab85f12d31d0ce878
 
       - name: Cache RPC Calls
         uses: actions/cache@v4.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca20144595b4524a219875db6511488acefa556648d88ab957083bee5b65efa6"
+checksum = "88bf35a939eaed69b8a71405c5d56fa52c3b1c76701b8c1056fe22b3e2569c7d"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d805fc6a019554765917eebc401d3eec3f521ca287f5f629531d353a5a9d9ced"
+checksum = "c13c2341fb2272999f6152b0fc2238148fe93c745183a07acba031b27eeb0b66"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -509,19 +509,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dc52a0a23c8f6ac1c0143337a49d340d0e8e06b8e659c4df86f89d4ae44865"
+checksum = "17cf782d64a29c4acb1eb2759c39783d5e92c397d5ae3775754edae5d2c665ee"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70c35fb1c70d0f35fe1f0a3dc8dbb141e7e5ea66981a2ec8b1f22181d5b8ac9"
+checksum = "80a146574d443e7fba848c069d7d84879c4635df5811963a18bf042df3e34e61"
 dependencies = [
+ "bincode 1.3.3",
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -530,14 +531,16 @@ dependencies = [
  "cairo-lang-utils",
  "itertools 0.14.0",
  "rust-analyzer-salsa",
+ "serde",
  "smol_str",
+ "typetag",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f5566e6fe15a81a3e28324fa86f6a8f71a30ec8029da03924b057bb40ce4d"
+checksum = "cb704187b1543aa4a2e0030d13ae6e0ad63712e5362cac3ded3237623a2b1b32"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -547,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0839865e47b5207cd60602ccfaac263bdf7e789fa70ff5bca6095a0a64be8d"
+checksum = "a5a2e6145241a4812820948278a86e11c25adc30e9a19b2e24b2517be19eedac"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -557,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b92dfb70e74886c79bae62762525e63ffef0fe9d554b9a6e4c0c8a797c5c2e8"
+checksum = "3c903cdcae48aa02c0ed41e1fd54b3231da51f1edf9538327ed155463594b8be"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -573,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087165d70104c91b3d32b7cdaecfa1dd77021cc22e37edd9fab298c940aff108"
+checksum = "a943f0818cfc091c3302acd92053ff2a642004d32757c3b4f94c5aa18e184ac0"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -593,10 +596,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750ba5e07fc5007ea1e060980336d3f23333d42d30757a8565d42b65fc7dc443"
+checksum = "7b86cd38af57c36b2a72a2483d04d8b17ea2f9a554fd45b9d83375773f948818"
 dependencies = [
+ "assert_matches",
  "bincode 1.3.3",
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -615,14 +619,13 @@ dependencies = [
  "num-traits",
  "rust-analyzer-salsa",
  "serde",
- "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d580b357d88fe2a3b16262197613a313e20a39c6c2295200b490964c2cb53d40"
+checksum = "f64f0a5ca9ac54975cdec98fe8491d9b62922b7cb048e6ded00188383b841b25"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -641,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1811cb86e54c73b0b282287776fd82f4018072457a260914a1bf03b64d22fa4"
+checksum = "6230c6d37e5e8361900709112e56b42e48478806b829a086727ef59b2f7f3310"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -666,9 +669,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74578b4f0f919071d02326b9dadd80e8c5bb9a69e2b4ff062ccdb017951a88"
+checksum = "b1e4872352761cf6d7f47eeb1626e3b1d84a514017fb4251173148d8c04f36d5"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -677,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7154735bbb4c6c8cfaf7fc611231f35f08e5b584139c6a676def1430cc14c7"
+checksum = "2327b8c070f9e50ac85a410f03c6aaf6a0dffee5ba8299d6af4bf2344587ac42"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -690,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a96853a0556740dbb486cbbc7784c0a775cfba26650b9772a10535c6a882ea"
+checksum = "775b064b0265e8408565b1ec9d360116015acf35753f02db255cbb13ad30670e"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -708,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5628ef5cdd431e96a736127ba479ceca1b1cea798682d47278e1e3e377eaaed"
+checksum = "e7166250692bda4b8b31f0480b8ba7fe75793b15bd4f0b6e5b5fe5d6dde01da8"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1",
@@ -738,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f142b9100cc6406b0bcbd01fb0711a9132c4b7f5fc8735654c3d6badc619e9b0"
+checksum = "f53a1ea47d1a0295179881d5578fc2b2c8cd5d2ac99bd81958c423d54960bb84"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -765,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4705aa4648321a72f61026f64549d93b97d05334d6942caee68d5b77a12fc7"
+checksum = "a48fe249ba77fb39363b1b40c81556c8d272083508b4618fb65b964559aca0ee"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -792,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22583651e32e4bd7bd7f28cc296843f773dc558da8c445ecc4a1346300331d1"
+checksum = "fad6cbf5cc904f4309179793fc3757c1db9615e71c1b78eff601d2e22206d1c6"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -808,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fcec423871e47d8ac0429cd82f5f412fa258c423e587a3a342286cfcdafaab"
+checksum = "704ec6a8cb1b38f78571d5561519e87672ed5008a018a422842fa2a122ca3c34"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -824,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de6863813f89afccbb09c3f0d38cb3f13a5f08760e739748e8cbdd900a0a901"
+checksum = "2e011122028a59557ff075b22f550f7d0267b493f3db3dbefc281ff6795d108c"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -848,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fd03b3dd28fcc4f22531332f49960bab91b2625fa513063899edebc13e4ef6"
+checksum = "6a43885fd8e806f5c50a80473798faad1a9a919f474e469d3027aece4f8b2002"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -869,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3548bcb7ae9f6d57af33460050b8ce0fb93f78b5b347df9e181b6daa19369de5"
+checksum = "860006ddce78cae65babf37ff279c31358336ae76717991837d7e0868561878c"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -879,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fa502787b9024015622d9f617a89504af6f50729fee8fb7a0be1f03b679f3b"
+checksum = "4ba6eb0a421d3411f4948e002d3dd81ab134044465bda3131f2718f56afda409"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -905,13 +908,14 @@ dependencies = [
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.12",
+ "typetag",
 ]
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab575002a5ccdcfe58936745f52ef40a9c1b5444983a286e7620b385743d171"
+checksum = "2cf81db2c36c1e3fe3bbf64ebc5c237f748e9f41bdd42a6ed3e03e00086d768c"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -932,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972ffca1d3676fe22ea423e9240602e1c42ea166f7e55291689e4361faef2d66"
+checksum = "f36620fd45292fd0276bd581e774222fbd06e13aa8a4bf820a4be8ad3bcec100"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -950,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf462ebea64b01a8e8879caf58941d84487713342f55fa8540864d69ac1ed82"
+checksum = "0e5e3c6be0b159dad1239fa83562087448aeb1d44b0ead059ea6ab73728909a8"
 dependencies = [
  "genco",
  "xshell",
@@ -960,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52698c6ee88e4fcbdb8d00b30ad7ef897f54b8ae4859e8247576db502b79ea49"
+checksum = "eb622d636da63a5cc8138dba941d9eb1918d06e297bdb5a76dc69fffdf3581d9"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -987,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753bfa814268a383424da937c4bc4ac08c302181f947deaa0871e57b7324b17"
+checksum = "4c65df2eee1678a29b4b9dcff5c10a70b44e38d445ba2522025b1b6b7177b61f"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -1000,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.12.0-dev.0"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cec425aef45ab28a7ee880481ad9ac22daeed811f325e9e135d71412338dacb"
+checksum = "5f043065d60a8a2510bfacb6c91767298fed50ed9abbd69ff7698322b7cb1e65"
 dependencies = [
  "hashbrown 0.15.2",
  "indexmap 2.8.0",
@@ -1673,6 +1677,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2062,15 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is-terminal"
@@ -3801,10 +3824,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typetag"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f22b40dd7bfe8c14230cf9702081366421890435b2d625fa92b4acc4c3de6f"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,14 +63,14 @@ normal = ["aquamarine"]
 [dependencies]
 aquamarine = "0.6.0"
 bumpalo = "3.16.0"
-cairo-lang-compiler = "=2.12.0-dev.0"
-cairo-lang-defs = "=2.12.0-dev.0"
-cairo-lang-filesystem = "=2.12.0-dev.0"
-cairo-lang-runner = "=2.12.0-dev.0"
-cairo-lang-semantic = "=2.12.0-dev.0"
-cairo-lang-sierra = "=2.12.0-dev.0"
-cairo-lang-sierra-generator = "=2.12.0-dev.0"
-cairo-lang-sierra-to-casm = "=2.12.0-dev.0"
+cairo-lang-compiler = "=2.12.0-dev.1"
+cairo-lang-defs = "=2.12.0-dev.1"
+cairo-lang-filesystem = "=2.12.0-dev.1"
+cairo-lang-runner = "=2.12.0-dev.1"
+cairo-lang-semantic = "=2.12.0-dev.1"
+cairo-lang-sierra = "=2.12.0-dev.1"
+cairo-lang-sierra-generator = "=2.12.0-dev.1"
+cairo-lang-sierra-to-casm = "=2.12.0-dev.1"
 educe = "0.5.11" # can't update until https://github.com/magiclen/educe/issues/27
 itertools = "0.14.0"
 lazy_static = "1.5"
@@ -92,11 +92,11 @@ utf8_iter = "1.0.4"
 
 
 # CLI dependencies
-cairo-lang-sierra-ap-change = "=2.12.0-dev.0"
-cairo-lang-sierra-gas = "=2.12.0-dev.0"
-cairo-lang-starknet = "=2.12.0-dev.0"
-cairo-lang-utils = "=2.12.0-dev.0"
-cairo-lang-starknet-classes = "=2.12.0-dev.0"
+cairo-lang-sierra-ap-change = "=2.12.0-dev.1"
+cairo-lang-sierra-gas = "=2.12.0-dev.1"
+cairo-lang-starknet = "=2.12.0-dev.1"
+cairo-lang-utils = "=2.12.0-dev.1"
+cairo-lang-starknet-classes = "=2.12.0-dev.1"
 clap = { version = "4.5.23", features = ["derive"], optional = true }
 libloading = "0.8.6"
 tracing-subscriber = { version = "0.3.19", features = [
@@ -106,7 +106,7 @@ tracing-subscriber = { version = "0.3.19", features = [
 ], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "1.0", optional = true }
-cairo-lang-test-plugin = { version = "=2.12.0-dev.0", optional = true }
+cairo-lang-test-plugin = { version = "=2.12.0-dev.1", optional = true }
 colored = { version = "2.1.0", optional = true }
 # needed to interface with cairo-lang-*
 keccak = "0.1.5"
@@ -129,7 +129,7 @@ starknet-curve = "0.5.1"
 
 [dev-dependencies]
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "368e3fb311601a33ff8945e784eaa332f1fd499a", features = ["cairo-1-hints"] }
-cairo-lang-semantic = { version = "=2.12.0-dev.0", features = ["testing"] }
+cairo-lang-semantic = { version = "=2.12.0-dev.1", features = ["testing"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 lambdaworks-math = "0.11.0"
 pretty_assertions_sorted = "1.2.3"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UNAME := $(shell uname)
 SCARB_VERSION = 2.11.2
-CAIRO_2_VERSION = 2.12.0-dev.0
+CAIRO_2_VERSION = 2.12.0-dev.1
 
 # Usage is the default target for newcomers running `make`.
 .PHONY: usage

--- a/debug_utils/sierra-emu/Cargo.toml
+++ b/debug_utils/sierra-emu/Cargo.toml
@@ -9,15 +9,15 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "compiler", "mlir"]
 
 [dependencies]
-cairo-lang-compiler = "=2.12.0-dev.0"
-cairo-lang-filesystem = "=2.12.0-dev.0"
-cairo-lang-runner = "=2.12.0-dev.0"
-cairo-lang-sierra = "=2.12.0-dev.0"
-cairo-lang-sierra-to-casm = "=2.12.0-dev.0"
-cairo-lang-sierra-ap-change = "=2.12.0-dev.0"
-cairo-lang-sierra-gas = "=2.12.0-dev.0"
-cairo-lang-starknet-classes = "=2.12.0-dev.0"
-cairo-lang-utils = "=2.12.0-dev.0"
+cairo-lang-compiler = "=2.12.0-dev.1"
+cairo-lang-filesystem = "=2.12.0-dev.1"
+cairo-lang-runner = "=2.12.0-dev.1"
+cairo-lang-sierra = "=2.12.0-dev.1"
+cairo-lang-sierra-to-casm = "=2.12.0-dev.1"
+cairo-lang-sierra-ap-change = "=2.12.0-dev.1"
+cairo-lang-sierra-gas = "=2.12.0-dev.1"
+cairo-lang-starknet-classes = "=2.12.0-dev.1"
+cairo-lang-utils = "=2.12.0-dev.1"
 clap = { version = "4.5.26", features = ["derive"] }
 k256 = "0.13.4"
 keccak = "0.1.5"
@@ -39,8 +39,8 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
-cairo-lang-compiler = "=2.12.0-dev.0"
-cairo-lang-starknet = "=2.12.0-dev.0"
+cairo-lang-compiler = "=2.12.0-dev.1"
+cairo-lang-starknet = "=2.12.0-dev.1"
 
 # On dev optimize dependencies a bit so it's not as slow.
 [profile.dev.package."*"]

--- a/debug_utils/sierra-emu/Makefile
+++ b/debug_utils/sierra-emu/Makefile
@@ -2,7 +2,7 @@
 
 UNAME := $(shell uname)
 
-CAIRO_2_VERSION= 2.12.0-dev.0
+CAIRO_2_VERSION= 2.12.0-dev.1
 SCARB_VERSION = 2.11.2
 
 needs-cairo2:

--- a/debug_utils/sierra-emu/src/debug.rs
+++ b/debug_utils/sierra-emu/src/debug.rs
@@ -423,6 +423,7 @@ pub fn libfunc_to_name(value: &CoreConcreteLibfunc) -> &'static str {
         CoreConcreteLibfunc::Felt252SquashedDict(_) => todo!(),
         CoreConcreteLibfunc::Trace(_) => todo!(),
         CoreConcreteLibfunc::QM31(_) => todo!(),
+        CoreConcreteLibfunc::UnsafePanic(_) => todo!(),
     }
 }
 

--- a/debug_utils/sierra-emu/src/vm.rs
+++ b/debug_utils/sierra-emu/src/vm.rs
@@ -519,5 +519,6 @@ fn eval<'a>(
         CoreConcreteLibfunc::QM31(_) => todo!(),
         CoreConcreteLibfunc::Felt252SquashedDict(_) => todo!(),
         CoreConcreteLibfunc::Trace(_) => todo!(),
+        CoreConcreteLibfunc::UnsafePanic(_) => todo!(),
     }
 }

--- a/debug_utils/sierra-emu/src/vm/bounded_int.rs
+++ b/debug_utils/sierra-emu/src/vm/bounded_int.rs
@@ -321,8 +321,8 @@ mod tests {
     #[test]
     fn test_bounded_int_sub() {
         let (_, program) = load_cairo!(
-            use core::internal::bounded_int::{SubHelper, BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, SubHelper, BoundedInt};
 
             impl U8BISub of SubHelper<u8, u8> {
                 type Result = BoundedInt<-255, 255>;
@@ -343,8 +343,10 @@ mod tests {
     #[test]
     fn test_trim_i8() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<-127, 127> {
                 let num = match bounded_int::trim_min::<i8>(1) {
                     OptionRev::Some(n) => n,
@@ -368,8 +370,10 @@ mod tests {
     #[test]
     fn test_trim_u32() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<0, 4294967294> {
                 let num = match bounded_int::trim_max::<u32>(0xfffffffe) {
                     OptionRev::Some(n) => n,
@@ -393,8 +397,10 @@ mod tests {
     #[test]
     fn test_trim_none() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<-32767, 32767> {
                 let num = match bounded_int::trim_min::<i16>(-0x8000) {
                     OptionRev::Some(n) => n,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -157,7 +157,13 @@ impl AbiArgument for ValueWithInfoWrapper<'_> {
                     let abi_ptr = unsafe { *abi_ptr.cast::<NonNull<()>>().as_ref() };
                     abi_ptr.as_ptr().to_bytes(buffer, find_dict_drop_override)?;
                 } else {
-                    match (info.variants.len().next_power_of_two().trailing_zeros() + 7) / 8 {
+                    match info
+                        .variants
+                        .len()
+                        .next_power_of_two()
+                        .trailing_zeros()
+                        .div_ceil(8)
+                    {
                         0 => {}
                         _ => (*tag as u64).to_bytes(buffer, find_dict_drop_override)?,
                     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -416,5 +416,6 @@ pub const fn libfunc_to_name(value: &CoreConcreteLibfunc) -> &'static str {
         },
         CoreConcreteLibfunc::Blake(_) => "blake",
         CoreConcreteLibfunc::QM31(_) => "qm31",
+        CoreConcreteLibfunc::UnsafePanic(_) => "unsafe_panic",
     }
 }

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -878,7 +878,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result.return_values, vec![Felt::from(3628800)]);
-        assert_eq!(result.remaining_gas, 18446744073709538315);
+        assert_eq!(result.remaining_gas, 18446744073709545475);
     }
 
     #[rstest]

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -244,6 +244,7 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
                 &info.signature.param_signatures,
             ),
             Self::QM31(_) => native_panic!("Implement QM31 libfunc"),
+            Self::UnsafePanic(_) => native_panic!("Implement unsafe_panic libfunc"),
         }
     }
 

--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -827,8 +827,10 @@ mod test {
     #[test]
     fn test_trim_some_pos_i8() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<-128, 126> {
                 let num = match bounded_int::trim_max::<i8>(1) {
                     OptionRev::Some(n) => n,
@@ -858,8 +860,10 @@ mod test {
     #[test]
     fn test_trim_some_neg_i8() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<-127, 127> {
                 let num = match bounded_int::trim_min::<i8>(1) {
                     OptionRev::Some(n) => n,
@@ -889,8 +893,10 @@ mod test {
     #[test]
     fn test_trim_some_u32() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<0, 4294967294> {
                 let num = match bounded_int::trim_max::<u32>(0xfffffffe) {
                     OptionRev::Some(n) => n,
@@ -920,8 +926,10 @@ mod test {
     #[test]
     fn test_trim_none() {
         let (_, program) = load_cairo!(
-            use core::internal::{OptionRev, bounded_int::BoundedInt};
-            use core::internal::bounded_int;
+            #[feature("bounded-int-utils")]
+            use core::internal::bounded_int::{self, BoundedInt};
+            use core::internal::OptionRev;
+
             fn main() -> BoundedInt<-32767, 32767> {
                 let num = match bounded_int::trim_min::<i16>(-0x8000) {
                     OptionRev::Some(n) => n,

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -399,7 +399,7 @@ mod test {
 
     lazy_static! {
         static ref DOWNCAST: (String, Program) = load_cairo! {
-            use core::integer::downcast;
+            extern const fn downcast<FromType, ToType>( x: FromType, ) -> Option<ToType> implicits(RangeCheck) nopanic;
 
             fn run_test(
                 v8: u8, v16: u16, v32: u32, v64: u64, v128: u128
@@ -420,7 +420,7 @@ mod test {
             }
         };
         static ref UPCAST: (String, Program) = load_cairo! {
-            use core::integer::upcast;
+            extern const fn upcast<FromType, ToType>(x: FromType) -> ToType nopanic;
 
             fn run_test(
                 v8: u8, v16: u16, v32: u32, v64: u64, v128: u128, v248: bytes31

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -1456,6 +1456,7 @@ mod test {
     fn run_into_u96_guarantee() {
         let program = load_cairo!(
             use core::circuit::{into_u96_guarantee, U96Guarantee};
+            #[feature("bounded-int-utils")]
             use core::internal::bounded_int::BoundedInt;
 
             fn main() -> (U96Guarantee, U96Guarantee, U96Guarantee) {

--- a/src/libfuncs/gas.rs
+++ b/src/libfuncs/gas.rs
@@ -317,6 +317,6 @@ mod test {
         );
 
         let result = run_program(&program, "run_test", &[]);
-        assert_eq!(result.remaining_gas, Some(18446744073709545265));
+        assert_eq!(result.remaining_gas, Some(18446744073709545665));
     }
 }

--- a/src/utils/sierra_gen.rs
+++ b/src/utils/sierra_gen.rs
@@ -439,10 +439,6 @@ where
     fn try_get_function_ap_change(&self, _function_id: &FunctionId) -> Option<SierraApChange> {
         todo!()
     }
-
-    fn as_type_specialization_context(&self) -> &dyn TypeSpecializationContext {
-        self
-    }
 }
 
 impl<T> TypeSpecializationContext for SierraGeneratorWrapper<'_, T>

--- a/tests/tests/starknet/keccak.rs
+++ b/tests/tests/starknet/keccak.rs
@@ -36,7 +36,7 @@ fn keccak_test() {
     );
 
     assert!(!result.failure_flag);
-    assert_eq!(result.remaining_gas, 18446744073709484425);
+    assert_eq!(result.remaining_gas, 18446744073709497055);
     assert_eq!(result.return_values, vec![1.into()]);
 
     let result_aot_ct = run_native_starknet_aot_contract(

--- a/tests/tests/starknet/u256.rs
+++ b/tests/tests/starknet/u256.rs
@@ -41,5 +41,5 @@ fn u256_test() {
         result.return_values,
         vec![Felt::from_hex("0xf70cba9bb86caa97b086fdfa3df602ed").unwrap()]
     );
-    assert_eq!(result.remaining_gas, 18446744073709532215);
+    assert_eq!(result.remaining_gas, 18446744073709532595);
 }


### PR DESCRIPTION
This PR bumps Cairo dependencies to v2.12.0-dev.1.
- Bounded int libfuncs are now gated under a feature.
- The `upcast` and `downcast` libfuncs are no longer exported, so we must declared them manually with `extern`.
- The gas usage is a bit different.

Bumping to this version requires bumping also the rust toolchain. This implies some changes that seem unrelated, in order to fix clippy lints.

This release adds a new libfunc: `unsafe_panic`. 