### PR TITLE
Remove unwrap in gas metadata

### DIFF
--- a/binaries/cairo-native-bin-utils/src/test.rs
+++ b/binaries/cairo-native-bin-utils/src/test.rs
@@ -259,6 +259,7 @@ pub fn run_tests(
                     .or_else(|| {
                         gas_metadata
                             .initial_required_gas(&func.id)
+                            .unwrap()
                             .map(|gas| gas.try_into().unwrap())
                     });
 

--- a/src/metadata/gas.rs
+++ b/src/metadata/gas.rs
@@ -23,7 +23,10 @@ use cairo_lang_sierra_to_casm::metadata::{
     MetadataComputationConfig, MetadataError as CairoGasMetadataError,
 };
 
-use crate::{error::Result as NativeResult, native_panic};
+use crate::{
+    error::{Error, Result as NativeResult},
+    native_panic,
+};
 
 use std::{collections::BTreeMap, fmt, ops::Deref};
 
@@ -69,7 +72,7 @@ impl GasMetadata {
         &self,
         func: &FunctionId,
         available_gas: Option<u64>,
-    ) -> Result<u64, GasMetadataError> {
+    ) -> Result<u64, Error> {
         let Some(available_gas) = available_gas else {
             return Ok(0);
         };
@@ -77,31 +80,35 @@ impl GasMetadata {
         // In case we don't have any costs - it means no gas equations were solved (and we are in
         // the case of no gas checking enabled) - so the gas builtin is irrelevant, and we
         // can return any value.
-        let Some(required_gas) = self.initial_required_gas(func) else {
+        let Some(required_gas) = self.initial_required_gas(func)? else {
             return Ok(0);
         };
 
         available_gas
             .checked_sub(required_gas)
-            .ok_or(GasMetadataError::NotEnoughGas {
+            .ok_or(Error::GasMetadataError(GasMetadataError::NotEnoughGas {
                 gas: Box::new((required_gas, available_gas)),
-            })
+            }))
     }
 
-    pub fn initial_required_gas(&self, func: &FunctionId) -> Option<u64> {
+    pub fn initial_required_gas(&self, func: &FunctionId) -> Result<Option<u64>, Error> {
         if self.gas_info.function_costs.is_empty() {
-            return None;
+            return Ok(None);
         }
-        Some(
+        Ok(Some(
             self.gas_info.function_costs[func]
                 .iter()
                 .map(|(token_type, val)| {
-                    TryInto::<usize>::try_into(*val)
-                        .expect("could not cast gas cost from i64 to usize")
-                        * token_gas_cost(*token_type)
+                    let Ok(val) = TryInto::<usize>::try_into(*val) else {
+                        native_panic!("could not cast gas cost from i64 to usize");
+                    };
+
+                    Ok(val * token_gas_cost(*token_type))
                 })
+                .collect::<Result<Vec<_>, _>>()?
+                .iter()
                 .sum::<usize>() as u64,
-        )
+        ))
     }
 
     pub fn initial_required_gas_for_entry_points(


### PR DESCRIPTION
# Remove unwrap in gas metadata

Closes #NA

This PR remove an unwrap when calculating the initial gas required for a program. Even though it should be unreachable, need should not panic

## Introduces Breaking Changes?

No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
