### PR TITLE
Fix bitwise builtin increment

### DIFF
--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -210,7 +210,7 @@ fn build_bitwise<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let bitwise = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let bitwise = super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 5)?;
 
     let lhs = entry.arg(1)?;
     let rhs = entry.arg(2)?;

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -948,7 +948,7 @@ mod test {
                 None,
             )?;
 
-            assert_eq!(result.builtin_stats.bitwise, 1);
+            assert_eq!(result.builtin_stats.bitwise, 5);
             assert_eq!(
                 result.return_value,
                 Value::Struct {


### PR DESCRIPTION
The bitwise libfunc should increment the bitwise builtin by 5.

- [Sierra to CASM code](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/bitwise.rs?plain=1#L31)

The size of the bitwise builtin is 5, which means that each builtin use requires 5 cells.