### PR TITLE
Prepare for publishing starknet-native-compile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
+      - name: publish starknet-native-compile
+        run: cargo publish --token ${CRATES_TOKEN} --all-features -p starknet-native-compile
       - name: publish sierra emu
         run: cargo publish --token ${CRATES_TOKEN} --all-features -p sierra-emu
       - name: publish cairo native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-native-compile"
-version = "0.0.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cairo-lang-sierra",

--- a/binaries/starknet-native-compile/Cargo.toml
+++ b/binaries/starknet-native-compile/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "starknet-native-compile"
+readme = "README.md"
+description = "A binary for compiling Sierra contracts with Cairo Native"
+version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/binaries/starknet-native-compile/README.md
+++ b/binaries/starknet-native-compile/README.md
@@ -1,0 +1,17 @@
+# Starknet Native Compile
+
+A binary for compiling Sierra contracts with [Cairo Native](https://lambdaclass.github.io/cairo_native/cairo_native/).
+
+## Requirements
+
+See [Cairo Native's instructions](https://lambdaclass.github.io/cairo_native/cairo_native/#getting-started) on how to build this binary properly.
+
+## Usage
+
+First, compile a sierra contract class with starknet-native-compile. The contract class format should be compatible with [cairo_lang_starknet_classes::contract_class::ContractClass](https://docs.rs/cairo-lang-starknet-classes/*/cairo_lang_starknet_classes/contract_class/struct.ContractClass.html).
+
+```bash
+starknet-native-compile <CONTRACT_CLASS> <OUTPUT_LIBRARY>
+```
+
+Then, load and execute the shared library with [cairo_native::executor::AotContractExecutor](https://lambdaclass.github.io/cairo_native/cairo_native/executor/struct.AotContractExecutor.html).


### PR DESCRIPTION
# Prepare for publishing starknet-native-compile

- Updates the release workflow to publish starknet-native-compile
- Adds very simple README and package metadata
