### PR TITLE
Fix `uint512_div_mod` range check increment

### DIFF
--- a/src/libfuncs/uint512.rs
+++ b/src/libfuncs/uint512.rs
@@ -48,7 +48,8 @@ pub fn build_divmod_u256<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 12)?;
+    let range_check =
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 12)?;
 
     let i128_ty = IntegerType::new(context, 128).into();
     let i512_ty = IntegerType::new(context, 512).into();


### PR DESCRIPTION
- [Native](https://github.com/lambdaclass/cairo_native/blob/main/src/libfuncs/uint512.rs#L42): adds range_check 1 time
- [Compiler](https://github.com/starkware-libs/cairo/blob/e22cf51b6a4751b46cacfbb99f8e1bfbe9c85616/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs#L23): adds range_check 12 times


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
