### PR TITLE
Skip zero-sized fields when building structs

### DIFF
--- a/src/libfuncs/struct.rs
+++ b/src/libfuncs/struct.rs
@@ -87,11 +87,6 @@ pub fn build_struct_value<'ctx, 'this>(
 ) -> Result<Value<'ctx, 'this>> {
     let struct_ty = registry.build_type(context, helper, metadata, struct_type)?;
 
-    let mut accumulator = entry
-        .append_operation(llvm::undef(struct_ty, location))
-        .result(0)?
-        .into();
-
     let struct_type = registry.get_type(struct_type)?;
 
     // LLVM fails when inserting zero-sized types into a struct.
@@ -114,6 +109,7 @@ pub fn build_struct_value<'ctx, 'this>(
         }
     };
 
+    let mut accumulator = entry.append_op_result(llvm::undef(struct_ty, location))?;
     for (idx, field) in fields.iter().enumerate() {
         if zst_fields[idx] {
             continue;


### PR DESCRIPTION
# Skip zero-sized fields when building structs

The contract class `0x013d9aacaccd717d2663692546631b60f355684067f0ee55c0072d0c95995c7c` fails to compile with Native, due to a LLVM bug: https://github.com/llvm/llvm-project/issues/107198. The bug fix has been included in LLVM 20, but not in LLVM 19.

This PR fixes this bug by skipping the insertion of zero-sized fields.

With this PR, compiling the contract class doesn't fail. We should still replay some blocks to ensure nothing is broken with this fix.

## Introduces Breaking Changes?

No.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
