### PR TITLE
Fix build_state_add_mul() ec_op increment

### DIFF
--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -247,7 +247,7 @@ pub fn build_state_add_mul<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the ec op builtin 1 time.
-    // https://github.com/starkware-libs/cairo/blob/ff2e19a3d671036e626ea89cac409c5325383584/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L439
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L439
     let ec_op = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -245,7 +245,7 @@ pub fn build_state_add_mul<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let ec_op = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let ec_op = super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 7)?;
 
     let felt252_ty = IntegerType::new(context, 252).into();
     let ec_state_ty = llvm::r#type::r#struct(

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -3,6 +3,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::{Error, Result},
+    execution_result::EC_OP_BUILTIN_SIZE,
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt, PRIME},
 };
@@ -245,7 +246,15 @@ pub fn build_state_add_mul<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let ec_op = super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 7)?;
+    // The sierra-to-casm compiler uses the ec op builtin 1 time.
+    // https://github.com/starkware-libs/cairo/blob/ff2e19a3d671036e626ea89cac409c5325383584/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L439
+    let ec_op = super::increment_builtin_counter_by(
+        context,
+        entry,
+        location,
+        entry.arg(0)?,
+        EC_OP_BUILTIN_SIZE,
+    )?;
 
     let felt252_ty = IntegerType::new(context, 252).into();
     let ec_state_ty = llvm::r#type::r#struct(


### PR DESCRIPTION
Libfunc: `build_state_add_mul()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/ec.rs#L239): increments ec_op builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/ff2e19a3d671036e626ea89cac409c5325383584/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L439): increments ec_op builtin by 7

**Changes**
- The libfunc now increments the ec_op builtin by 7

Take into account that the the size of the ec_op builtin is 7, this means that each of these requires 7 cells.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
