### PR TITLE
Fix build_square_root() range_check increment

### DIFF
--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -346,7 +346,8 @@ pub fn build_square_root<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let range_check =
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 7)?;
 
     let i128_ty = IntegerType::new(context, 128).into();
     let i256_ty = IntegerType::new(context, 256).into();


### PR DESCRIPTION
Libfunc: `build_square_root()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/uint256.rs#L340): increments range_check by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/b067c4531f55e0e6836c203c74ce3e793512f355/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs#L189): increments range_check by 7

**Changes**
- The libfunc now increments the range_check builtin by 7

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
