### PR TITLE
Add tests for `enum_from_bounded_int`

### DIFF
--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -190,7 +190,7 @@ pub fn build_enum_value<'ctx, 'this>(
 ///   of possible values in the `BoundedInt` range.
 /// - The range of the `BoundedInt` must start from **0**.
 ///
-/// # Cairo Signature
+/// # Signature
 ///
 /// ```cairo
 /// fn enum_from_bounded_int<T, U>(index: U) -> T nopanic


### PR DESCRIPTION
# Add tests for `enum_from_bounded_int`

Add libfunc `enum_from_bounded_int` which didn't have any

## Introduces Breaking Changes?

No.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
