### PR TITLE
Optimization: lazy conversion of circuit outputs to struct form

### DIFF
--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -464,12 +464,24 @@ fn build_eval<'ctx, 'this>(
     Ok(())
 }
 
-/// Builds the evaluation of all circuit gates, returning:
-/// - An array of two branches, the success block and the error block respectively.
-///   - The error block contains the index of the first failure as argument.
-/// - A vector of the gate values. In case of failure, not all values are guaranteed to be computed.
+/// Receives the circuit inputs, and buils the evaluation of the full circuit.
 ///
-/// The original Cairo hint evaluates all gates, even in case of failure. This implementation exits on first error, as there is no need for the partial outputs yet.
+/// Returns two branches. The success block and the error block respectively.
+/// - The success block receives nothing:
+/// - The error block receives:
+///   - The index of the first gate that could not be computed.
+///
+/// The evaluated gates are returned separately, as a vector of `MLIR` values.
+/// Note that in the case of error, not all MLIR values are guaranteed to have been computed,
+/// and should not be used carelessly.
+///
+/// TODO: Consider returning the evaluated gates through the block directly:
+/// - As a pointer to a heap allocated array of gates.
+/// - As a llvm struct/array of evaluted gates (its size could get really big).
+/// - As different arguments to the block (one argument per block).
+///
+/// The original Cairo hint evaluates all gates, even in case of failure.
+/// This implementation exits on first error, as there is no need for the partial outputs yet.
 fn build_gate_evaluation<'ctx, 'this>(
     context: &'this Context,
     mut block: &'this Block<'ctx>,

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -513,6 +513,7 @@ fn build_gate_evaluation<'ctx, 'this>(
         IntegerType::new(context, 64).into(),
         location,
     )]));
+    let ok_block = helper.append_block(Block::new(&[]));
 
     let mut add_offsets = circuit_info.add_offsets.iter().peekable();
     let mut mul_offsets = circuit_info.mul_offsets.iter().enumerate();
@@ -708,6 +709,8 @@ fn build_gate_evaluation<'ctx, 'this>(
         }
     }
 
+    block.append_operation(cf::br(ok_block, &[], location));
+
     // Validate all values have been calculated
     // Should only fail if the circuit is not solvable (bad form)
     let values = gates
@@ -716,7 +719,7 @@ fn build_gate_evaluation<'ctx, 'this>(
         .collect::<Option<Vec<Value>>>()
         .ok_or(SierraAssertError::ImpossibleCircuit)?;
 
-    Ok(([block, err_block], values))
+    Ok(([ok_block, err_block], values))
 }
 
 /// Generate MLIR operations for the `circuit_failure_guarantee_verify` libfunc.

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -464,7 +464,7 @@ fn build_eval<'ctx, 'this>(
 /// Receives the circuit inputs, and buils the evaluation of the full circuit.
 ///
 /// Returns two branches. The success block and the error block respectively.
-/// - The success block receives nothing:
+/// - The success block receives nothing.
 /// - The error block receives:
 ///   - The index of the first gate that could not be computed.
 ///
@@ -892,6 +892,7 @@ fn build_get_output<'ctx, 'this>(
         .values
         .get(output_type_id)
         .ok_or(SierraAssertError::BadTypeInfo)?;
+
     let output_idx = output_offset_idx - circuit_info.n_inputs - 1;
 
     let outputs = entry.arg(0)?;

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -313,7 +313,7 @@ fn build_eval<'ctx, 'this>(
     let circuit_data = entry.arg(3)?;
     let circuit_modulus = entry.arg(4)?;
 
-    // arguments 5 and 6 are used to build the gate 0 (with constant value 1)
+    // Arguments 5 and 6 are used to build the gate 0 (with constant value 1).
     // let zero = entry.argument(5)?;
     // let one = entry.argument(6)?;
 

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -383,7 +383,7 @@ fn build_eval<'ctx, 'this>(
             location,
         )?)?;
 
-        // Insert evaluated gated into the array.
+        // Insert evaluated gates into the array.
         for (i, gate) in gates.into_iter().enumerate() {
             let value_ptr = ok_block.gep(
                 context,
@@ -461,7 +461,7 @@ fn build_eval<'ctx, 'this>(
     Ok(())
 }
 
-/// Receives the circuit inputs, and buils the evaluation of the full circuit.
+/// Receives the circuit inputs, and builds the evaluation of the full circuit.
 ///
 /// Returns two branches. The success block and the error block respectively.
 /// - The success block receives nothing.
@@ -475,7 +475,7 @@ fn build_eval<'ctx, 'this>(
 /// TODO: Consider returning the evaluated gates through the block directly:
 /// - As a pointer to a heap allocated array of gates.
 /// - As a llvm struct/array of evaluted gates (its size could get really big).
-/// - As different arguments to the block (one argument per block).
+/// - As arguments to the block (one argument per block).
 ///
 /// The original Cairo hint evaluates all gates, even in case of failure.
 /// This implementation exits on first error, as there is no need for the partial outputs yet.

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -361,10 +361,6 @@ fn build_eval<'ctx, 'this>(
             circuit_info.mul_offsets.len() * MUL_MOD_BUILTIN_SIZE,
         )?;
 
-        // TODO: We are saving the whole circuit. We should only save the gates
-        // that will be queried later. We are also saving them in integer form,
-        // and should probably be saved in struct form.
-
         // Calculate capacity for array.
         let outputs_capacity = circuit_info.values.len();
         let u384_integer_layout = get_integer_layout(384);

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -717,13 +717,13 @@ fn build_gate_evaluation<'ctx, 'this>(
 
     // Validate all values have been calculated
     // Should only fail if the circuit is not solvable (bad form)
-    let values = gates
+    let evaluated_gates = gates
         .into_iter()
         .skip(1 + circuit_info.n_inputs)
         .collect::<Option<Vec<Value>>>()
         .ok_or(SierraAssertError::ImpossibleCircuit)?;
 
-    Ok(([ok_block, err_block], values))
+    Ok(([ok_block, err_block], evaluated_gates))
 }
 
 /// Generate MLIR operations for the `circuit_failure_guarantee_verify` libfunc.

--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -524,10 +524,10 @@ fn build_gate_evaluation<'ctx, 'this>(
     // We loop until all gates have been solved
     loop {
         // We iterate the add gate offsets as long as we can
-        while let Some(&add_gate_offset) = add_offsets.peek() {
-            let lhs_value = values[add_gate_offset.lhs].to_owned();
-            let rhs_value = values[add_gate_offset.rhs].to_owned();
-            let output_value = values[add_gate_offset.output].to_owned();
+        while let Some(&gate_offset) = add_offsets.peek() {
+            let lhs_value = gates[gate_offset.lhs].to_owned();
+            let rhs_value = gates[gate_offset.rhs].to_owned();
+            let output_value = gates[gate_offset.output].to_owned();
 
             // Depending on the values known at the time, we can deduce if we are dealing with an ADD gate or a SUB gate.
             match (lhs_value, rhs_value, output_value) {
@@ -556,7 +556,7 @@ fn build_gate_evaluation<'ctx, 'this>(
                     // Truncate back
                     let value =
                         block.trunci(value, IntegerType::new(context, 384).into(), location)?;
-                    values[add_gate_offset.output] = Some(value);
+                    gates[gate_offset.output] = Some(value);
                 }
                 // SUB: lhs = out - rhs
                 (None, Some(rhs_value), Some(output_value)) => {
@@ -584,7 +584,7 @@ fn build_gate_evaluation<'ctx, 'this>(
                     // Truncate back
                     let value =
                         block.trunci(value, IntegerType::new(context, 384).into(), location)?;
-                    values[add_gate_offset.lhs] = Some(value);
+                    gates[gate_offset.lhs] = Some(value);
                 }
                 // We can't solve this add gate yet, so we break from the loop
                 _ => break,

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -278,9 +278,12 @@ pub fn build_circuit_data<'ctx>(
 ///
 /// ## Layout:
 ///
-/// Holds 1 + N_VALUES + N_INPUTS elements, where each element is an u384 integer (u384i),
+/// Holds the evaluated circuit output gates and the circuit modulus.
+/// - The data is stored as a dynamic array of u384 integers (i384i).
+/// - The modulus is stored as a u384 in struct form (u384s).
 ///
-/// Also holds the modulus as a u384 struct. An u384 struct (u348s) contains 4 limbs, each a u96 integer.
+/// TODO: Right know, the data array holds N_VALUES elements.
+/// We should store only the elements that will be queried later.
 ///
 /// ```txt
 /// type = struct {

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -279,19 +279,16 @@ pub fn build_circuit_data<'ctx>(
 /// ## Layout:
 ///
 /// Holds the evaluated circuit output gates and the circuit modulus.
-/// - The data is stored as a dynamic array of u384 integers (i384i).
-/// - The modulus is stored as a u384 in struct form (u384s).
-///
-/// TODO: Right know, the data array holds N_VALUES elements.
-/// We should store only the elements that will be queried later.
+/// - The data is stored as a dynamic array of u384 integers.
+/// - The modulus is stored as a u384 in struct form (multi-limb).
 ///
 /// ```txt
 /// type = struct {
-///     data: *u384i,
-///     modulus: u384s,
+///     data: *u384,
+///     modulus: u384struct,
 /// };
 ///
-/// u384s = struct {
+/// u384struct = struct {
 ///     limb1: u96,
 ///     limb2: u96,
 ///     limb3: u96,

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -278,12 +278,13 @@ pub fn build_circuit_data<'ctx>(
 ///
 /// ## Layout:
 ///
-/// Holds N_VALUES elements, where each element is a u384 struct,
-/// A u384 struct contains 4 limbs, each a u96 integer.
+/// Holds 1 + N_VALUES + N_INPUTS elements, where each element is an u384 integer (u384i),
+///
+/// Also holds the modulus as a u384 struct. An u384 struct (u348s) contains 4 limbs, each a u96 integer.
 ///
 /// ```txt
 /// type = struct {
-///     data: *u384s,
+///     data: *u384i,
 ///     modulus: u384s,
 /// };
 ///

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -342,7 +342,7 @@ pub fn build_circuit_outputs<'ctx>(
                 &entry,
                 location,
                 gates_ptr,
-                circuit.circuit_info.values.len() + circuit.circuit_info.n_inputs + 1,
+                circuit.circuit_info.values.len(),
                 u384_integer_layout,
             )?;
 

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -331,15 +331,15 @@ pub fn build_circuit_outputs<'ctx>(
                 0,
             )?;
 
-            let u384_struct_layout = layout_repeat(&get_integer_layout(96), 4)?.0;
+            let u384_integer_layout = get_integer_layout(384);
 
             let new_gates_ptr = build_array_dup(
                 context,
                 &entry,
                 location,
                 gates_ptr,
-                circuit.circuit_info.values.len(),
-                u384_struct_layout,
+                circuit.circuit_info.values.len() + circuit.circuit_info.n_inputs + 1,
+                u384_integer_layout,
             )?;
 
             let new_outputs = entry.insert_value(context, location, outputs, new_gates_ptr, 0)?;


### PR DESCRIPTION
Instead of converting gate values from integer to struct form in the circuit_eval libfunc, they are lazily converted in the get_output libfunc. This avoids converting gate values that will never be read.

Also, adds some documentation to the circuit lowering.

This PR contains one of the optimizations included in https://github.com/lambdaclass/cairo_native/pull/1344. It seems that the other optimization (dynamic array while evaluating circuit) doesn't improve compilation, so there is no need to merge it for now.

# Benchmark

These benchmarks were executed in a Macbook M4 Pro.

I compiled several circuit-heavy contract classes, and compared the compilation time before and this PR. The contract classes were compiled with optimization level -O2.

| Class Hash | Before | After | Improvement |
| ---------- | ------ | ----- | ----------- |
| 0x1b5fbe10... | 42821 | 35357 | 1.21x |
| 0x3100defc... | 42059 | 34638 | 1.21x |
| 0x79666cdb... | 40039 | 33334 | 1.20x |
| 0xa40ecaa0... | 41878 | 35094 | 1.19x |
| 0x4ffeed29... | 50508 | 40952 | 1.23x |
| 0x2269858a... | 46784 | 38624 | 1.21x |
| 0x5ff378cb... | 42489 | 35061 | 1.21x |
| 0x4edde37c... | 42799 | 35632 | 1.20x |
