### PR TITLE
Rename `increment_builtin_counter_by_if` to `increment_builtin_counter_conditionally_by`

### DIFF
--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -497,7 +497,7 @@ fn increment_builtin_counter_by<'ctx: 'a, 'a>(
     ))
 }
 
-fn increment_builtin_counter_by_if<'ctx: 'a, 'a>(
+fn increment_builtin_counter_conditionally_by<'ctx: 'a, 'a>(
     context: &'ctx Context,
     block: &'ctx Block<'ctx>,
     location: Location<'ctx>,

--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -256,7 +256,7 @@ pub fn build_downcast<'ctx, 'this>(
             //   https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs#L87
             // * If it is not in bounds, increment the range check builtin by 3.
             //   https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs#L79
-            super::increment_builtin_counter_by_if(
+            super::increment_builtin_counter_conditionally_by(
                 context,
                 entry,
                 location,
@@ -279,7 +279,7 @@ pub fn build_downcast<'ctx, 'this>(
 
                     // If the result is in range, increment the range check builtin by 2. Otherwise, increment it by 1.
                     // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs#L160
-                    super::increment_builtin_counter_by_if(
+                    super::increment_builtin_counter_conditionally_by(
                         context,
                         entry,
                         location,

--- a/src/libfuncs/ec.rs
+++ b/src/libfuncs/ec.rs
@@ -4,7 +4,7 @@ use super::LibfuncHelper;
 use crate::{
     error::{Error, Result},
     execution_result::EC_OP_BUILTIN_SIZE,
-    libfuncs::increment_builtin_counter_by_if,
+    libfuncs::increment_builtin_counter_conditionally_by,
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     utils::{get_integer_layout, BlockExt, ProgramRegistryExt, PRIME},
 };
@@ -181,7 +181,7 @@ pub fn build_point_from_x<'ctx, 'this>(
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times if the
     // point is on the curve. Otherwise it is not used.
     // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs#L167
-    let range_check = increment_builtin_counter_by_if(
+    let range_check = increment_builtin_counter_conditionally_by(
         context,
         entry,
         location,

--- a/src/libfuncs/int.rs
+++ b/src/libfuncs/int.rs
@@ -491,7 +491,7 @@ fn build_from_felt252<'ctx, 'this>(
     // With the range check size being 2**128
     // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs#L26
     let rc_size = BigInt::from(1) << 128;
-    let range_check = super::increment_builtin_counter_by_if(
+    let range_check = super::increment_builtin_counter_conditionally_by(
         context,
         entry,
         location,
@@ -921,7 +921,7 @@ fn build_u128s_from_felt252<'ctx, 'this>(
     // The sierra-to-casm compiler uses the range check builtin a total of 3 times when the value is greater than u128 max.
     // Otherwise it will be used once.
     // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs#L234
-    let range_check = super::increment_builtin_counter_by_if(
+    let range_check = super::increment_builtin_counter_conditionally_by(
         context,
         entry,
         location,

--- a/src/libfuncs/uint256.rs
+++ b/src/libfuncs/uint256.rs
@@ -2,7 +2,7 @@
 
 use super::{BlockExt, LibfuncHelper};
 use crate::{
-    error::Result, libfuncs::increment_builtin_counter_by_if, metadata::MetadataStorage,
+    error::Result, libfuncs::increment_builtin_counter_conditionally_by, metadata::MetadataStorage,
     utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
@@ -933,7 +933,7 @@ pub fn build_u256_guarantee_inv_mod_n<'ctx, 'this>(
     // The sierra-to-casm compiler uses the range check builtin a total of 9 times if the inverse is
     // not equal to 0 and lhs is invertible. Otherwise it will be used 7 times.
     // https://github.com/starkware-libs/cairo/blob/v2.12.0-dev.1/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs#L21
-    let range_check = increment_builtin_counter_by_if(
+    let range_check = increment_builtin_counter_conditionally_by(
         context,
         entry,
         location,


### PR DESCRIPTION
Renames the function `increment_builtin_counter_by_if` to `increment_builtin_counter_conditionally_by`. I think the new name is easier to understand.

As the function was introduced by many different pull requests, it was better to wait until all those PRs were merged, and then rename the function in a different pull request.