### PR TITLE
Rename udeps job to unused-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
             <!-- thiscommentistofindthisformatcomment -->
           edit-mode: replace
 
-  # Check for unnecessary dependencies.
   unused-deps:
+    name: No unused dependencies
     runs-on: ubuntu-24.04
     env:
       MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/


### PR DESCRIPTION
# Rename udeps job to unused-deps

We should update the configuration to make this job required.
