### PR TITLE
Fix BoundedInt is_zero libfunc

### DIFF
--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -816,6 +816,8 @@ fn build_is_zero<'ctx, 'this>(
     );
 
     let k0 = if src_ty.is_bounded_int(registry)? {
+        // We can do the substraction since the lower bound of the bounded int will
+        // always be less or equal than 0.
         entry.const_int_from_type(context, location, 0 - src_range.lower, src_value.r#type())?
     } else {
         entry.const_int_from_type(context, location, 0, src_value.r#type())?


### PR DESCRIPTION
# Fix BoundedInt is_zero libfunc

When using `bounded_int_is_zero()` libfunc with bounded ints that had a lower bound different than 0, we were not taking into account the offset used so it was not working properly.

Closes #NA

<!--
Description of the pull request changes and motivation.
-->

## Introduces Breaking Changes?

Yes/No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
