### PR TITLE
Fix build_divmod() range_check increment

### DIFF
--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -61,7 +61,8 @@ pub fn build_divmod<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let range_check =
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 6)?;
 
     let i128_ty = IntegerType::new(context, 128).into();
     let i256_ty = IntegerType::new(context, 256).into();


### PR DESCRIPTION
Libfunc: `uint256.rs/build_divmod()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/uint256.rs#L55): increments range_check builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs#L47): increment range_check builtin by 6

**Changes**
- The libfunc now increments the range_check builtin by 6


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
