### PR TITLE
Fix BoundedInt Constrain libfunc

### DIFF
--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -1113,6 +1113,19 @@ mod test {
                     Err(gt0) => gt0,
                 }
             }
+
+            impl ConstrainTest5 of ConstrainHelper<BoundedInt<30, 100>, 100> {
+                type LowT = BoundedInt<30, 99>;
+                type HighT = BoundedInt<100, 100>;
+            }
+
+            fn run_test_11(a: felt252) -> BoundedInt<100, 100> {
+                let a_bi: BoundedInt<30, 100> = a.try_into().unwrap();
+                match constrain::<_, 100>(a_bi) {
+                    Ok(_lt0) => panic!(),
+                    Err(gt0) => gt0,
+                }
+            }
         };
 
         let result = run_program(&program, "run_test_1", &[Value::Sint8(-1)]).return_value;
@@ -1259,6 +1272,23 @@ mod test {
                 range: Range {
                     lower: BigInt::from(-150),
                     upper: BigInt::from(-99),
+                },
+            },
+        );
+
+        let result = run_program(
+            &program,
+            "run_test_11",
+            &[Value::Felt252(Felt252::from(100))],
+        )
+        .return_value;
+        assert_constrain_output(
+            result,
+            Value::BoundedInt {
+                value: Felt252::from(100),
+                range: Range {
+                    lower: BigInt::from(100),
+                    upper: BigInt::from(101),
                 },
             },
         );


### PR DESCRIPTION
# Fix BoundedInt Constrain libfunc

We were not contemplating the case where the libfunc `bounded_int_constrain()` could receive a bounded int. Now, that case is handled by moving the boundary to the same range the bounded int is and using the same offset to represent it.

Co-authored-by: @JulianGCalderon 
Co-authored-by: @FrancoGiachetta 

Closes #NA

<!--
Description of the pull request changes and motivation.
-->

## Introduces Breaking Changes?

Yes/No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
