### PR TITLE
Don't process builtins for noops in starknet libfuncs

### DIFF
--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -51,7 +51,7 @@ pub fn build<'ctx, 'this>(
         | StarknetConcreteLibfunc::StorageAddressFromBase(info)
         | StarknetConcreteLibfunc::StorageAddressToFelt252(info)
         | StarknetConcreteLibfunc::Sha256StateHandleInit(info)
-        | StarknetConcreteLibfunc::Sha256StateHandleDigest(info) => super::build_noop::<1, true>(
+        | StarknetConcreteLibfunc::Sha256StateHandleDigest(info) => super::build_noop::<1, false>(
             context,
             registry,
             entry,


### PR DESCRIPTION
Disables builtin processing for the following libfuncs, as the sierra to casm compiler calls `build_identity`, which does not increase any builtin pointer.

- [ClassHashToFelt252](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L41)
- [ContractAddressToFelt252](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L41)
- [StorageAddressFromBase](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L45)
- [StorageAddressToFelt252](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L41)
- [Sha256StateHandleInit](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L73)
- [Sha256StateHandleDigest](https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs?plain=1#L74)