### PR TITLE
Update sequencer's and starknet replay's ref in starknet-blocks workflow and fix cmp_script

### DIFF
--- a/.github/workflows/starknet-blocks.yml
+++ b/.github/workflows/starknet-blocks.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: lambdaclass/starknet-replay
           path: starknet-replay
-          ref: 95c7e85f65acbf536462ffb538b866ddafb7ce39
+          ref: 208af485470515f8a1e826384f3e94842a65c5b0
       # We need native to use the linux deps ci action
       - name: Checkout Native
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: lambdaclass/sequencer
           path: sequencer
-          ref: c12c6a72f2375413fc5ba04e50af87ef21096784
+          ref: 0f69d1a56b949eccced10e3303109eb82ee92ec8
       - name: Cache RPC Calls
         uses: actions/cache@v4.2.0
         with:

--- a/scripts/cmp_state_dumps.py
+++ b/scripts/cmp_state_dumps.py
@@ -45,7 +45,9 @@ def compare(vm_dump_path: str):
         return ("MISS", block, tx)
 
     native_dump = re.sub(r".*reverted.*", "", native_dump, count=1)
+    native_dump = re.sub(r".*cairo_native.*", "", native_dump)
     vm_dump = re.sub(r".*reverted.*", "", vm_dump, count=1)
+    vm_dump = re.sub(r".*cairo_native.*", "", vm_dump)
 
     if native_dump == vm_dump:
         return ("MATCH", block, tx, vm_dump_path, native_dump_path)


### PR DESCRIPTION
This PR updates both the sequencer and the replays' ref in starknet-blocks workflow so that the point to the same ref as the daily workflow. Additionally, it change the cmp_state_dumps script to ignore the new introduced flag `cairo_native` which tells whether the entrypoint was run with cairo native or not.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
