### PR TITLE
Remove todo for struct `U256`

### DIFF
--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -53,7 +53,6 @@ impl From<&Felt252Abi> for Felt {
 }
 
 /// Binary representation of a `u256` (in MLIR).
-// TODO: This shouldn't need to be public. See: https://github.com/lambdaclass/cairo_native/issues/1221
 #[derive(
     Debug,
     Clone,


### PR DESCRIPTION
# Remove todo for struct `U256`

Closes #NA

This PR remove a TODO for struct U256 as we agreed it is not actually necessary. 

## Introduces Breaking Changes?

No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
