### PR TITLE
Fix builtin usage in Box ForwardSnapshot libfunc

### DIFF
--- a/src/libfuncs/box.rs
+++ b/src/libfuncs/box.rs
@@ -43,7 +43,7 @@ pub fn build<'ctx, 'this>(
         BoxConcreteLibfunc::Unbox(info) => {
             build_unbox(context, registry, entry, location, helper, metadata, info)
         }
-        BoxConcreteLibfunc::ForwardSnapshot(info) => super::build_noop::<1, true>(
+        BoxConcreteLibfunc::ForwardSnapshot(info) => super::build_noop::<1, false>(
             context,
             registry,
             entry,


### PR DESCRIPTION
To imitate the CASM compiler, this libfunc should not increment builtin counters.

- [Sierra to CASM code](https://github.com/starkware-libs/cairo/blob/92d5f1ce477871d5e93914fc238bc9662890e023/crates/cairo-lang-sierra-to-casm/src/invocations/boxing.rs#L21)