### PR TITLE
Fix replay usage in blocks CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -148,13 +148,13 @@ jobs:
         run: |
           BLOCK_START=${{ matrix.block }}
           BLOCK_END=$(($BLOCK_START + $RANGE_SIZE - 1))
-          cargo run --release --features state_dump block-range $BLOCK_START $BLOCK_END mainnet
+          cargo run --release --bin replay --features state_dump block-range $BLOCK_START $BLOCK_END mainnet
       - name: Run with VM
         if: ${{ matrix.runner == 'vm' }}
         run: |
           BLOCK_START=${{ matrix.block }}
           BLOCK_END=$(($BLOCK_START + $RANGE_SIZE - 1))
-          cargo run --release --features state_dump,only_cairo_vm block-range $BLOCK_START $BLOCK_END mainnet
+          cargo run --release --bin replay --features state_dump,only_cairo_vm block-range $BLOCK_START $BLOCK_END mainnet
 
       # We always upload the dump, even if the job fails
       - name: Upload dumps

--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: lambdaclass/starknet-replay
           path: starknet-replay
-          ref: d36491aa5fca3f48b4d7fb25eba599603ff48225
+          ref: 95c7e85f65acbf536462ffb538b866ddafb7ce39
       # We need native to use the linux deps ci action
       - name: Checkout Native
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: lambdaclass/sequencer
           path: sequencer
-          ref: 14be65ca995ac702bad26ac20f2a522d9515f70a
+          ref: 7aaf0e38c2c80276b8121bca5df8e8389bcdc2f6
       - name: Cache RPC Calls
         uses: actions/cache@v4.2.0
         with:

--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -89,12 +89,12 @@ jobs:
       - name: Run with Native
         if: ${{ matrix.runner == 'native' }}
         run: |
-          cargo run --features state_dump block mainnet ${{ matrix.block }}
+          cargo run --release --bin replay --features state_dump block mainnet ${{ matrix.block }}
 
       - name: Run with VM
         if: ${{ matrix.runner == 'vm' }}
         run: |
-          cargo run --features "state_dump,only_cairo_vm" block mainnet ${{ matrix.block }}
+          cargo run --release --bin replay --features "state_dump,only_cairo_vm" block mainnet ${{ matrix.block }}
 
       - name: Upload dumps
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The last version of starknet-replay intoduces a series of binaries. Thus, we now need to specify which of them we are going to use. This wasn't updated in cairo native's ci, which caused its failure. 
Also, updated the starknet-replay's and sequencer's version in starknet-blocks workflow so that they match the ones in the daily workflow.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
