### PR TITLE
fixed a bug with array slice index wrapping

### DIFF
--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -1185,24 +1185,26 @@ pub fn build_slice<'ctx, 'this>(
 
     let slice_start = entry.argument(2)?.into();
     let slice_len = entry.argument(3)?.into();
-    let slice_end = entry.append_op_result(arith::addi(slice_start, slice_len, location))?;
 
-    let slice_lhs_bound = entry.append_op_result(arith::cmpi(
+    // Compute `slice_end = slice_start + slice_len` in 64 bits. In 32-bit
+    // arithmetic the sum wraps and lets an attacker-chosen `slice_len`
+    // sneak past the bound below. Since `slice_len` is unsigned (Sierra
+    // u32) it cannot be negative, so once we've checked
+    // `slice_end <= array_len` we also know `slice_start <= array_len`.
+    let wide_ty = IntegerType::new(context, 64).into();
+    let slice_start_wide = entry.extui(slice_start, wide_ty, location)?;
+    let slice_len_wide = entry.extui(slice_len, wide_ty, location)?;
+    let array_len_wide = entry.extui(array_len, wide_ty, location)?;
+    let slice_end_wide =
+        entry.append_op_result(arith::addi(slice_start_wide, slice_len_wide, location))?;
+
+    let slice_bounds = entry.append_op_result(arith::cmpi(
         context,
         CmpiPredicate::Ule,
-        slice_start,
-        array_len,
+        slice_end_wide,
+        array_len_wide,
         location,
     ))?;
-    let slice_rhs_bound = entry.append_op_result(arith::cmpi(
-        context,
-        CmpiPredicate::Ule,
-        slice_end,
-        array_len,
-        location,
-    ))?;
-    let slice_bounds =
-        entry.append_op_result(arith::andi(slice_lhs_bound, slice_rhs_bound, location))?;
 
     let valid_block = helper.append_block(Block::new(&[]));
     let error_block = helper.append_block(Block::new(&[]));

--- a/test_data/programs/array_slice_overflow.cairo
+++ b/test_data/programs/array_slice_overflow.cairo
@@ -1,0 +1,4 @@
+fn run_test(user_len: u32) {
+    let arr: Array<u64> = array![10_u64, 20_u64];
+    let slice = arr.span().slice(1, user_len);
+}

--- a/tests/tests/arrays.rs
+++ b/tests/tests/arrays.rs
@@ -59,3 +59,35 @@ proptest! {
         .unwrap();
     }
 }
+
+#[test]
+fn array_slice_u32_overflow() {
+    let program = &load_program_and_runner("test_data_artifacts/programs/array_slice_overflow");
+    let user_len = u32::MAX;
+
+    let result_vm = run_vm_program(
+        program,
+        "run_test",
+        vec![Arg::Value(Felt::from(user_len))],
+        Some(DEFAULT_GAS as usize),
+    )
+    .unwrap();
+    let result_native = run_native_program(
+        program,
+        "run_test",
+        &[Value::Uint32(user_len)],
+        Some(DEFAULT_GAS),
+        Option::<DummySyscallHandler>::None,
+    );
+
+    compare_outputs(
+        &program.1,
+        &program.2.find_function("run_test").unwrap().id,
+        &result_vm,
+        &result_native,
+    )
+    .expect(
+        "array_slice diverges between VM and native — native let a u32-overflowing \
+         slice through; see build_slice in src/libfuncs/array.rs",
+    );
+}


### PR DESCRIPTION
# Fix u32 overflow in array_slice bounds check


  build_slice in src/libfuncs/array.rs computed slice_end = slice_start + slice_len in 32-bit arithmetic and then compared it against array_len with Ule. With an attacker-chosen
  slice_len = u32::MAX and slice_start ≥ 1, the sum wraps to a small value and the bounds check passes spuriously. The returned snapshot has end < start, so a subsequent
  array_len (which computes end − start as unsigned) yields 0xFFFFFFFF, and any later array_at / array_pop_* reads off the end of the backing allocation.

  The CASM VM performs the same check in felt/range-check arithmetic and does not wrap, so it correctly panics with "Index out of bounds" — meaning the same Sierra bytecode
  produced different results on Native vs the VM. This was observed in the wild against a problematic class on testnet that the sequencer was executing through Native.

  The fix promotes slice_start, slice_len, and array_len to 64 bits before the add and compare, so the sum can never wrap. The 32-bit arithmetic in the valid branch
  (new_array_start = array_start + slice_start, new_array_end = new_array_start + slice_len) stays as-is because once the 64-bit check has passed both partial sums are provably ≤
   array_end ≤ u32::MAX.

  A regression test was added in tests/tests/arrays.rs (array_slice_u32_overflow) which calls arr.span().slice(1, u32::MAX) on a 2-element array and asserts that Native and the
  VM agree (both panic with the same payload). The test fails on the unfixed build with a gas/output mismatch and passes after the fix.

  A repo-wide audit of arith::addi / .addi(...) sites in src/libfuncs/ confirmed build_slice was the only libfunc with this shape (two user-controlled variable-width integers
  added then compared against a same-width bound).

 ## Introduces Breaking Changes?

  No.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1594)
<!-- Reviewable:end -->
