### PR TITLE
Fix builtin counting for bounded_int_wrap_non_zero

### DIFF
--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -805,7 +805,7 @@ fn build_wrap_non_zero<'ctx, 'this>(
         "value must not be zero"
     );
 
-    super::build_noop::<1, true>(
+    super::build_noop::<1, false>(
         context,
         registry,
         entry,


### PR DESCRIPTION
We should not process builtins, as the compiler is using `build_identity`, which does not increment builtins.

-[ Sierra to casm code.](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs?plain=1#L47)


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
