### PR TITLE
Fix u128 byte reverse bitwise increment

### DIFF
--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -990,7 +990,7 @@ mod test {
         for value in data.into_iter() {
             let result = executor.invoke_dynamic(&program.funcs[0].id, &[value.into()], None)?;
 
-            assert_eq!(result.builtin_stats.bitwise, 1);
+            assert_eq!(result.builtin_stats.bitwise, 20);
             assert_eq!(result.return_value, Value::Uint128(value.swap_bytes()));
         }
 

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -236,7 +236,7 @@ fn build_byte_reverse<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let bitwise = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let bitwise = super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 20)?;
 
     let value =
         entry.append_op_result(ods::llvm::intr_bswap(context, entry.arg(1)?, location).into())?;


### PR DESCRIPTION
The u128 byte reverse libfunc should increment the bitwise builtin by 20. As it uses the builtin 4 times.

- [Sierra to CASM code](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs?plain=1#L356)

The size of the bitwise builtin is 5, which means that each builtin use requires 5 cells.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
