### PR TITLE
Fix int_operation range_check counting

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -497,6 +497,31 @@ fn increment_builtin_counter_by<'ctx: 'a, 'a>(
     ))
 }
 
+fn increment_builtin_counter_by_if<'ctx: 'a, 'a>(
+    context: &'ctx Context,
+    block: &'ctx Block<'ctx>,
+    location: Location<'ctx>,
+    value_to_inc: Value<'ctx, '_>,
+    true_amount: impl Into<BigInt>,
+    false_amount: impl Into<BigInt>,
+    condition: Value<'ctx, '_>,
+) -> crate::error::Result<Value<'ctx, 'a>> {
+    let true_amount_value = block.const_int(context, location, true_amount, 64)?;
+    let false_amount_value = block.const_int(context, location, false_amount, 64)?;
+
+    let true_incremented =
+        block.append_op_result(arith::addi(value_to_inc, true_amount_value, location))?;
+    let false_incremented =
+        block.append_op_result(arith::addi(value_to_inc, false_amount_value, location))?;
+
+    block.append_op_result(arith::select(
+        condition,
+        true_incremented,
+        false_incremented,
+        location,
+    ))
+}
+
 fn build_noop<'ctx, 'this, const N: usize, const PROCESS_BUILTINS: bool>(
     context: &'ctx Context,
     registry: &ProgramRegistry<CoreType, CoreLibfunc>,


### PR DESCRIPTION
Fixes range check counting in libfunc `int_operation` for every int type.

- `build_operation()` 
    - unsigned 
        - [Native](https://github.com/lambdaclass/cairo_native/blob/470083391c0c4a55e8860e1993389b0b029a53d1/src/libfuncs/int.rs#L520): adds range_check 1 time
        - [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L142C13-L145C11): increments range_check by 1
    - signed 
        - Native: same as above
        - [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs#L146C9-L148C10): if the jump to **IsInRange** is NOT done, then the range_check is only incremented by 1. If the jump is made, then the range_check first is added once and then if `!(min_value == i128::MIN && max_value == i128::MAX)` it will be incremented an additional time
    - unsigned128 
        - Native: same as above
        - [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L22C10-L25C11): increments range_check by 1
    - signed128 ❌
        - Native: same as above
        - [Compiler](https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed128.rs#L19C15-L21C10): same case as with the *signed*


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
