### PR TITLE
Fix `uint128_mul_guarantee_verify` range check counting

### DIFF
--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -1458,7 +1458,7 @@ mod test {
             let lo = u128::from_le_bytes(res_bytes[..16].try_into().unwrap());
             let hi = u128::from_le_bytes(res_bytes[16..].try_into().unwrap());
 
-            assert_eq!(result.builtin_stats.range_check, 1);
+            assert_eq!(result.builtin_stats.range_check, 9);
             assert_eq!(
                 result.return_value,
                 Value::Struct {

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -512,7 +512,8 @@ fn build_mul_guarantee_verify<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
+    let range_check =
+        super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 9)?;
 
     helper.br(entry, 0, &[range_check], location)
 }


### PR DESCRIPTION
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/int.rs#L506): counts range_check 1 time
- [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L32):  counts range_check 9 times.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
