### PR TITLE
Fix build_from_felt252() range_check increment

### DIFF
--- a/src/libfuncs/bytes31.rs
+++ b/src/libfuncs/bytes31.rs
@@ -111,7 +111,7 @@ pub fn build_from_felt252<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     let range_check: Value =
-        super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
     let value: Value = entry.arg(1)?;
 


### PR DESCRIPTION
Libfunc: `build_from_felt252()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/bytes31.rs#L104): increments range_check by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs#L266): increments range_check by 3

**Changes**
- The libfunc now increments the range_check builtin by 3


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
