### PR TITLE
Fix unwrap non zero builtin processing

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -234,7 +234,7 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
             Self::Uint512(selector) => self::uint512::build(
                 context, registry, entry, location, helper, metadata, selector,
             ),
-            Self::UnwrapNonZero(info) => build_noop::<1, true>(
+            Self::UnwrapNonZero(info) => build_noop::<1, false>(
                 context,
                 registry,
                 entry,


### PR DESCRIPTION
The sierra to casm compiler uses build_identity, which doesn't process builtins.

- [Sierra to casm code.](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs?plain=1#L696)