### PR TITLE
Fix felt252_dict_squash builtin counting

### DIFF
--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -129,6 +129,8 @@ pub fn build_squash<'ctx, 'this>(
     let segment_arena = entry.arg(2)?;
     let dict_ptr = entry.arg(3)?;
 
+    // Increase the segment arena builtin by 1 usage.
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L148-L151
     let segment_arena = super::increment_builtin_counter_by(
         context,
         entry,

--- a/src/libfuncs/felt252_dict.rs
+++ b/src/libfuncs/felt252_dict.rs
@@ -21,7 +21,7 @@ use cairo_lang_sierra::{
 };
 use melior::{
     dialect::{llvm, ods},
-    ir::{Block, Location},
+    ir::{r#type::IntegerType, Block, Location},
     Context,
 };
 
@@ -124,26 +124,56 @@ pub fn build_squash<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     _info: &SignatureOnlyConcreteLibfunc,
 ) -> Result<()> {
-    let range_check = super::increment_builtin_counter(context, entry, location, entry.arg(0)?)?;
-    let gas_builtin = entry.arg(1)?;
-    let segment_arena = super::increment_builtin_counter(context, entry, location, entry.arg(2)?)?;
+    let range_check = entry.arg(0)?;
+    let gas = entry.arg(1)?;
+    let segment_arena = entry.arg(2)?;
     let dict_ptr = entry.arg(3)?;
+
+    let segment_arena = super::increment_builtin_counter_by(
+        context,
+        entry,
+        location,
+        segment_arena,
+        SEGMENT_ARENA_BUILTIN_SIZE,
+    )?;
 
     let runtime_bindings = metadata
         .get_mut::<RuntimeBindingsMeta>()
         .to_native_assert_error("runtime library should be available")?;
 
-    let gas_refund = runtime_bindings
-        .dict_gas_refund(context, helper, entry, dict_ptr, location)?
-        .result(0)?
-        .into();
+    let range_check_ptr =
+        entry.alloca1(context, location, IntegerType::new(context, 64).into(), 0)?;
+    entry.store(context, location, range_check_ptr, range_check)?;
+    let gas_ptr = entry.alloca1(context, location, IntegerType::new(context, 64).into(), 0)?;
+    entry.store(context, location, gas_ptr, gas)?;
 
-    let new_gas_builtin = entry.addi(gas_builtin, gas_refund, location)?;
+    runtime_bindings.dict_squash(
+        context,
+        helper,
+        entry,
+        dict_ptr,
+        range_check_ptr,
+        gas_ptr,
+        location,
+    )?;
+
+    let range_check = entry.load(
+        context,
+        location,
+        range_check_ptr,
+        IntegerType::new(context, 64).into(),
+    )?;
+    let gas_builtin = entry.load(
+        context,
+        location,
+        gas_ptr,
+        IntegerType::new(context, 64).into(),
+    )?;
 
     helper.br(
         entry,
         0,
-        &[range_check, new_gas_builtin, segment_arena, entry.arg(3)?],
+        &[range_check, gas_builtin, segment_arena, entry.arg(3)?],
         location,
     )
 }
@@ -151,7 +181,9 @@ pub fn build_squash<'ctx, 'this>(
 #[cfg(test)]
 mod test {
     use crate::{
-        utils::test::{jit_dict, jit_enum, jit_struct, load_cairo, run_program_assert_output},
+        utils::test::{
+            jit_dict, jit_enum, jit_struct, load_cairo, run_program, run_program_assert_output,
+        },
         values::Value,
     };
 
@@ -337,5 +369,85 @@ mod test {
                 2 => jit_enum!(2, 3u128.into()),
             ),
         );
+    }
+
+    #[test]
+    fn run_dict_squash() {
+        let program = load_cairo! {
+            use core::dict::{Felt252Dict, Felt252DictEntryTrait, SquashedFelt252DictImpl};
+
+            pub fn main() {
+                // The squash libfunc has a fixed range check cost of 2.
+
+                // If no big keys, 3 per unique key access.
+                let mut dict: Felt252Dict<felt252> = Default::default();
+                dict.insert(1, 1); // 3
+                dict.insert(2, 2); // 3
+                dict.insert(3, 3); // 3
+                dict.insert(4, 4); // 3
+                dict.insert(5, 4); // 3
+                dict.insert(6, 4); // 3
+                let _ = dict.squash(); // 2
+                // SUBTOTAL: 20
+
+                // A dictionary has big keys if there is at least one key greater than
+                // the range check bound (2**128 - 1).
+
+                // If has big keys, 2 for first unique key access,
+                // and 6 each of the remaining unique key accesses.
+                let mut dict: Felt252Dict<felt252> = Default::default();
+                dict.insert(1, 1); // 2
+                dict.insert(0xF00000000000000000000000000000002, 1); // 6
+                dict.insert(3, 1); // 6
+                dict.insert(0xF00000000000000000000000000000004, 1); // 6
+                dict.insert(5, 1); // 6
+                dict.insert(0xF00000000000000000000000000000006, 1); // 6
+                dict.insert(7, 1); // 6
+                let _ = dict.squash(); // 2
+                // SUBTOTAL: 40
+
+
+                // If no big keys, 3 per unique key access.
+                // Each repeated key adds an extra range check usage.
+                let mut dict: Felt252Dict<felt252> = Default::default();
+                dict.insert(1, 1); // 3
+                dict.insert(2, 1); // 3
+                dict.insert(3, 1); // 3
+                dict.insert(4, 1); // 3
+                dict.insert(1, 1); // 1
+                dict.insert(2, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(2, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(2, 1); // 1
+                let _ = dict.squash(); // 2
+                // SUBTOTAL: 20
+
+
+                // If has big keys, 2 for first unique key access,
+                // and 6 each of the remaining unique key accesses.
+                // Each repeated key access adds an extra range check usage.
+                let mut dict: Felt252Dict<felt252> = Default::default();
+                dict.insert(1, 1); // 2
+                dict.insert(0xF00000000000000000000000000000002, 1); // 6
+                dict.insert(1, 1); // 1
+                dict.insert(0xF00000000000000000000000000000002, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(0xF00000000000000000000000000000002, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(0xF00000000000000000000000000000002, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(0xF00000000000000000000000000000002, 1); // 1
+                dict.insert(1, 1); // 1
+                dict.insert(0xF00000000000000000000000000000002, 1); // 1
+                let _ = dict.squash(); // 2
+                // SUBTOTAL: 20
+
+                // TOTAL: 100
+            }
+        };
+
+        let result = run_program(&program, "main", &[]);
+        assert_eq!(result.builtin_stats.range_check, 100);
     }
 }

--- a/src/metadata/runtime_bindings.rs
+++ b/src/metadata/runtime_bindings.rs
@@ -36,7 +36,7 @@ enum RuntimeBinding {
     EcPointFromXNz,
     DictNew,
     DictGet,
-    DictGasRefund,
+    DictSquash,
     DictDrop,
     DictDup,
     GetCostsBuiltin,
@@ -61,7 +61,7 @@ impl RuntimeBinding {
             RuntimeBinding::EcPointFromXNz => "cairo_native__libfunc__ec__ec_point_from_x_nz",
             RuntimeBinding::DictNew => "cairo_native__dict_new",
             RuntimeBinding::DictGet => "cairo_native__dict_get",
-            RuntimeBinding::DictGasRefund => "cairo_native__dict_gas_refund",
+            RuntimeBinding::DictSquash => "cairo_native__dict_squash",
             RuntimeBinding::DictDrop => "cairo_native__dict_drop",
             RuntimeBinding::DictDup => "cairo_native__dict_dup",
             RuntimeBinding::GetCostsBuiltin => "cairo_native__get_costs_builtin",
@@ -101,9 +101,7 @@ impl RuntimeBinding {
             }
             RuntimeBinding::DictNew => crate::runtime::cairo_native__dict_new as *const (),
             RuntimeBinding::DictGet => crate::runtime::cairo_native__dict_get as *const (),
-            RuntimeBinding::DictGasRefund => {
-                crate::runtime::cairo_native__dict_gas_refund as *const ()
-            }
+            RuntimeBinding::DictSquash => crate::runtime::cairo_native__dict_squash as *const (),
             RuntimeBinding::DictDrop => crate::runtime::cairo_native__dict_drop as *const (),
             RuntimeBinding::DictDup => crate::runtime::cairo_native__dict_dup as *const (),
             RuntimeBinding::GetCostsBuiltin => {
@@ -571,29 +569,26 @@ impl RuntimeBindingsMeta {
     ///
     /// Returns a u64 of the result.
     #[allow(clippy::too_many_arguments)]
-    pub fn dict_gas_refund<'c, 'a>(
+    pub fn dict_squash<'c, 'a>(
         &mut self,
         context: &'c Context,
         module: &Module,
         block: &'a Block<'c>,
-        dict_ptr: Value<'c, 'a>, // ptr to the dict
+        dict_ptr: Value<'c, 'a>,        // ptr to the dict
+        range_check_ptr: Value<'c, 'a>, // ptr to range check
+        gas_ptr: Value<'c, 'a>,         // ptr to gas
         location: Location<'c>,
     ) -> Result<OperationRef<'c, 'a>>
     where
         'c: 'a,
     {
-        let function = self.build_function(
-            context,
-            module,
-            block,
-            location,
-            RuntimeBinding::DictGasRefund,
-        )?;
+        let function =
+            self.build_function(context, module, block, location, RuntimeBinding::DictSquash)?;
 
         Ok(block.append_operation(
             OperationBuilder::new("llvm.call", location)
                 .add_operands(&[function])
-                .add_operands(&[dict_ptr])
+                .add_operands(&[dict_ptr, range_check_ptr, gas_ptr])
                 .add_results(&[IntegerType::new(context, 64).into()])
                 .build()?,
         ))
@@ -677,7 +672,7 @@ pub fn setup_runtime(find_symbol_ptr: impl Fn(&str) -> Option<*mut c_void>) {
         RuntimeBinding::EcPointFromXNz,
         RuntimeBinding::DictNew,
         RuntimeBinding::DictGet,
-        RuntimeBinding::DictGasRefund,
+        RuntimeBinding::DictSquash,
         RuntimeBinding::DictDrop,
         RuntimeBinding::DictDup,
         RuntimeBinding::GetCostsBuiltin,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn cairo_native__dict_squash(
 ) {
     let dict = Rc::from_raw(dict_ptr);
 
-    *gas_ptr -=
+    *gas_ptr +=
         (dict.count.saturating_sub(dict.mappings.len() as u64)) * *DICT_GAS_REFUND_PER_ACCESS;
 
     // Squashing a dictionary always uses the range check builtin at least twice.
@@ -883,10 +883,10 @@ mod tests {
         unsafe { *ptr = 42 };
 
         let mut range_check = 0;
-        let mut gas = 4050;
+        let mut gas = 0;
 
         unsafe { cairo_native__dict_squash(dict, &mut range_check, &mut gas) };
-        assert_eq!(gas, 0);
+        assert_eq!(gas, 4050);
 
         let cloned_dict = unsafe { cairo_native__dict_dup(dict) };
         unsafe { cairo_native__dict_drop(dict) };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -328,28 +328,38 @@ pub unsafe extern "C" fn cairo_native__dict_squash(
     // - If there are big keys:
     //   - the first unique key increases the range check by 2.
     //   - the remaining unique keys increase the range check by 6.
+
+    // The sierra-to-casm implementation calls the `SquashDict` after some initial validation.
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L159
+    //
+    // For each unique key, the `SquashDictInner` function is called, which
+    // loops over all accesses to that key. At the end, the function calls
+    // itself recursively until all keys have been iterated.
+
+    // If there are no big keys, the first range check usage is done by the
+    // caller of the inner function, which implies that it appears in two places:
+    // 1a. Once in `SquashDict`, right before calling the inner function for the first time.
+    //     https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L326
+    // 1b. Once at the end of `SquashDictInner`, right before recursing.
+    //     https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L507
     if no_big_keys {
-        // The first increase actually appears in two places:
-        // 1a. https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L326
-        // 1b. https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L507
-        // 2.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L416
-        // 3.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L480
-        *range_check_ptr += 3 * number_of_keys;
-    } else {
-        if number_of_keys > 0 {
-            // These increments are shared with the "no big keys" case.
-            // 2.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L416
-            // 3.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L480
-            *range_check_ptr += 2;
-        }
-        if number_of_keys > 1 {
-            // In addition to the increments for the first unique key, we also increase the range check 4 additional times:
-            // - https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs#L669-L674
-            *range_check_ptr += 6 * (number_of_keys - 1);
-        }
+        *range_check_ptr += 1 * number_of_keys;
     }
-    // For each non unique accessed key, we increase the range check once.
-    // - https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L602
+
+    // The next two range check usages are done always inside of the inner
+    // function (regardless of whether we have big keys or not).
+    // 2.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L416
+    // 3.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L480
+    *range_check_ptr += 2 * number_of_keys;
+
+    // If there are big keys, then we use the range check 4 additional times per key, except for the first key.
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs#L669-L674
+    if !no_big_keys && number_of_keys > 1 {
+        *range_check_ptr += 4 * (number_of_keys - 1);
+    }
+
+    // For each non unique accessed key, we increase the range check an additional time.
+    // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L602
     *range_check_ptr += dict.count.saturating_sub(dict.mappings.len() as u64);
 
     forget(dict);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn cairo_native__dict_squash(
         *range_check_ptr += 3 * number_of_keys;
     } else {
         if number_of_keys > 0 {
-            // These incremenets are shared with the "no big keys" case.
+            // These increments are shared with the "no big keys" case.
             // 2.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L416
             // 3.  https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L480
             *range_check_ptr += 2;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn cairo_native__dict_squash(
     // 1b. Once at the end of `SquashDictInner`, right before recursing.
     //     https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs?plain=1#L507
     if no_big_keys {
-        *range_check_ptr += 1 * number_of_keys;
+        *range_check_ptr += number_of_keys;
     }
 
     // The next two range check usages are done always inside of the inner


### PR DESCRIPTION
This PRs fixes felt252_dict_squash libfunc, so that it updates the range check builtin correctly.

Before this PR, we use to call `cairo_native__dict_gas_refund` for calculating how much gas to refund when squashing dictionaries. Now, we actually need to do update both the gas builtin and the range check builtin. As a C compatible rust function cannot return two different values, I renamed `cairo_native__dict_gas_refund` to `cairo_native__dict_squash`, and modified the signature so that it receives a pointers to the both builtins, allowing us to modify both values.

In addition to this signature change, I properly implemented the runtime function to update the range check correctly, and added a test that was validated with the CairoVM.

## Summary of the range check increment logic

The squash libfunc has a fixed range check cost of at least 2, even if its empty.

In addition to this, How we update the range check depends on whether we have any big key or not.
- If there are no big keys, every unique key increases the range check by 3.
- If there are big keys:
  - the first unique key increases the range check by 2.
  - the remaining unique keys increase the range check by 6.

In either case, every repeated key access increases the range check by 1.
