### PR TITLE
Change sequencer's reference from replay to main-v0.14.0 in block's daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           repository: lambdaclass/sequencer
           path: sequencer
-          ref: replay
+          ref: main-v0.14.0
 
       - name: Restore RPC Calls
         id: restore-rpc-calls


### PR DESCRIPTION
The daily workflow is currently running with an old version of the sequencer. This causes it to have differences with the builtin counting. This PR updates it to the correct one.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
