### PR TITLE
Change cairo's repo version used in range check doc links

### DIFF
--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -590,7 +590,7 @@ fn build_divrem<'ctx, 'this>(
     };
 
     // Increase range check builtin by 3, regardless of `div_rem_algorithm`:
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L100
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L100
     let range_check = match div_rem_algorithm {
         BoundedIntDivRemAlgorithm::KnownSmallRhs => crate::libfuncs::increment_builtin_counter_by(
             context,
@@ -603,8 +603,8 @@ fn build_divrem<'ctx, 'this>(
         | BoundedIntDivRemAlgorithm::KnownSmallLhs { .. } => {
             // If `div_rem_algorithm` is `KnownSmallQuotient` or `KnownSmallLhs`, increase range check builtin by 1.
             //
-            // Case KnownSmallQuotient: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L129
-            // Case KnownSmallLhs: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L157
+            // Case KnownSmallQuotient: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L129
+            // Case KnownSmallLhs: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L157
             crate::libfuncs::increment_builtin_counter_by(
                 context,
                 entry,

--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -590,7 +590,7 @@ fn build_divrem<'ctx, 'this>(
     };
 
     // Increase range check builtin by 3, regardless of `div_rem_algorithm`:
-    // https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L97
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L100
     let range_check = match div_rem_algorithm {
         BoundedIntDivRemAlgorithm::KnownSmallRhs => crate::libfuncs::increment_builtin_counter_by(
             context,
@@ -603,8 +603,8 @@ fn build_divrem<'ctx, 'this>(
         | BoundedIntDivRemAlgorithm::KnownSmallLhs { .. } => {
             // If `div_rem_algorithm` is `KnownSmallQuotient` or `KnownSmallLhs`, increase range check builtin by 1.
             //
-            // Case KnownSmallQuotient: https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L126
-            // Case KnownSmallLhs: https://github.com/starkware-libs/cairo/blob/61c56aff349b4715f2a6619faf5b710f2da8a663/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L154
+            // Case KnownSmallQuotient: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L129
+            // Case KnownSmallLhs: https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs#L157
             crate::libfuncs::increment_builtin_counter_by(
                 context,
                 entry,

--- a/src/libfuncs/bytes31.rs
+++ b/src/libfuncs/bytes31.rs
@@ -111,7 +111,7 @@ pub fn build_from_felt252<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check: Value =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 

--- a/src/libfuncs/bytes31.rs
+++ b/src/libfuncs/bytes31.rs
@@ -111,7 +111,7 @@ pub fn build_from_felt252<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check: Value =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -317,7 +317,7 @@ fn build_eval<'ctx, 'this>(
     // let one = entry.argument(6)?;
 
     // Always increase the add mod builtin pointer, regardless of the evaluation result.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L257
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L257
     let add_mod = increment_builtin_counter_by(
         context,
         entry,
@@ -351,7 +351,7 @@ fn build_eval<'ctx, 'this>(
 
         // Increase the mul mod builtin pointer by the number of evaluated gates.
         // If the evaluation succedes, then we assume that every gate was evaluated.
-        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
+        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
         let mul_mod = increment_builtin_counter_by(
             context,
             ok_block,
@@ -432,7 +432,7 @@ fn build_eval<'ctx, 'this>(
         // Increase the mul mod builtin pointer by the number of evaluated gates.
         // As the evaluation failed, we read the number of evaluated gates from
         // the first argument of the error block.
-        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
+        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
         let mul_mod = {
             let mul_mod_usage = err_block.muli(
                 err_block.arg(0)?,
@@ -1209,7 +1209,7 @@ fn build_u96_guarantee_verify<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // We increase the range_check96 builtin by 1 usage
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L534
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L534
     let range_check96 = increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -317,7 +317,7 @@ fn build_eval<'ctx, 'this>(
     // let one = entry.argument(6)?;
 
     // Always increase the add mod builtin pointer, regardless of the evaluation result.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L257
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L257
     let add_mod = increment_builtin_counter_by(
         context,
         entry,
@@ -351,7 +351,7 @@ fn build_eval<'ctx, 'this>(
 
         // Increase the mul mod builtin pointer by the number of evaluated gates.
         // If the evaluation succedes, then we assume that every gate was evaluated.
-        // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
+        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
         let mul_mod = increment_builtin_counter_by(
             context,
             ok_block,
@@ -432,7 +432,7 @@ fn build_eval<'ctx, 'this>(
         // Increase the mul mod builtin pointer by the number of evaluated gates.
         // As the evaluation failed, we read the number of evaluated gates from
         // the first argument of the error block.
-        // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
+        // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L261
         let mul_mod = {
             let mul_mod_usage = err_block.muli(
                 err_block.arg(0)?,
@@ -1209,7 +1209,7 @@ fn build_u96_guarantee_verify<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // We increase the range_check96 builtin by 1 usage
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L534
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs?plain=1#L534
     let range_check96 = increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -55,7 +55,7 @@ pub fn build_new<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // We increase the segment arena builtin by 1 usage.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L45-L49
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L45-L49
     let segment_arena = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -55,7 +55,7 @@ pub fn build_new<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // We increase the segment arena builtin by 1 usage.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L45-L49
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L45-L49
     let segment_arena = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -335,7 +335,7 @@ fn build_divmod<'ctx, 'this>(
         ))?;
     // The sierra-to-casm compiler uses the range check builtin 3 times if the algorithm
     // is KnownSmallRhs. Otherwise it is used 4 times.
-    // https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L151C1-L155C11
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L151C1-L155C11
     let range_check = match div_rem_algorithm {
         BoundedIntDivRemAlgorithm::KnownSmallRhs => {
             super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?
@@ -550,7 +550,7 @@ fn build_mul_guarantee_verify<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 9 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs?plain=1#L112
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs?plain=1#L112
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 9)?;
 
@@ -655,7 +655,7 @@ fn build_square_root<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range_check builtin 4 times.
-    // https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L73
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L73
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 4)?;
 
@@ -880,7 +880,7 @@ fn build_u128s_from_felt252<'ctx, 'this>(
 
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times when the value is greater than u128 max.
     // Otherwise it will be used once.
-    // https://github.com/starkware-libs/cairo/blob/96625b57abee8aca55bdeb3ecf29f82e8cea77c3/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
     let range_check = super::increment_builtin_counter_by_if(
         context,
         entry,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -335,7 +335,7 @@ fn build_divmod<'ctx, 'this>(
         ))?;
     // The sierra-to-casm compiler uses the range check builtin 3 times if the algorithm
     // is KnownSmallRhs. Otherwise it is used 4 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L151C1-L155C11
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L151C1-L155C11
     let range_check = match div_rem_algorithm {
         BoundedIntDivRemAlgorithm::KnownSmallRhs => {
             super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?
@@ -550,7 +550,7 @@ fn build_mul_guarantee_verify<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 9 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs?plain=1#L112
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs?plain=1#L112
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 9)?;
 
@@ -655,7 +655,7 @@ fn build_square_root<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range_check builtin 4 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L73
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs#L73
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 4)?;
 
@@ -880,7 +880,7 @@ fn build_u128s_from_felt252<'ctx, 'this>(
 
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times when the value is greater than u128 max.
     // Otherwise it will be used once.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
     let range_check = super::increment_builtin_counter_by_if(
         context,
         entry,

--- a/src/libfuncs/int_range.rs
+++ b/src/libfuncs/int_range.rs
@@ -57,7 +57,7 @@ pub fn build_int_range_try_new<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs?plain=1#L24
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs?plain=1#L24
     let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
     let x = entry.arg(1)?;
     let y = entry.arg(2)?;

--- a/src/libfuncs/int_range.rs
+++ b/src/libfuncs/int_range.rs
@@ -57,7 +57,7 @@ pub fn build_int_range_try_new<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs?plain=1#L24
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs?plain=1#L24
     let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
     let x = entry.arg(1)?;
     let y = entry.arg(2)?;

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -53,7 +53,7 @@ pub fn build_pedersen<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     // The sierra-to-casm compiler uses the pedersen builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs?plain=1#L23
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs?plain=1#L23
     let pedersen_builtin = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/pedersen.rs
+++ b/src/libfuncs/pedersen.rs
@@ -53,7 +53,7 @@ pub fn build_pedersen<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     // The sierra-to-casm compiler uses the pedersen builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs?plain=1#L23
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs?plain=1#L23
     let pedersen_builtin = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -54,7 +54,7 @@ pub fn build_hades_permutation<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     // The sierra-to-casm compiler uses the poseidon builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs?plain=1#L19
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs?plain=1#L19
     let poseidon_builtin = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/poseidon.rs
+++ b/src/libfuncs/poseidon.rs
@@ -54,7 +54,7 @@ pub fn build_hades_permutation<'ctx>(
         .to_native_assert_error("runtime library should be available")?;
 
     // The sierra-to-casm compiler uses the poseidon builtin a total of 1 time.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs?plain=1#L19
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs?plain=1#L19
     let poseidon_builtin = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -391,7 +391,7 @@ pub fn build_class_hash_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -450,7 +450,7 @@ pub fn build_contract_address_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -823,7 +823,7 @@ pub fn build_storage_base_address_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs?plain=1#L30
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs?plain=1#L30
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -881,7 +881,7 @@ pub fn build_storage_address_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 

--- a/src/libfuncs/starknet.rs
+++ b/src/libfuncs/starknet.rs
@@ -391,7 +391,7 @@ pub fn build_class_hash_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -450,7 +450,7 @@ pub fn build_contract_address_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -823,7 +823,7 @@ pub fn build_storage_base_address_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs?plain=1#L30
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs?plain=1#L30
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 
@@ -881,7 +881,7 @@ pub fn build_storage_address_try_from_felt252<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs?plain=1#L266
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 3)?;
 

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -62,7 +62,7 @@ pub fn build_divmod<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 6 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L47
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L47
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 6)?;
 
@@ -350,7 +350,7 @@ pub fn build_square_root<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 7 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L189
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L189
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 7)?;
 

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -62,7 +62,7 @@ pub fn build_divmod<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 6 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L47
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L47
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 6)?;
 
@@ -350,7 +350,7 @@ pub fn build_square_root<'ctx, 'this>(
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 7 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L189
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs?plain=1#L189
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 7)?;
 

--- a/src/libfuncs/uint512.rs
+++ b/src/libfuncs/uint512.rs
@@ -49,7 +49,7 @@ pub fn build_divmod_u256<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 12 times.
-    // https://github.com/starkware-libs/cairo/blob/dc8b4f0b2e189a3b107b15062895597588b78a46/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs?plain=1#L33
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs?plain=1#L23
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 12)?;
 

--- a/src/libfuncs/uint512.rs
+++ b/src/libfuncs/uint512.rs
@@ -49,7 +49,7 @@ pub fn build_divmod_u256<'ctx, 'this>(
     info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
     // The sierra-to-casm compiler uses the range check builtin a total of 12 times.
-    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.0/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs?plain=1#L23
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs?plain=1#L23
     let range_check =
         super::increment_builtin_counter_by(context, entry, location, entry.arg(0)?, 12)?;
 


### PR DESCRIPTION
This PR changes the version referenced by the documentation links when updating the range check builtin to meet the one used by the blockifier in version [v0.14.0-testnet](https://github.com/starkware-libs/sequencer/tree/apollo-v0.14.0-testnet) (currently being v2.12.0-dev.1)


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
