### PR TITLE
Fix build_hades_permutation() poseidon increment

### DIFF
--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -53,7 +53,7 @@ pub fn build_hades_permutation<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     let poseidon_builtin =
-        super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 6)?;
 
     let felt252_ty =
         registry.build_type(context, helper, metadata, &info.param_signatures()[1].ty)?;


### PR DESCRIPTION
Libfunc: build_hades_permutation()
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/poseidon.rs#L42): increments poseidon builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs#L19): increments poseidon builtin by 6

**Changes**
- The libfunc now increments the poseidon builtin by 6

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
