### PR TITLE
Add Vscode config for rust analyzer to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ the needed environment variables.
 source env.sh
 ```
 
+##### Vscode: rust-analyzer (only MacOS)
+If you are using vscode as your code editor, you'll need to add this to you settings.json:
+```json
+"rust-analyzer.cargo.extraEnv": {
+  "LIBRARY_PATH": "/opt/homebrew/lib",
+  "MLIR_SYS_190_PREFIX": "<path-to-llvm-19>",
+  "LLVM_SYS_191_PREFIX": "<path-to-llvm-19>",
+  "TABLEGEN_190_PREFIX": "<path-to-llvm-19>",
+}
+```
+Without this additional config, rust-analyzer won't be able to work properly
+
 ### Make targets:
 Running `make` by itself will check whether the required LLVM installation and
 corelib is found, and then list available targets.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ the needed environment variables.
 source env.sh
 ```
 
-##### Vscode: rust-analyzer (only MacOS)
+#### rust-analyzer config for Vscode(only MacOS)
 If you are using vscode as your code editor, you'll need to add this to you settings.json:
 ```json
 "rust-analyzer.cargo.extraEnv": {

--- a/README.md
+++ b/README.md
@@ -133,15 +133,18 @@ the needed environment variables.
 source env.sh
 ```
 
-#### rust-analyzer config for Vscode(only MacOS)
+#### Configure rust-analyzer for Vscode
 If you are using vscode as your code editor, you'll need to add this to you settings.json:
 ```json
 "rust-analyzer.cargo.extraEnv": {
-  "LIBRARY_PATH": "/opt/homebrew/lib",
   "MLIR_SYS_190_PREFIX": "<path-to-llvm-19>",
   "LLVM_SYS_191_PREFIX": "<path-to-llvm-19>",
   "TABLEGEN_190_PREFIX": "<path-to-llvm-19>",
 }
+```
+if you are on MacOs, you'll need to add this extra line:
+```json
+"LIBRARY_PATH": "/opt/homebrew/lib",
 ```
 Without this additional config, rust-analyzer won't be able to work properly
 


### PR DESCRIPTION
In MacOs vscode, rust-analyzer will fail if it can't find the envar to reach llvm. We need to specify them through the setting.json. This PR adds this config to the Readme


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
