### PR TITLE
add ContractExecutor dispatch enum (Aot + Emu)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,9 @@ with-debug-utils = []
 with-mem-tracing = []
 with-libfunc-profiling = []
 with-segfault-catcher = []
-with-trace-dump = ["dep:sierra-emu"]
+with-trace-dump = ["sierra-emu"]
+# Enables `sierra_emu_bridge` for routing a cairo-native syscall handler into the sierra-emu VM.
+sierra-emu = ["dep:sierra-emu"]
 testing = ["dep:cairo-lang-compiler", "dep:cairo-lang-filesystem"]
 
 [dependencies]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,7 +3,14 @@
 //! This module provides methods to execute the programs, either via JIT or compiled ahead
 //! of time. It also provides a cache to avoid recompiling previously compiled programs.
 
-pub use self::{aot::AotNativeExecutor, contract::AotContractExecutor, jit::JitNativeExecutor};
+pub use self::{
+    aot::AotNativeExecutor,
+    contract::AotContractExecutor,
+    contract_executor::ContractExecutor,
+    jit::JitNativeExecutor,
+};
+#[cfg(feature = "sierra-emu")]
+pub use self::contract_executor::EmuContractInfo;
 use crate::{
     arch::{AbiArgument, ValueWithInfoWrapper},
     error::{panic::ToNativeAssertError, Error},
@@ -39,6 +46,7 @@ use std::{alloc::Layout, arch::global_asm, ptr::NonNull};
 
 mod aot;
 mod contract;
+mod contract_executor;
 mod jit;
 
 #[cfg(target_arch = "aarch64")]

--- a/src/executor/contract_executor.rs
+++ b/src/executor/contract_executor.rs
@@ -1,0 +1,118 @@
+//! Dispatch enum that lets a single call site choose between AOT-compiled execution and
+//! sierra-emu interpretation, without changing call-site code.
+//!
+//! The `Emu` variant is gated on the `sierra-emu` feature and uses
+//! [`crate::sierra_emu_bridge::SierraEmuSyscallBridge`] to thread a cairo-native syscall
+//! handler through the sierra-emu VM.
+
+#[cfg(feature = "sierra-emu")]
+use cairo_lang_sierra::program::Program;
+#[cfg(feature = "sierra-emu")]
+use cairo_lang_starknet_classes::compiler_version::VersionId;
+#[cfg(feature = "sierra-emu")]
+use cairo_lang_starknet_classes::contract_class::ContractEntryPoints;
+use starknet_types_core::felt::Felt;
+#[cfg(feature = "sierra-emu")]
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::execution_result::ContractExecutionResult;
+use crate::executor::AotContractExecutor;
+#[cfg(feature = "sierra-emu")]
+use crate::sierra_emu_bridge::SierraEmuSyscallBridge;
+use crate::starknet::StarknetSyscallHandler;
+use crate::utils::BuiltinCosts;
+
+/// Runtime selection between cairo-native's AOT executor and the sierra-emu interpreter.
+///
+/// `Emu` is constructed from the program + entry points + sierra version triple that
+/// `sierra_emu::VirtualMachine::new_starknet` requires; the `Arc<Program>` is shared across
+/// invocations rather than cloned per call.
+#[derive(Debug)]
+pub enum ContractExecutor {
+    Aot(AotContractExecutor),
+    #[cfg(feature = "sierra-emu")]
+    Emu(EmuContractInfo),
+}
+
+/// Inputs required to construct a `sierra_emu::VirtualMachine` for the `Emu` variant.
+#[cfg(feature = "sierra-emu")]
+#[derive(Debug, Clone)]
+pub struct EmuContractInfo {
+    pub program: Arc<Program>,
+    pub entry_points: ContractEntryPoints,
+    pub sierra_version: VersionId,
+}
+
+impl From<AotContractExecutor> for ContractExecutor {
+    fn from(value: AotContractExecutor) -> Self {
+        Self::Aot(value)
+    }
+}
+
+#[cfg(feature = "sierra-emu")]
+impl From<EmuContractInfo> for ContractExecutor {
+    fn from(value: EmuContractInfo) -> Self {
+        Self::Emu(value)
+    }
+}
+
+impl ContractExecutor {
+    /// Run the contract entry point identified by `selector`.
+    ///
+    /// Dispatches to [`AotContractExecutor::run`] for the `Aot` variant and to a
+    /// [`sierra_emu::VirtualMachine`] for the `Emu` variant. The same `syscall_handler`
+    /// is reused across both paths; for the `Emu` variant it's wrapped in a
+    /// [`SierraEmuSyscallBridge`] so it satisfies the sierra-emu trait.
+    pub fn run<H: StarknetSyscallHandler>(
+        &self,
+        selector: Felt,
+        args: &[Felt],
+        gas: u64,
+        builtin_costs: Option<BuiltinCosts>,
+        #[cfg_attr(not(feature = "sierra-emu"), allow(unused_mut))] mut syscall_handler: H,
+    ) -> Result<ContractExecutionResult> {
+        match self {
+            ContractExecutor::Aot(aot) => aot.run(selector, args, gas, builtin_costs, syscall_handler),
+            #[cfg(feature = "sierra-emu")]
+            ContractExecutor::Emu(EmuContractInfo { program, entry_points, sierra_version }) => {
+                let mut virtual_machine = sierra_emu::VirtualMachine::new_starknet(
+                    Arc::clone(program),
+                    entry_points,
+                    *sierra_version,
+                );
+
+                let emu_builtin_costs = builtin_costs.map(convert_builtin_costs);
+
+                virtual_machine.call_contract(selector, gas, args.to_vec(), emu_builtin_costs);
+
+                let mut bridge = SierraEmuSyscallBridge(&mut syscall_handler);
+                let result = virtual_machine
+                    .run(&mut bridge)
+                    .expect("sierra-emu VM run failed");
+
+                Ok(ContractExecutionResult {
+                    remaining_gas: result.remaining_gas,
+                    failure_flag: result.failure_flag,
+                    return_values: result.return_values,
+                    error_msg: result.error_msg,
+                    builtin_stats: Default::default(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(feature = "sierra-emu")]
+fn convert_builtin_costs(builtin_costs: BuiltinCosts) -> sierra_emu::BuiltinCosts {
+    sierra_emu::BuiltinCosts {
+        r#const: builtin_costs.r#const,
+        pedersen: builtin_costs.pedersen,
+        bitwise: builtin_costs.bitwise,
+        ecop: builtin_costs.ecop,
+        poseidon: builtin_costs.poseidon,
+        add_mod: builtin_costs.add_mod,
+        mul_mod: builtin_costs.mul_mod,
+        blake: builtin_costs.blake,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod libfuncs;
 pub mod metadata;
 pub mod module;
 mod runtime;
+pub mod sierra_emu_bridge;
 pub mod starknet;
 pub mod starknet_stub;
 pub mod statistics;

--- a/src/sierra_emu_bridge.rs
+++ b/src/sierra_emu_bridge.rs
@@ -1,0 +1,377 @@
+//! Bridge between cairo-native's [`StarknetSyscallHandler`](crate::starknet::StarknetSyscallHandler)
+//! and the sierra-emu VM's
+//! [`StarknetSyscallHandler`](::sierra_emu::starknet::StarknetSyscallHandler).
+//!
+//! The sierra-emu interpreter expects a syscall handler implementing its own copy of the
+//! `StarknetSyscallHandler` trait, while cairo-native callers normally provide a handler that
+//! implements the cairo-native version. [`SierraEmuSyscallBridge`] adapts the latter to the
+//! former, performing the small set of type-level translations between the two crates.
+//!
+//! Available under the `sierra-emu` feature.
+
+#![cfg(feature = "sierra-emu")]
+
+use sierra_emu::starknet as emu;
+use starknet_types_core::felt::Felt;
+
+use crate::starknet as native;
+
+/// Wraps a cairo-native [`StarknetSyscallHandler`](native::StarknetSyscallHandler) so it can be
+/// driven by the sierra-emu VM, which expects [`emu::StarknetSyscallHandler`].
+pub struct SierraEmuSyscallBridge<'a, H>(pub &'a mut H);
+
+impl<H: native::StarknetSyscallHandler> emu::StarknetSyscallHandler
+    for SierraEmuSyscallBridge<'_, H>
+{
+    fn get_block_hash(
+        &mut self,
+        block_number: u64,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Felt> {
+        self.0.get_block_hash(block_number, remaining_gas)
+    }
+
+    fn get_execution_info(
+        &mut self,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::ExecutionInfo> {
+        self.0.get_execution_info(remaining_gas).map(convert_execution_info)
+    }
+
+    fn get_execution_info_v2(
+        &mut self,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::ExecutionInfoV2> {
+        self.0.get_execution_info_v2(remaining_gas).map(convert_execution_info_v2)
+    }
+
+    fn deploy(
+        &mut self,
+        class_hash: Felt,
+        contract_address_salt: Felt,
+        calldata: Vec<Felt>,
+        deploy_from_zero: bool,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<(Felt, Vec<Felt>)> {
+        self.0.deploy(class_hash, contract_address_salt, &calldata, deploy_from_zero, remaining_gas)
+    }
+
+    fn replace_class(
+        &mut self,
+        class_hash: Felt,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<()> {
+        self.0.replace_class(class_hash, remaining_gas)
+    }
+
+    fn library_call(
+        &mut self,
+        class_hash: Felt,
+        function_selector: Felt,
+        calldata: Vec<Felt>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Vec<Felt>> {
+        self.0.library_call(class_hash, function_selector, &calldata, remaining_gas)
+    }
+
+    fn call_contract(
+        &mut self,
+        address: Felt,
+        entry_point_selector: Felt,
+        calldata: Vec<Felt>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Vec<Felt>> {
+        self.0.call_contract(address, entry_point_selector, &calldata, remaining_gas)
+    }
+
+    fn storage_read(
+        &mut self,
+        address_domain: u32,
+        address: Felt,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Felt> {
+        self.0.storage_read(address_domain, address, remaining_gas)
+    }
+
+    fn storage_write(
+        &mut self,
+        address_domain: u32,
+        address: Felt,
+        value: Felt,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<()> {
+        self.0.storage_write(address_domain, address, value, remaining_gas)
+    }
+
+    fn emit_event(
+        &mut self,
+        keys: Vec<Felt>,
+        data: Vec<Felt>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<()> {
+        self.0.emit_event(&keys, &data, remaining_gas)
+    }
+
+    fn send_message_to_l1(
+        &mut self,
+        to_address: Felt,
+        payload: Vec<Felt>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<()> {
+        self.0.send_message_to_l1(to_address, &payload, remaining_gas)
+    }
+
+    fn keccak(
+        &mut self,
+        input: Vec<u64>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::U256> {
+        self.0.keccak(&input, remaining_gas).map(convert_u256)
+    }
+
+    fn secp256k1_new(
+        &mut self,
+        x: emu::U256,
+        y: emu::U256,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Option<emu::Secp256k1Point>> {
+        self.0
+            .secp256k1_new(convert_from_u256(x), convert_from_u256(y), remaining_gas)
+            .map(|opt| opt.map(convert_secp_256_k1_point))
+    }
+
+    fn secp256k1_add(
+        &mut self,
+        p0: emu::Secp256k1Point,
+        p1: emu::Secp256k1Point,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::Secp256k1Point> {
+        self.0
+            .secp256k1_add(
+                convert_from_secp_256_k1_point(p0),
+                convert_from_secp_256_k1_point(p1),
+                remaining_gas,
+            )
+            .map(convert_secp_256_k1_point)
+    }
+
+    fn secp256k1_mul(
+        &mut self,
+        p: emu::Secp256k1Point,
+        m: emu::U256,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::Secp256k1Point> {
+        self.0
+            .secp256k1_mul(convert_from_secp_256_k1_point(p), convert_from_u256(m), remaining_gas)
+            .map(convert_secp_256_k1_point)
+    }
+
+    fn secp256k1_get_point_from_x(
+        &mut self,
+        x: emu::U256,
+        y_parity: bool,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Option<emu::Secp256k1Point>> {
+        self.0
+            .secp256k1_get_point_from_x(convert_from_u256(x), y_parity, remaining_gas)
+            .map(|opt| opt.map(convert_secp_256_k1_point))
+    }
+
+    fn secp256k1_get_xy(
+        &mut self,
+        p: emu::Secp256k1Point,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<(emu::U256, emu::U256)> {
+        self.0
+            .secp256k1_get_xy(convert_from_secp_256_k1_point(p), remaining_gas)
+            .map(|(x, y)| (convert_u256(x), convert_u256(y)))
+    }
+
+    fn secp256r1_new(
+        &mut self,
+        x: emu::U256,
+        y: emu::U256,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Option<emu::Secp256r1Point>> {
+        self.0
+            .secp256r1_new(convert_from_u256(x), convert_from_u256(y), remaining_gas)
+            .map(|opt| opt.map(convert_secp_256_r1_point))
+    }
+
+    fn secp256r1_add(
+        &mut self,
+        p0: emu::Secp256r1Point,
+        p1: emu::Secp256r1Point,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::Secp256r1Point> {
+        self.0
+            .secp256r1_add(
+                convert_from_secp_256_r1_point(p0),
+                convert_from_secp_256_r1_point(p1),
+                remaining_gas,
+            )
+            .map(convert_secp_256_r1_point)
+    }
+
+    fn secp256r1_mul(
+        &mut self,
+        p: emu::Secp256r1Point,
+        m: emu::U256,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<emu::Secp256r1Point> {
+        self.0
+            .secp256r1_mul(convert_from_secp_256_r1_point(p), convert_from_u256(m), remaining_gas)
+            .map(convert_secp_256_r1_point)
+    }
+
+    fn secp256r1_get_point_from_x(
+        &mut self,
+        x: emu::U256,
+        y_parity: bool,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Option<emu::Secp256r1Point>> {
+        self.0
+            .secp256r1_get_point_from_x(convert_from_u256(x), y_parity, remaining_gas)
+            .map(|opt| opt.map(convert_secp_256_r1_point))
+    }
+
+    fn secp256r1_get_xy(
+        &mut self,
+        p: emu::Secp256r1Point,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<(emu::U256, emu::U256)> {
+        self.0
+            .secp256r1_get_xy(convert_from_secp_256_r1_point(p), remaining_gas)
+            .map(|(x, y)| (convert_u256(x), convert_u256(y)))
+    }
+
+    fn sha256_process_block(
+        &mut self,
+        mut prev_state: [u32; 8],
+        current_block: [u32; 16],
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<[u32; 8]> {
+        self.0.sha256_process_block(&mut prev_state, &current_block, remaining_gas)?;
+        Ok(prev_state)
+    }
+
+    fn meta_tx_v0(
+        &mut self,
+        address: Felt,
+        entry_point_selector: Felt,
+        calldata: Vec<Felt>,
+        signature: Vec<Felt>,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Vec<Felt>> {
+        self.0.meta_tx_v0(address, entry_point_selector, &calldata, &signature, remaining_gas)
+    }
+
+    fn get_class_hash_at(
+        &mut self,
+        contract_address: Felt,
+        remaining_gas: &mut u64,
+    ) -> emu::SyscallResult<Felt> {
+        self.0.get_class_hash_at(contract_address, remaining_gas)
+    }
+}
+
+// --- Type conversion helpers between cairo-native and sierra-emu syscall types. ---
+
+fn convert_u256(x: native::U256) -> emu::U256 {
+    emu::U256 { lo: x.lo, hi: x.hi }
+}
+
+fn convert_from_u256(x: emu::U256) -> native::U256 {
+    native::U256 { lo: x.lo, hi: x.hi }
+}
+
+fn convert_secp_256_k1_point(x: native::Secp256k1Point) -> emu::Secp256k1Point {
+    emu::Secp256k1Point { x: convert_u256(x.x), y: convert_u256(x.y) }
+}
+
+fn convert_from_secp_256_k1_point(x: emu::Secp256k1Point) -> native::Secp256k1Point {
+    // sierra-emu has no `is_infinity` flag and represents the identity element as (0, 0).
+    // Detect that here so cairo-native (which has the flag) treats it as infinity rather
+    // than the literal point (0, 0), which is not on the curve.
+    let is_infinity = is_u256_zero(&x.x) && is_u256_zero(&x.y);
+    native::Secp256k1Point { x: convert_from_u256(x.x), y: convert_from_u256(x.y), is_infinity }
+}
+
+fn convert_secp_256_r1_point(x: native::Secp256r1Point) -> emu::Secp256r1Point {
+    emu::Secp256r1Point { x: convert_u256(x.x), y: convert_u256(x.y) }
+}
+
+fn convert_from_secp_256_r1_point(x: emu::Secp256r1Point) -> native::Secp256r1Point {
+    let is_infinity = is_u256_zero(&x.x) && is_u256_zero(&x.y);
+    native::Secp256r1Point { x: convert_from_u256(x.x), y: convert_from_u256(x.y), is_infinity }
+}
+
+fn is_u256_zero(x: &emu::U256) -> bool {
+    x.lo == 0 && x.hi == 0
+}
+
+fn convert_execution_info(x: native::ExecutionInfo) -> emu::ExecutionInfo {
+    emu::ExecutionInfo {
+        block_info: convert_block_info(x.block_info),
+        tx_info: convert_tx_info(x.tx_info),
+        caller_address: x.caller_address,
+        contract_address: x.contract_address,
+        entry_point_selector: x.entry_point_selector,
+    }
+}
+
+fn convert_tx_info(x: native::TxInfo) -> emu::TxInfo {
+    emu::TxInfo {
+        version: x.version,
+        account_contract_address: x.account_contract_address,
+        max_fee: x.max_fee,
+        signature: x.signature,
+        transaction_hash: x.transaction_hash,
+        chain_id: x.chain_id,
+        nonce: x.nonce,
+    }
+}
+
+fn convert_execution_info_v2(x: native::ExecutionInfoV2) -> emu::ExecutionInfoV2 {
+    emu::ExecutionInfoV2 {
+        block_info: convert_block_info(x.block_info),
+        tx_info: convert_tx_v2_info(x.tx_info),
+        caller_address: x.caller_address,
+        contract_address: x.contract_address,
+        entry_point_selector: x.entry_point_selector,
+    }
+}
+
+fn convert_tx_v2_info(x: native::TxV2Info) -> emu::TxV2Info {
+    emu::TxV2Info {
+        version: x.version,
+        account_contract_address: x.account_contract_address,
+        max_fee: x.max_fee,
+        signature: x.signature,
+        transaction_hash: x.transaction_hash,
+        chain_id: x.chain_id,
+        nonce: x.nonce,
+        resource_bounds: x.resource_bounds.into_iter().map(convert_resource_bounds).collect(),
+        tip: x.tip,
+        paymaster_data: x.paymaster_data,
+        nonce_data_availability_mode: x.nonce_data_availability_mode,
+        fee_data_availability_mode: x.fee_data_availability_mode,
+        account_deployment_data: x.account_deployment_data,
+    }
+}
+
+fn convert_resource_bounds(x: native::ResourceBounds) -> emu::ResourceBounds {
+    emu::ResourceBounds {
+        resource: x.resource,
+        max_amount: x.max_amount,
+        max_price_per_unit: x.max_price_per_unit,
+    }
+}
+
+fn convert_block_info(x: native::BlockInfo) -> emu::BlockInfo {
+    emu::BlockInfo {
+        block_number: x.block_number,
+        block_timestamp: x.block_timestamp,
+        sequencer_address: x.sequencer_address,
+    }
+}


### PR DESCRIPTION
## Summary

Adds a public dispatch enum that lets a single call site choose between the AOT executor and the sierra-emu interpreter at runtime, without forcing every caller to maintain its own match.

> [!IMPORTANT]
> Stacked on top of #1597 (SierraEmuSyscallBridge). Merge #1597 first; the diff for this PR will then narrow to just the new `contract_executor` module.

## Changes

- **`src/executor/contract_executor.rs`** — new module:
  - `pub enum ContractExecutor { Aot(AotContractExecutor), Emu(EmuContractInfo) }`, with `Emu` gated on the `sierra-emu` feature added in #1597.
  - `From` impls for both variants.
  - `ContractExecutor::run` dispatches: the `Aot` arm calls `AotContractExecutor::run` directly; the `Emu` arm constructs a `sierra_emu::VirtualMachine`, wraps the cairo-native syscall handler in `SierraEmuSyscallBridge`, and converts the result.
  - `EmuContractInfo` carries `Arc<Program>` so the program is shared across invocations rather than cloned per call.

## Test plan

- [ ] CI passes with default features
- [ ] CI passes with `--features sierra-emu`

## Context

This is the dispatch shape that downstream consumers (e.g. the blockifier in `starkware-libs/sequencer`) currently maintain locally; with this PR they can drop their copy and import `cairo_native::ContractExecutor`.