### PR TITLE
added blake builtin counter for blake libfuncs

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,7 +14,7 @@ use crate::{
         SEGMENT_ARENA_BUILTIN_SIZE,
     },
     native_panic,
-    runtime::BUILTIN_COSTS,
+    runtime::{BLAKE_CALL_COUNT, BUILTIN_COSTS},
     starknet::{handler::StarknetSyscallHandlerCallbacks, StarknetSyscallHandler},
     types::TypeBuilder,
     utils::{libc_free, BuiltinCosts, RangeExt},
@@ -346,6 +346,10 @@ fn invoke_dynamic(
             fields: vec![],
             debug_name: None,
         });
+
+    // Get the blake call count from the global counter (blake doesn't have a buffer-based counter
+    // like other builtins, so it's tracked globally via the blake libfuncs)
+    builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.replace(0)) as usize;
 
     #[cfg(feature = "with-mem-tracing")]
     crate::utils::mem_tracing::report_stats();

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -47,6 +47,7 @@ use crate::{
     metadata::runtime_bindings::setup_runtime,
     module::NativeModule,
     native_assert, native_panic,
+    runtime::BLAKE_CALL_COUNT,
     starknet::{handler::StarknetSyscallHandlerCallbacks, StarknetSyscallHandler},
     statistics::{SierraDeclaredTypeStats, SierraFuncStats, Statistics},
     types::{array::ArrayMetadata, TypeBuilder},
@@ -699,6 +700,10 @@ impl AotContractExecutor {
 
         // Restore the original builtin costs pointer.
         drop(builtin_costs_guard);
+
+        // Get the blake call count from the global counter (blake doesn't have a buffer-based counter
+        // like other builtins, so it's tracked globally via the blake libfuncs on each invocation)
+        builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.replace(0)) as usize;
 
         #[cfg(feature = "with-mem-tracing")]
         crate::utils::mem_tracing::report_stats();

--- a/src/libfuncs/blake.rs
+++ b/src/libfuncs/blake.rs
@@ -105,10 +105,10 @@ mod tests {
         let program =
             get_compiled_program("test_data_artifacts/programs/libfuncs/blake_3_bytes_compress");
 
-        let result = run_program(&program, "run_test", &[]).return_value;
+        let result = run_program(&program, "run_test", &[]);
 
         assert_eq!(
-            result,
+            result.return_value,
             jit_struct!(
                 Value::Uint32(0x8C5E8C50),
                 Value::Uint32(0xE2147C32),
@@ -119,6 +119,12 @@ mod tests {
                 Value::Uint32(0x4C9B994D),
                 Value::Uint32(0x82596786),
             )
+        );
+
+        // blake2s_finalize calls build_blake_operation once → blake count = 1
+        assert_eq!(
+            result.builtin_stats.blake, 1,
+            "blake counter should be exactly 1 for a single blake2s_finalize call"
         );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -166,6 +166,10 @@ pub unsafe extern "C" fn cairo_native__libfunc__blake_compress(
     );
 
     *state = new_state;
+
+    // Track blake invocations: Blake doesn't have an implicit counter argument
+    // like buffer-based builtins, so we count calls here directly.
+    BLAKE_CALL_COUNT.with(|c| c.set(c.get() + 1));
 }
 
 /// Felt252 type used in cairo native runtime
@@ -809,6 +813,12 @@ thread_local! {
             blake: 0,
         })
     };
+
+    /// Global counter for blake builtin calls.
+    /// Unlike buffer-based builtins (Pedersen, etc.), Blake is a VM opcode without
+    /// an implicit counter argument. This global counter is incremented by the
+    /// Blake libfuncs (blake2s_compress, blake2s_finalize) on each invocation.
+    pub(crate) static BLAKE_CALL_COUNT: Cell<u64> = const { Cell::new(0) };
 }
 
 // TODO: This is already implemented on types-rs but there is no release

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -825,6 +825,9 @@ pub fn compare_outputs(
         native_builtins.insert("range_check96", native_result.builtin_stats.range_check96);
         native_builtins.insert("add_mod", native_result.builtin_stats.add_mod);
         native_builtins.insert("mul_mod", native_result.builtin_stats.mul_mod);
+        // Note: blake is not included here because the VM tracks it as an opcode
+        // (OpcodeExtension::Blake), not as a builtin in builtin_instance_counter.
+        // Blake counter accuracy is validated separately in test_blake_builtin_counter.
         native_builtins.retain(|_, &mut v| v != 0);
         native_builtins
     };

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -209,3 +209,37 @@ fn test_contract_cases(name: &str, args: &[u128]) {
 
     assert_eq_sorted!(vm_output, native_output);
 }
+
+/// Test that the blake builtin counter accurately tracks the number of blake operations.
+/// The heavy_blake2s contract calls blake2s_compress 6 times and blake2s_finalize once,
+/// for a total of 7 blake operations.
+#[test]
+fn test_blake_builtin_counter() {
+    let contract =
+        load_contract("test_data_artifacts/contracts/cairo_vm/heavy_blake2s.contract.json");
+
+    let entrypoint = contract
+        .entry_points_by_type
+        .external
+        .first()
+        .expect("contract should have at least one external entrypoint");
+
+    let program = contract
+        .extract_sierra_program(false)
+        .expect("contract bytes should be a valid sierra program")
+        .program;
+
+    let native_result =
+        run_native_starknet_contract(&program, entrypoint.function_idx, &[], DummySyscallHandler);
+
+    assert!(
+        !native_result.failure_flag,
+        "native contract execution failed"
+    );
+
+    // heavy_blake2s: 6 blake2s_compress + 1 blake2s_finalize = 7 blake operations
+    assert_eq!(
+        native_result.builtin_stats.blake, 7,
+        "blake counter should be exactly 7 (6 compress + 1 finalize)"
+    );
+}


### PR DESCRIPTION
# Title

Closes #NA

<!--
added blake builtin counter for blake libfuncs
-->

## Introduces Breaking Changes?

No.

<!--
Explain how this PR modifies the API.
-->

<!--
If the PR is breaking, then we need to update starknet-replay
and our sequencer fork to comply with the latest changes.

The following checklist can be removed if not required.
-->

- [ ] Created PR in [sequencer](https://github.com/lambdaclass/sequencer)
- [ ] Created PR in [starknet-replay](https://github.com/lambdaclass/starknet-replay)   
- [ ] Updated the `starknet-blocks.yml` workflow to use these PRs.

These PRs should be merged after this one right away, in that order.

## Checklist

- [ ] Linked to Github Issue.
- [ ] Unit tests added.
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo_native/1558)
<!-- Reviewable:end -->
