### PR TITLE
Prepare for 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-native"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "casm-data-flow"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bincode",
  "cairo-lang-casm",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "debug_utils"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cairo-lang-starknet-classes",
  "clap",
@@ -3365,7 +3365,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sierra-emu"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-filesystem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo_native"
@@ -189,7 +189,7 @@ harness = false
 members = ["debug_utils", "debug_utils/sierra-emu", "debug_utils/casm-data-flow"]
 
 [workspace.dependencies]
-sierra-emu = { path = "debug_utils/sierra-emu", version = "0.6.1" }
+sierra-emu = { path = "debug_utils/sierra-emu", version = "0.6.2" }
 cairo-lang-casm = "~2.12.3"
 cairo-lang-compiler = "~2.12.3"
 cairo-lang-defs = "~2.12.3"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ often so use it at your own risk. 🚧
 
 For versions under `1.0` `cargo` doesn't comply with
 [semver](https://semver.org/), so we advise to pin the version you
-use. This can be done by adding `cairo-native = "0.6.1"` to your Cargo.toml
+use. This can be done by adding `cairo-native = "0.6.2"` to your Cargo.toml
 
 ## Getting Started
 


### PR DESCRIPTION
# Prepare for 0.6.2

- Reverts circuit optimization: https://github.com/lambdaclass/cairo_native/pull/1397
- Bumps Cairo dependencies: https://github.com/lambdaclass/cairo_native/pull/1398
