### PR TITLE
Fix build_pedersen() pedersen increment

### DIFF
--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -52,7 +52,7 @@ pub fn build_pedersen<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     let pedersen_builtin =
-        super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
     let felt252_ty =
         registry.build_type(context, helper, metadata, &info.param_signatures()[1].ty)?;


### PR DESCRIPTION
Libfunc: `build_pedersen()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/pedersen.rs#L41): increments pedersen builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs#L23): increments pedersen builtin by 3

**Changes**
- The libfunc now increments the pedersen builtin by 3


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
