### PR TITLE
Fix build_int_range_try_new() range_check increment

### DIFF
--- a/src/libfuncs/int_range.rs
+++ b/src/libfuncs/int_range.rs
@@ -56,7 +56,7 @@ pub fn build_int_range_try_new<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = entry.arg(0)?;
+    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
     let x = entry.arg(1)?;
     let y = entry.arg(2)?;
     let range_ty = registry.build_type(


### PR DESCRIPTION
Libfunc: `build_int_range_try_new()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/int_range.rs#L50): does not increment range_check builtin
- [Compiler](https://github.com/starkware-libs/cairo/blob/cebe5aca839db3ae1c50dcde48806dd1212f8043/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs#L24): increments the range_check builtin by 1. Either if *is_valid_range* is true or false.

**Changes**
- The libfunc now increments the range_check builtin by 1

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
