### PR TITLE
Fix walk_mlir_operations with manual iterator

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -100,7 +100,6 @@ use mlir_sys::{
 use std::{
     cell::Cell,
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
-    ffi::c_void,
     ops::Deref,
 };
 
@@ -652,17 +651,11 @@ fn compile_func(
                     // When statistics are enabled, we iterate from the start
                     // to the end block of the compiled libfunc, and count all the operations.
                     if let Some(&mut ref mut stats) = stats {
-                        unsafe extern "C" fn callback(
-                            _: mlir_sys::MlirOperation,
-                            data: *mut c_void,
-                        ) -> mlir_sys::MlirWalkResult {
-                            let data = data.cast::<u128>().as_mut().unwrap();
-                            *data += 1;
-                            0
-                        }
-                        let data = walk_mlir_block(*block, *helper.last_block.get(), callback, 0);
+                        let mut operations = 0;
+                        walk_mlir_block(*block, *helper.last_block.get(), &mut |_| operations += 1);
                         let name = libfunc_to_name(libfunc).to_string();
-                        *stats.mlir_operations_by_libfunc.entry(name).or_insert(0) += data;
+
+                        *stats.mlir_operations_by_libfunc.entry(name).or_insert(0) += operations;
                     }
 
                     native_assert!(

--- a/src/context.rs
+++ b/src/context.rs
@@ -33,7 +33,7 @@ use mlir_sys::{
     mlirLLVMDIModuleAttrGet, MlirLLVMDIEmissionKind_MlirLLVMDIEmissionKindFull,
     MlirLLVMDINameTableKind_MlirLLVMDINameTableKindDefault,
 };
-use std::{ffi::c_void, sync::OnceLock, time::Instant};
+use std::{sync::OnceLock, time::Instant};
 
 /// Context of IRs, dialects and passes for Cairo programs compilation.
 #[derive(Debug, Eq, PartialEq)]
@@ -204,16 +204,9 @@ impl NativeContext {
         }
 
         if let Some(&mut ref mut stats) = stats {
-            unsafe extern "C" fn callback(
-                _: mlir_sys::MlirOperation,
-                data: *mut c_void,
-            ) -> mlir_sys::MlirWalkResult {
-                let data = data.cast::<u128>().as_mut().unwrap();
-                *data += 1;
-                0
-            }
-            let data = walk_mlir_operations(module.as_operation(), callback, 0);
-            stats.mlir_operation_count = Some(data)
+            let mut operations = 0;
+            walk_mlir_operations(module.as_operation(), &mut |_| operations += 1);
+            stats.mlir_operation_count = Some(operations)
         }
 
         let pre_mlir_passes_instant = Instant::now();

--- a/src/utils/walk_ir.rs
+++ b/src/utils/walk_ir.rs
@@ -1,5 +1,3 @@
-use std::ffi::c_void;
-
 use llvm_sys::{
     core::{
         LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstInstruction,
@@ -9,65 +7,51 @@ use llvm_sys::{
     LLVMBasicBlock, LLVMValue,
 };
 use melior::ir::{BlockLike, BlockRef, OperationRef};
-use mlir_sys::{MlirOperation, MlirWalkResult};
-
-type OperationWalkCallback =
-    unsafe extern "C" fn(MlirOperation, *mut ::std::os::raw::c_void) -> MlirWalkResult;
 
 /// Traverses the given operation tree in preorder.
 ///
-/// Calls `f` on each operation encountered. The second argument to `f` should
-/// be interpreted as a pointer to a value of type `T`.
-///
-/// TODO: Can we receive a closure instead?
-/// We may need to save a pointer to the closure
-/// inside of the callback data.
-pub fn walk_mlir_operations<T: Sized>(
-    top_op: OperationRef,
-    f: OperationWalkCallback,
-    initial: T,
-) -> T {
-    let mut data = Box::new(initial);
-    unsafe {
-        mlir_sys::mlirOperationWalk(
-            top_op.to_raw(),
-            Some(f),
-            data.as_mut() as *mut _ as *mut c_void,
-            mlir_sys::MlirWalkOrder_MlirWalkPreOrder,
-        );
-    };
-    *data
+/// Calls `f` on each operation encountered.
+pub fn walk_mlir_operations(top_op: OperationRef, f: &mut impl FnMut(OperationRef)) {
+    f(top_op);
+
+    for region in top_op.regions() {
+        let mut next_block = region.first_block();
+
+        while let Some(block) = next_block {
+            let mut next_operation = block.first_operation();
+
+            while let Some(operation) = next_operation {
+                walk_mlir_operations(operation, f);
+
+                // we have to convert it to raw, and back to ref to bypass borrow checker.
+                next_operation = unsafe {
+                    operation
+                        .next_in_block()
+                        .map(OperationRef::to_raw)
+                        .map(|op| OperationRef::from_raw(op))
+                }
+            }
+
+            next_block = block.next_in_region();
+        }
+    }
 }
 
 /// Traverses from start block to end block (including) in preorder.
 ///
-/// Calls `f` on each operation encountered. The second argument to `f` should
-/// be interpreted as a pointer to a value of type `T`.
-///
-/// TODO: Can we receive a closure instead?
-/// We may need to save a pointer to the closure
-/// inside of the callback data.
-pub fn walk_mlir_block<T: Sized>(
+/// Calls `f` on each operation encountered.
+pub fn walk_mlir_block(
     start_block: BlockRef,
     end_block: BlockRef,
-    f: OperationWalkCallback,
-    initial: T,
-) -> T {
-    let mut data = Box::new(initial);
+    f: &mut impl FnMut(OperationRef),
+) {
+    let mut next_block = Some(start_block);
 
-    let mut current_block = start_block;
-    loop {
-        let mut next_operation = current_block.first_operation();
+    while let Some(block) = next_block {
+        let mut next_operation = block.first_operation();
 
         while let Some(operation) = next_operation {
-            unsafe {
-                mlir_sys::mlirOperationWalk(
-                    operation.to_raw(),
-                    Some(f),
-                    data.as_mut() as *mut _ as *mut c_void,
-                    mlir_sys::MlirWalkOrder_MlirWalkPreOrder,
-                );
-            };
+            walk_mlir_operations(operation, f);
 
             // we have to convert it to raw, and back to ref to bypass borrow checker.
             next_operation = unsafe {
@@ -78,16 +62,12 @@ pub fn walk_mlir_block<T: Sized>(
             }
         }
 
-        if current_block == end_block {
-            break;
+        if block == end_block {
+            return;
         }
 
-        current_block = current_block
-            .next_in_region()
-            .expect("should always reach `end_block`");
+        next_block = block.next_in_region();
     }
-
-    *data
 }
 
 /// Traverses the whole LLVM Module, calling `f` on each instruction.


### PR DESCRIPTION
We used to call `mlir_sys::mlirOperationWalk` directly, which is provided by the MLIR library. This works great if we don't need to access operation attributes (for example, if we are just counting the number of operations).

For some reason, when trying to access the operation, segmentation fault occurs. I don't know what causes this. To fix it, is implemented the iterator manually, instead of relying on the already implemented function.

This approach also has the benefit of being able to use a closure instead of an extern function. So regardless of this bug, I think this new approach is better.