### PR TITLE
Fix build_u128s_from_felt252() range_check increment

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -497,6 +497,31 @@ fn increment_builtin_counter_by<'ctx: 'a, 'a>(
     ))
 }
 
+fn increment_builtin_counter_by_if<'ctx: 'a, 'a>(
+    context: &'ctx Context,
+    block: &'ctx Block<'ctx>,
+    location: Location<'ctx>,
+    value_to_inc: Value<'ctx, '_>,
+    true_amount: impl Into<BigInt>,
+    false_amount: impl Into<BigInt>,
+    condition: Value<'ctx, '_>,
+) -> crate::error::Result<Value<'ctx, 'a>> {
+    let true_amount_value = block.const_int(context, location, true_amount, 64)?;
+    let false_amount_value = block.const_int(context, location, false_amount, 64)?;
+
+    let true_incremented =
+        block.append_op_result(arith::addi(value_to_inc, true_amount_value, location))?;
+    let false_incremented =
+        block.append_op_result(arith::addi(value_to_inc, false_amount_value, location))?;
+
+    block.append_op_result(arith::select(
+        condition,
+        true_incremented,
+        false_incremented,
+        location,
+    ))
+}
+
 fn build_noop<'ctx, 'this, const N: usize, const PROCESS_BUILTINS: bool>(
     context: &'ctx Context,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -907,6 +907,7 @@ mod test {
         fmt::Display,
         mem,
         ops::{BitAnd, BitOr, BitXor},
+        u128,
     };
 
     fn test_bitwise<T>() -> Result<(), Box<dyn std::error::Error>>
@@ -1808,7 +1809,11 @@ mod test {
             let lo = u128::from_le_bytes(value_bytes[..16].try_into().unwrap());
             let hi = u128::from_le_bytes(value_bytes[16..].try_into().unwrap());
 
-            assert_eq!(result.builtin_stats.range_check, 1);
+            if value < Felt::from(BigInt::from(u128::MAX + 1)) {
+                assert_eq!(result.builtin_stats.range_check, 3);
+            } else {
+                assert_eq!(result.builtin_stats.range_check, 1);
+            }
             assert_eq!(
                 result.return_value,
                 Value::Enum {

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -824,8 +824,6 @@ fn build_u128s_from_felt252<'ctx, 'this>(
     _metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
-
     let target_ty = IntegerType::new(context, 128).into();
 
     let lo = entry.trunci(entry.arg(1)?, target_ty, location)?;
@@ -836,6 +834,16 @@ fn build_u128s_from_felt252<'ctx, 'this>(
 
     let k0 = entry.const_int_from_type(context, location, 0, target_ty)?;
     let is_wide = entry.cmpi(context, CmpiPredicate::Ne, hi, k0, location)?;
+
+    let range_check = super::increment_builtin_counter_by_if(
+        context,
+        entry,
+        location,
+        entry.arg(0)?,
+        1,
+        3,
+        is_wide,
+    )?;
 
     helper.cond_br(
         context,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -835,8 +835,8 @@ fn build_u128s_from_felt252<'ctx, 'this>(
     let k0 = entry.const_int_from_type(context, location, 0, target_ty)?;
     let is_wide = entry.cmpi(context, CmpiPredicate::Ne, hi, k0, location)?;
 
-    // The sierra-to-casm compiler uses the range check builtin a total of 3 times if the
-    // is_wide condition is true. Otherwise it will be used once.
+    // The sierra-to-casm compiler uses the range check builtin a total of 3 times when the value is greater than u128 max.
+    // Otherwise it will be used once.
     // https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
     let range_check = super::increment_builtin_counter_by_if(
         context,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -907,7 +907,6 @@ mod test {
         fmt::Display,
         mem,
         ops::{BitAnd, BitOr, BitXor},
-        u128,
     };
 
     fn test_bitwise<T>() -> Result<(), Box<dyn std::error::Error>>

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -1809,7 +1809,7 @@ mod test {
             let lo = u128::from_le_bytes(value_bytes[..16].try_into().unwrap());
             let hi = u128::from_le_bytes(value_bytes[16..].try_into().unwrap());
 
-            if value < Felt::from(BigInt::from(u128::MAX + 1)) {
+            if value <= Felt::from(BigInt::from(u128::MAX)) {
                 assert_eq!(result.builtin_stats.range_check, 3);
             } else {
                 assert_eq!(result.builtin_stats.range_check, 1);


### PR DESCRIPTION
Libfunc: `build_u128s_from_felt252()`
- [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/int.rs#L818): increments range_check builtin by 1
- [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234): if *is_u128* is not equal to 0 range_check is incremented by 1. Else, if it is equal to 0, the range_check is incremented by 3.

**Changes**
- Use increment_builtin_counter_by_if() to add the corresponding amount to the range_check builtin according to the condition


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
