### PR TITLE
Fix build_point_from_x() range_check increment

### DIFF
--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -147,7 +147,9 @@ pub fn build_point_from_x<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let original_range_check = entry.arg(0)?;
+    let range_check_on_curve =
+        super::increment_builtin_counter_by(context, entry, location, original_range_check, 3)?;
 
     let ec_point_ty = llvm::r#type::r#struct(
         context,
@@ -183,7 +185,7 @@ pub fn build_point_from_x<'ctx, 'this>(
         entry,
         result,
         [0, 1],
-        [&[range_check, point], &[range_check]],
+        [&[range_check_on_curve, point], &[original_range_check]],
         location,
     )
 }


### PR DESCRIPTION
Libfunc: `build_point_from_x()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/ec.rs#L141): adds range_check 1 time
- [Compiler](https://github.com/starkware-libs/cairo/blob/ff2e19a3d671036e626ea89cac409c5325383584/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L167): if **VerifyNotOnCurve** is equal to 0 the range_check is increased 3 times, otherwise is never increased

**Changes**
- `original_range_check` and `range_check_on_curve` were created with their values and returned on their branches


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
