### PR TITLE
Don't process builtins for noops in nullable libfuncs

### DIFF
--- a/src/libfuncs/nullable.rs
+++ b/src/libfuncs/nullable.rs
@@ -33,7 +33,7 @@ pub fn build<'ctx, 'this>(
 ) -> Result<()> {
     match selector {
         NullableConcreteLibfunc::ForwardSnapshot(info)
-        | NullableConcreteLibfunc::NullableFromBox(info) => super::build_noop::<1, true>(
+        | NullableConcreteLibfunc::NullableFromBox(info) => super::build_noop::<1, false>(
             context,
             registry,
             entry,


### PR DESCRIPTION
Disables builtin processing for the following libfuncs, as the sierra to casm compiler calls build_identity, which does not increase any builtin pointer.
- [ForwardSnapshot](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/nullable.rs?plain=1#L26)
- [NullableFromBox](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/nullable.rs?plain=1#L23)
