### PR TITLE
fix range check counting in `libfuncs/mem.rs`

### DIFF
--- a/src/libfuncs/mem.rs
+++ b/src/libfuncs/mem.rs
@@ -41,7 +41,7 @@ pub fn build<'ctx, 'this>(
         MemConcreteLibfunc::StoreLocal(info) => {
             build_store_local(context, registry, entry, location, helper, metadata, info)
         }
-        MemConcreteLibfunc::FinalizeLocals(info) => super::build_noop::<0, true>(
+        MemConcreteLibfunc::FinalizeLocals(info) => super::build_noop::<0, false>(
             context,
             registry,
             entry,


### PR DESCRIPTION
Fixes range check counting in every libfunc contained in `libfuncs/mem.rs`.

The following libfuncs use `build_noop()` which adds to the builtin if it is a parameter. So for example if we call `store_temp<RangeCheck>` it will add 1 to the range check builtin. However, I dont see that the same is being done on the compilers side: 
    - `store_temp()`
    - `finalize_locals()`
    - `rename()`


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
