### PR TITLE
v0.3.5: Use dynamic arrays instead of static arrays for circuit data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
         run: make test-ci
       - name: test-cairo
         run: |
-          echo > corelib/src/test/circuit_test.cairo
           make test-cairo
 
   test_macos:
@@ -184,7 +183,6 @@ jobs:
         run: make test-ci
       - name: test-cairo
         run: |
-          echo > corelib/src/test/circuit_test.cairo
           make test-cairo
 
   coverage:

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -376,9 +376,9 @@ fn build_eval<'ctx, 'this>(
             let value_ptr = ok_block.gep(
                 context,
                 location,
-                circuit_data,
+                outputs_ptr,
                 &[GepIndex::Const(i as i32)],
-                IntegerType::new(context, 384).into(),
+                build_u384_struct_type(context),
             )?;
             ok_block.store(context, location, value_ptr, gate)?;
         }

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -193,14 +193,14 @@ fn build_add_input<'ctx, 'this>(
         1,
     )?;
     // Get pointer to next input to insert
-    let next_input_ptr = entry.append_op_result(llvm::get_element_ptr_dynamic(
+    let next_input_ptr = entry.gep(
         context,
-        inputs_ptr,
-        &[current_length],
-        accumulator.r#type(),
-        llvm::r#type::pointer(context, 0),
         location,
-    ))?;
+        inputs_ptr,
+        &[GepIndex::Value(current_length)],
+        IntegerType::new(context, 384).into(),
+    )?;
+
     // Interpret u384 struct (input) as u384 integer
     let u384_struct = entry.arg(1)?;
     let new_input = u384_struct_to_integer(context, entry, location, u384_struct)?;

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -2,8 +2,6 @@
 //!
 //! Relevant casm code: https://github.com/starkware-libs/cairo/blob/v2.10.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs
 
-#![allow(unused_variables, unreachable_code)]
-
 use super::{increment_builtin_counter_by, LibfuncHelper};
 use crate::{
     error::{Result, SierraAssertError},
@@ -48,8 +46,6 @@ pub fn build<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     selector: &CircuitConcreteLibfunc,
 ) -> Result<()> {
-    native_panic!("circuit libfuncs are disabled at the moment, due to limitations in LLVM");
-
     match selector {
         CircuitConcreteLibfunc::AddInput(info) => {
             build_add_input(context, registry, entry, location, helper, metadata, info)
@@ -1183,7 +1179,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_add_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1220,7 +1215,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_sub_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1257,7 +1251,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_mul_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1294,7 +1287,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_inverse_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1329,7 +1321,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_no_coprime_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1366,7 +1357,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_mul_overflow_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1412,7 +1402,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_full_circuit() {
         let program = load_cairo!(
             use core::circuit::{
@@ -1464,7 +1453,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn run_into_u96_guarantee() {
         let program = load_cairo!(
             use core::circuit::{into_u96_guarantee, U96Guarantee};

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -115,7 +115,7 @@ fn build_init_circuit_data<'ctx, 'this>(
     )?;
 
     // Calculate full capacity for array.
-    let capacity = circuit_info.n_inputs - 1;
+    let capacity = circuit_info.n_inputs;
     let u384_layout = get_integer_layout(384);
     let capacity_bytes = layout_repeat(&u384_layout, capacity)?
         .0

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -95,10 +95,10 @@ pub fn build<'ctx>(
 ///
 /// ## Layout:
 ///
-/// Holds up to N_INPUTS - 1 elements. Where each element is an u384.
+/// Holds up to N_INPUTS elements. Where each element is an u384 integer.
 ///
-/// ```ignore
-/// struct {
+/// ```txt
+/// type = struct {
 ///     size: u64,
 ///     data: *u384,
 /// }
@@ -200,10 +200,8 @@ pub fn build_circuit_accumulator<'ctx>(
 ///
 /// Holds N_INPUTS elements. Where each element is an u384.
 ///
-/// ```ignore
-/// struct {
-///     data: *u384,
-/// }
+/// ```txt
+/// type = *u384
 /// ```
 pub fn build_circuit_data<'ctx>(
     context: &'ctx Context,
@@ -279,14 +277,21 @@ pub fn build_circuit_data<'ctx>(
 ///
 /// ## Layout:
 ///
-/// Holds N_VALUES elements, where each element is a struct-shaped u384,
-/// A struct-shaped u384 contains 4 limbs, each a u96.
+/// Holds N_VALUES elements, where each element is a u384 struct,
+/// A u384 struct contains 4 limbs, each a u96 integer.
 ///
-/// ```ignore
-/// struct {
-///     data: *u384_struct,
-///     modulus: u384_struct,
+/// ```txt
+/// type = struct {
+///     data: *u384s,
+///     modulus: u384s,
 /// };
+///
+/// u384s = struct {
+///     limb1: u96,
+///     limb2: u96,
+///     limb3: u96,
+///     limb4: u96,
+/// }
 /// ```
 pub fn build_circuit_outputs<'ctx>(
     context: &'ctx Context,

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -11,10 +11,9 @@ use crate::{
 use cairo_lang_sierra::{
     extensions::{
         circuit::{CircuitTypeConcrete, ConcreteU96LimbsLessThanGuarantee},
-        core::{CoreLibfunc, CoreType, CoreTypeConcrete},
+        core::{CoreLibfunc, CoreType},
         types::InfoOnlyConcreteType,
     },
-    program::GenericArg,
     program_registry::ProgramRegistry,
 };
 use melior::{

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -93,7 +93,7 @@ pub fn build<'ctx>(
 ///
 /// Holds up to N_INPUTS - 1 elements. Where each element is an u384.
 ///
-/// ```rust
+/// ```ignore
 /// struct {
 ///     size: u64,
 ///     data: *u384,
@@ -120,7 +120,7 @@ pub fn build_circuit_accumulator<'ctx>(
 ///
 /// Holds N_INPUTS elements. Where each element is an u384.
 ///
-/// ```rust
+/// ```ignore
 /// struct {
 ///     data: *u384,
 /// }
@@ -142,7 +142,7 @@ pub fn build_circuit_data<'ctx>(
 /// Holds N_VALUES elements, where each element is a struct-shaped u384,
 /// A struct-shaped u384 contains 4 limbs, each a u96.
 ///
-/// ```rust
+/// ```ignore
 /// struct {
 ///     data: *u384_struct,
 ///     modulus: u384_struct,

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -88,78 +88,78 @@ pub fn build<'ctx>(
     }
 }
 
+/// Builds the circuit accumulator type.
+///
+/// ## Layout:
+///
+/// Holds up to N_INPUTS - 1 elements. Where each element is an u384.
+///
+/// ```rust
+/// struct {
+///     size: u64,
+///     data: *u384,
+/// }
+/// ```
 pub fn build_circuit_accumulator<'ctx>(
     context: &'ctx Context,
     _module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     _metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    let n_inputs = circuit.circuit_info.n_inputs;
-
     let fields = vec![
         IntegerType::new(context, 64).into(),
-        llvm::r#type::array(IntegerType::new(context, 384).into(), n_inputs as u32 - 1),
+        llvm::r#type::pointer(context, 0),
     ];
 
     Ok(llvm::r#type::r#struct(context, &fields, false))
 }
 
+/// Builds the circuit data type.
+///
+/// ## Layout:
+///
+/// Holds N_INPUTS elements. Where each element is an u384.
+///
+/// ```rust
+/// struct {
+///     data: *u384,
+/// }
+/// ```
 pub fn build_circuit_data<'ctx>(
     context: &'ctx Context,
     _module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     _metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    let n_inputs = circuit.circuit_info.n_inputs;
-
-    Ok(llvm::r#type::array(
-        IntegerType::new(context, 384).into(),
-        n_inputs as u32,
-    ))
+    Ok(llvm::r#type::pointer(context, 0))
 }
 
+/// Builds the circuit outputs type.
+///
+/// ## Layout:
+///
+/// Holds N_VALUES elements, where each element is a struct-shaped u384,
+/// A struct-shaped u384 contains 4 limbs, each a u96.
+///
+/// ```rust
+/// struct {
+///     data: *u384_struct,
+///     modulus: u384_struct,
+/// };
+/// ```
 pub fn build_circuit_outputs<'ctx>(
     context: &'ctx Context,
     _module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     _metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    let n_gates = circuit.circuit_info.values.len();
-
     Ok(llvm::r#type::r#struct(
         context,
         &[
-            llvm::r#type::array(build_u384_struct_type(context), n_gates as u32),
+            llvm::r#type::pointer(context, 0),
             build_u384_struct_type(context),
         ],
         false,

--- a/tests/tests/circuit.rs
+++ b/tests/tests/circuit.rs
@@ -72,7 +72,6 @@ lazy_static! {
 }
 
 #[test]
-#[ignore]
 fn circuit_guarantee_first_limb() {
     let program = &TEST;
 
@@ -111,7 +110,6 @@ fn circuit_guarantee_first_limb() {
 }
 
 #[test]
-#[ignore]
 fn circuit_guarantee_last_limb() {
     let program = &TEST;
 
@@ -150,7 +148,6 @@ fn circuit_guarantee_last_limb() {
 }
 
 #[test]
-#[ignore]
 fn circuit_guarantee_middle_limb() {
     let program = &TEST;
 


### PR DESCRIPTION
This PR modifies the circuit implementation to use dynamic arrays, instead of static arrays.

This implies the following changes:
- Changed the type definition to use pointers instead of arrays
- Implemented `dup` and `drop` overrides for all requiring types
- Modified implementation of circuit libfuncs to take this into account.

For reviewing, I suggest first looking at the new type definitions, and then looking at the actual implementation changes.

This PR should also be applied to the main branch.