### PR TITLE
Fix build_class_hash_try_from_felt252() range_check increment

### DIFF
--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -390,7 +390,8 @@ pub fn build_class_hash_try_from_felt252<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let range_check =
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
     let value = entry.arg(1)?;
 


### PR DESCRIPTION
Libfunc: `build_class_hash_try_from_felt252()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/starknet.rs#L384): increments the range_check builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/a0bb22206ade04f065c84a12d6c2568ee98d325d/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs#L266): increments the range_check builtin by 3

**Changes**
- The libfunc now increments the range_check builtin by 3


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
