### PR TITLE
Fix libfunc `enum_from_bounded_int`

### DIFF
--- a/src/libfuncs/enum.rs
+++ b/src/libfuncs/enum.rs
@@ -243,8 +243,10 @@ pub fn build_from_bounded_int<'ctx, 'this>(
         }
     };
 
-    let value = entry.append_op_result(llvm::undef(enum_ty, location))?;
-    let value = entry.insert_value(context, location, value, tag_value, 0)?;
+    let mut value = entry.append_op_result(llvm::undef(enum_ty, location))?;
+    if info.n_variants > 1 {
+        value = entry.insert_value(context, location, value, tag_value, 0)?;
+    }
 
     helper.br(entry, 0, &[value], location)
 }


### PR DESCRIPTION
# Fix libfunc `enum_from_bounded_int`

We were not handling correctly the case of using the libfunc `enum_from_bounded_int` with an enum that has only 1 variant.

Enums are represented as an struct that has 2 fields. The first is an integer that tells which variant of the enum is being represented and the second field is an array of i8 which holds the bytes of the variant type. However, when having a struct of 1 variant, this type of representation is no longer needed and the type of the only existing variant is built.

In `enum_from_bounded_int` we were building the enum, so we were thinking we were always building an struct with two fields. After building that, we insert in the first field the number of the variant we want to represent which comes from the bounded int. However, when the result is an enum of 1 variant, we no longer have an struct of two fields so we dont need to insert the number of the variant as before. We were doing an insert in a struct with no fields an this generated the error `'llvm.insertvalue' op position out of bounds: 0`.

Now we check how many variants the struct has, so in the case of 1 variant we dont try to insert anything.

### How did we find this

We want to stop using the `load_cairo!` macro in the tests so we stop doing the cairo to sierra compilation in them. To do this, we compile all the cairo files with the binary `compile-cairo-project` which compiles them without optimizations (this was added in #1535), which is different to the macro which uses the default optimizations level. This change in the compilation triggered this case we were not handling

## Introduces Breaking Changes?

No.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
