### PR TITLE
Fix upcast for bounded ints

### DIFF
--- a/src/libfuncs/cast.rs
+++ b/src/libfuncs/cast.rs
@@ -372,7 +372,7 @@ pub fn build_upcast<'ctx, 'this>(
             };
             let signed_dst_contains_src = signed_dst_range.lower <= src_range.lower
                 && signed_dst_range.upper >= src_range.upper;
-            dst_contains_src | signed_dst_contains_src
+            dst_contains_src || signed_dst_contains_src
         } else {
             dst_contains_src
         };


### PR DESCRIPTION
# Fix upcast for bounded ints

Closes #1457 

- Improves documentation on bounded ints
- Adds more tests, replacing the old incomplete test.
- Fixes the implementation: we were not offsetting the value when the source value was not offsetted.

## Introduces Breaking Changes?

No.

## Checklist

- [x] Linked to Github Issue.
- [x] Unit tests added.
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
