### PR TITLE
Implement DummyFunctionCall libfunc

### DIFF
--- a/debug_utils/sierra-emu/src/vm.rs
+++ b/debug_utils/sierra-emu/src/vm.rs
@@ -497,7 +497,7 @@ fn eval<'a>(
         CoreConcreteLibfunc::Felt252DictEntry(selector) => {
             self::felt252_dict_entry::eval(registry, selector, args)
         }
-        CoreConcreteLibfunc::FunctionCall(info) => {
+        CoreConcreteLibfunc::DummyFunctionCall(info) | CoreConcreteLibfunc::FunctionCall(info) => {
             self::function_call::eval_function_call(registry, info, args)
         }
         CoreConcreteLibfunc::CouponCall(info) => {
@@ -539,7 +539,6 @@ fn eval<'a>(
         CoreConcreteLibfunc::Felt252SquashedDict(_) => todo!(),
         CoreConcreteLibfunc::Trace(_) => todo!(),
         CoreConcreteLibfunc::UnsafePanic(_) => todo!(),
-        CoreConcreteLibfunc::DummyFunctionCall(_) => todo!(),
         CoreConcreteLibfunc::GasReserve(_) => todo!(),
     }
 }

--- a/src/libfuncs.rs
+++ b/src/libfuncs.rs
@@ -182,7 +182,7 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
             Self::Felt252DictEntry(selector) => self::felt252_dict_entry::build(
                 context, registry, entry, location, helper, metadata, selector,
             ),
-            Self::FunctionCall(info) => self::function_call::build(
+            Self::DummyFunctionCall(info) | Self::FunctionCall(info) => self::function_call::build(
                 context, registry, entry, location, helper, metadata, info,
             ),
             Self::Gas(selector) => self::gas::build(
@@ -258,7 +258,6 @@ impl LibfuncBuilder for CoreConcreteLibfunc {
             Self::QM31(_) => native_panic!("Implement QM31 libfunc"),
             Self::UnsafePanic(_) => native_panic!("Implement unsafe_panic libfunc"),
             Self::GasReserve(_) => native_panic!("Implement gas_reserve libfunc"),
-            Self::DummyFunctionCall(_) => native_panic!("Implement dummy_function_call libfunc"),
         }
     }
 


### PR DESCRIPTION
# Implement DummyFunctionCall libfunc

The `DummyFunctionCall` libfunc does the same as the `FunctionCall` one, except that it does not check the stack. In the compiler the difference is in whether it executes this [function](https://github.com/starkware-libs/cairo/blob/454ff805949bfa6c999e7b29538bd0a08f202908/crates/cairo-lang-sierra-to-casm/src/invocations/function_call.rs#L21C5-L23C6) or not:
```rust
 if check_args_on_stack {
      check_references_on_stack(builder.refs)?;
  }
```
Since in Native we don't receive arguments through a stack, there is no difference with the `FunctionCall` libfunc.


Closes #1427 

## Introduces Breaking Changes?

No.

## Checklist

- [x] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
