### PR TITLE
Fix is_not_i128 condition for overflowing operation libfunc

### DIFF
--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -647,8 +647,8 @@ fn build_operation<'ctx, 'this>(
         ));
 
         {
-            let is_not_i128 =
-                !(value_range.lower == i128::MIN.into() && value_range.upper == i128::MAX.into());
+            let is_not_i128 = !(value_range.lower == i128::MIN.into()
+                && value_range.upper - 1 == i128::MAX.into());
 
             // if we are not handling an i128 and the in_range condition is met, increase the range check builtin by 1:
             // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs#L105


### PR DESCRIPTION
The upper bound is exclusive, so the i128 range would be represented as `{ lower: i128::min, upper: i128::max + 1}`. 

Similarly, to check if a range is the same as the i128 range, we must check that `lower == i128::min`, and `upper - 1 == i128::max`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
