### PR TITLE
[sierra-emu] Fix `secp256_get_point_from_x` and `secp256_new` implementation

### DIFF
--- a/debug_utils/sierra-emu/src/vm/starknet.rs
+++ b/debug_utils/sierra-emu/src/vm/starknet.rs
@@ -174,7 +174,7 @@ fn eval_secp256_new(
                 None => Value::Enum {
                     self_ty: enum_ty.clone(),
                     index: 1,
-                    payload: Box::new(Value::Unit),
+                    payload: Box::new(Value::Struct(vec![])),
                 },
             };
 
@@ -328,7 +328,7 @@ fn eval_secp256_get_point_from_x(
                 None => Value::Enum {
                     self_ty: enum_ty.clone(),
                     index: 1,
-                    payload: Box::new(Value::Unit),
+                    payload: Box::new(Value::Struct(vec![])),
                 },
             };
 

--- a/debug_utils/sierra-emu/tests/corelib.rs
+++ b/debug_utils/sierra-emu/tests/corelib.rs
@@ -67,7 +67,6 @@ fn test_corelib() {
         "core::test::hash_test::test_blake2s",
         "core::test::testing_test::test_get_unspent_gas",
         "core::test::qm31_test::",
-        "core::test::secp256k1_test::test_verify_eth_signature_invalid_signature",
     ];
 
     let compiled = compile_tests(


### PR DESCRIPTION
# Fix `secp256_get_point_from_x` and `secp256_new` implementation

Closes #1512

<!--
Description of the pull request changes and motivation.
-->

This PR fixes the implementation of the mentioned libfuncs. Both call a syscall which returns `SyscallResult<Option<Secp256k1Point>>`, and the wrong value was being returned when the syscall returned `Ok(None)`.
## Introduces Breaking Changes?

No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [x] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
