### PR TITLE
Save total compilation time statistic in cairo-native-compile binary

### DIFF
--- a/src/bin/cairo-native-compile.rs
+++ b/src/bin/cairo-native-compile.rs
@@ -9,6 +9,7 @@ use std::{
     fs::{self, File},
     path::PathBuf,
     sync::Arc,
+    time::Instant,
 };
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
@@ -79,6 +80,8 @@ fn main() -> anyhow::Result<()> {
     let mut stats_with_path = args.stats_path.map(|path| (Statistics::default(), path));
     let stats = stats_with_path.as_mut().map(|v| &mut v.0);
 
+    let pre_compilation_instant = Instant::now();
+
     // Compile the sierra program into a MLIR module.
     let native_context = NativeContext::new();
     let native_module = native_context
@@ -101,8 +104,13 @@ fn main() -> anyhow::Result<()> {
         clone_option_mut!(stats),
     )
     .context("Failed to convert MLIR to object.")?;
-    object_to_shared_lib(&object_data, &args.output_library, stats)
+    object_to_shared_lib(&object_data, &args.output_library, clone_option_mut!(stats))
         .context("Failed to write shared library.")?;
+
+    let compilation_time = pre_compilation_instant.elapsed().as_millis();
+    if let Some(&mut ref mut stats) = stats {
+        stats.compilation_total_time_ms = Some(compilation_time);
+    }
 
     if let Some((stats, stats_path)) = stats_with_path {
         fs::write(stats_path, serde_json::to_string_pretty(&stats)?)?;


### PR DESCRIPTION
This PR adds support for saving total compilation time statistic in the cairo-native-compile binary.