### PR TITLE
Fix `felt_const` arithmetic operations

### DIFF
--- a/src/libfuncs/felt252.rs
+++ b/src/libfuncs/felt252.rs
@@ -3,7 +3,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::Result,
-    metadata::{ MetadataStorage},
+    metadata::MetadataStorage,
     utils::{ProgramRegistryExt, PRIME},
 };
 use cairo_lang_sierra::{
@@ -81,11 +81,9 @@ pub fn build_binary_operation<'ctx, 'this>(
         }
         Felt252BinaryOperationConcrete::WithConst(operation) => {
             let value = match operation.c.sign() {
-                Sign::Minus => {
-                    (BigInt::from_biguint(Sign::Plus, PRIME.clone()) + &operation.c)
-                        .magnitude()
-                        .clone()
-                }
+                Sign::Minus => (BigInt::from_biguint(Sign::Plus, PRIME.clone()) + &operation.c)
+                    .magnitude()
+                    .clone(),
                 _ => operation.c.magnitude().clone(),
             };
 
@@ -697,7 +695,8 @@ pub mod test {
             jit_struct!(
                 f("0").into(),
                 f("1").into(),
-                f("1809251394333065606848661391547535052811553607665798349986546028067936010240").into(),
+                f("1809251394333065606848661391547535052811553607665798349986546028067936010240")
+                    .into(),
                 f("-1").into(),
                 f("1").into(),
                 f("-1").into(),

--- a/src/libfuncs/felt252.rs
+++ b/src/libfuncs/felt252.rs
@@ -423,7 +423,24 @@ pub mod test {
         static ref FELT252_DIV_CONST: (String, Program) = load_cairo! {
             extern fn felt252_div_const<const rhs: felt252>(lhs: felt252) -> felt252 nopanic;
 
-            fn run_test() -> (felt252, felt252, felt252, felt252, felt252, felt252, felt252) {
+            fn run_test() -> (
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252,
+                felt252
+            ) {
                 (
                     felt252_div_const::<1>(0),
                     felt252_div_const::<1>(1),
@@ -432,6 +449,15 @@ pub mod test {
                     felt252_div_const::<-1>(-1),
                     felt252_div_const::<-1>(1),
                     felt252_div_const::<1>(-1),
+                    felt252_div_const::<500>(1000),
+                    felt252_div_const::<256>(1024),
+                    felt252_div_const::<-256>(1024),
+                    felt252_div_const::<256>(-1024),
+                    felt252_div_const::<-256>(-1024),
+                    felt252_div_const::<8>(64),
+                    felt252_div_const::<8>(-64),
+                    felt252_div_const::<-8>(64),
+                    felt252_div_const::<-8>(-64),
                 )
             }
         };
@@ -701,6 +727,15 @@ pub mod test {
                 f("1").into(),
                 f("-1").into(),
                 f("-1").into(),
+                f("2").into(),
+                f("4").into(),
+                f("-4").into(),
+                f("-4").into(),
+                f("4").into(),
+                f("8").into(),
+                f("-8").into(),
+                f("-8").into(),
+                f("8").into(),
             )
         );
     }

--- a/src/libfuncs/felt252.rs
+++ b/src/libfuncs/felt252.rs
@@ -3,7 +3,7 @@
 use super::LibfuncHelper;
 use crate::{
     error::Result,
-    metadata::MetadataStorage,
+    metadata::{ MetadataStorage},
     utils::{ProgramRegistryExt, PRIME},
 };
 use cairo_lang_sierra::{
@@ -81,9 +81,11 @@ pub fn build_binary_operation<'ctx, 'this>(
         }
         Felt252BinaryOperationConcrete::WithConst(operation) => {
             let value = match operation.c.sign() {
-                Sign::Minus => (&operation.c + BigInt::from_biguint(Sign::Minus, PRIME.clone()))
-                    .magnitude()
-                    .clone(),
+                Sign::Minus => {
+                    (BigInt::from_biguint(Sign::Plus, PRIME.clone()) + &operation.c)
+                        .magnitude()
+                        .clone()
+                }
                 _ => operation.c.magnitude().clone(),
             };
 
@@ -329,7 +331,7 @@ pub fn build_is_zero<'ctx, 'this>(
 #[cfg(test)]
 pub mod test {
     use crate::{
-        utils::test::{load_cairo, run_program},
+        utils::test::{jit_struct, load_cairo, run_program},
         values::Value,
     };
     use cairo_lang_sierra::program::Program;
@@ -342,30 +344,21 @@ pub mod test {
                 lhs + rhs
             }
         };
-
         static ref FELT252_SUB: (String, Program) = load_cairo! {
             fn run_test(lhs: felt252, rhs: felt252) -> felt252 {
                 lhs - rhs
             }
         };
-
         static ref FELT252_MUL: (String, Program) = load_cairo! {
             fn run_test(lhs: felt252, rhs: felt252) -> felt252 {
                 lhs * rhs
             }
         };
-
         static ref FELT252_DIV: (String, Program) = load_cairo! {
             fn run_test(lhs: felt252, rhs: felt252) -> felt252 {
                 felt252_div(lhs, rhs.try_into().unwrap())
             }
         };
-
-        // TODO: Add test program for `felt252_add_const`. See: https://github.com/lambdaclass/cairo_native/issues/1214
-        // TODO: Add test program for `felt252_sub_const`. See: https://github.com/lambdaclass/cairo_native/issues/1214
-        // TODO: Add test program for `felt252_mul_const`. See: https://github.com/lambdaclass/cairo_native/issues/1214
-        // TODO: Add test program for `felt252_div_const`. See: https://github.com/lambdaclass/cairo_native/issues/1214
-
         static ref FELT252_CONST: (String, Program) = load_cairo! {
             extern fn felt252_const<const value: felt252>() -> felt252 nopanic;
 
@@ -378,7 +371,72 @@ pub mod test {
                 )
             }
         };
+        static ref FELT252_ADD_CONST: (String, Program) = load_cairo! {
+            extern fn felt252_add_const<const rhs: felt252>(lhs: felt252) -> felt252 nopanic;
 
+            fn run_test() -> (felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252) {
+                (
+                    felt252_add_const::<0>(0),
+                    felt252_add_const::<0>(1),
+                    felt252_add_const::<1>(0),
+                    felt252_add_const::<1>(1),
+                    felt252_add_const::<0>(-1),
+                    felt252_add_const::<-1>(0),
+                    felt252_add_const::<-1>(-1),
+                    felt252_add_const::<-1>(1),
+                    felt252_add_const::<1>(-1),
+                )
+            }
+        };
+        static ref FELT252_SUB_CONST: (String, Program) = load_cairo! {
+            extern fn felt252_sub_const<const rhs: felt252>(lhs: felt252) -> felt252 nopanic;
+
+            fn run_test() -> (felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252) {
+                (
+                    felt252_sub_const::<0>(0),
+                    felt252_sub_const::<0>(1),
+                    felt252_sub_const::<1>(0),
+                    felt252_sub_const::<1>(1),
+                    felt252_sub_const::<0>(-1),
+                    felt252_sub_const::<-1>(0),
+                    felt252_sub_const::<-1>(-1),
+                    felt252_sub_const::<-1>(1),
+                    felt252_sub_const::<1>(-1),
+                )
+            }
+        };
+        static ref FELT252_MUL_CONST: (String, Program) = load_cairo! {
+            extern fn felt252_mul_const<const rhs: felt252>(lhs: felt252) -> felt252 nopanic;
+
+            fn run_test() -> (felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252, felt252) {
+                (
+                    felt252_mul_const::<0>(0),
+                    felt252_mul_const::<0>(1),
+                    felt252_mul_const::<1>(0),
+                    felt252_mul_const::<1>(1),
+                    felt252_mul_const::<2>(-1),
+                    felt252_mul_const::<-2>(2),
+                    felt252_mul_const::<-1>(-1),
+                    felt252_mul_const::<-1>(1),
+                    felt252_mul_const::<1>(-1),
+                )
+            }
+        };
+        static ref FELT252_DIV_CONST: (String, Program) = load_cairo! {
+            extern fn felt252_div_const<const rhs: felt252>(lhs: felt252) -> felt252 nopanic;
+
+            fn run_test() -> (felt252, felt252, felt252, felt252, felt252, felt252, felt252) {
+                (
+                    felt252_div_const::<1>(0),
+                    felt252_div_const::<1>(1),
+                    felt252_div_const::<2>(-1),
+                    felt252_div_const::<-2>(2),
+                    felt252_div_const::<-1>(-1),
+                    felt252_div_const::<-1>(1),
+                    felt252_div_const::<1>(-1),
+                )
+            }
+        };
         static ref FELT252_IS_ZERO: (String, Program) = load_cairo! {
             fn run_test(x: felt252) -> bool {
                 match x {
@@ -575,6 +633,76 @@ pub mod test {
                     .to_vec(),
                 debug_name: None
             }
+        );
+    }
+
+    #[test]
+    fn felt252_add_const() {
+        assert_eq!(
+            run_program(&FELT252_ADD_CONST, "run_test", &[]).return_value,
+            jit_struct!(
+                f("0").into(),
+                f("1").into(),
+                f("1").into(),
+                f("2").into(),
+                f("-1").into(),
+                f("-1").into(),
+                f("-2").into(),
+                f("0").into(),
+                f("0").into(),
+            )
+        );
+    }
+
+    #[test]
+    fn felt252_sub_const() {
+        assert_eq!(
+            run_program(&FELT252_SUB_CONST, "run_test", &[]).return_value,
+            jit_struct!(
+                f("0").into(),
+                f("1").into(),
+                f("-1").into(),
+                f("0").into(),
+                f("-1").into(),
+                f("1").into(),
+                f("0").into(),
+                f("2").into(),
+                f("-2").into(),
+            )
+        );
+    }
+
+    #[test]
+    fn felt252_mul_const() {
+        assert_eq!(
+            run_program(&FELT252_MUL_CONST, "run_test", &[]).return_value,
+            jit_struct!(
+                f("0").into(),
+                f("0").into(),
+                f("0").into(),
+                f("1").into(),
+                f("-2").into(),
+                f("-4").into(),
+                f("1").into(),
+                f("-1").into(),
+                f("-1").into(),
+            )
+        );
+    }
+
+    #[test]
+    fn felt252_div_const() {
+        assert_eq!(
+            run_program(&FELT252_DIV_CONST, "run_test", &[]).return_value,
+            jit_struct!(
+                f("0").into(),
+                f("1").into(),
+                f("1809251394333065606848661391547535052811553607665798349986546028067936010240").into(),
+                f("-1").into(),
+                f("1").into(),
+                f("-1").into(),
+                f("-1").into(),
+            )
         );
     }
 


### PR DESCRIPTION
# Fix felt_const arithmetic operations.

Closes #1214 
Closes #143

This PR fixes felt_const operations. The error was rising because we were converting the const operation incorrectly. In addition to this fix, I added the missing tests for every operation.

## Introduces Breaking Changes?

No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [x] Linked to Github Issue.
- [x] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
