### PR TITLE
Tomer/fixed signed bounded ints width checking

### DIFF
--- a/src/libfuncs/bounded_int.rs
+++ b/src/libfuncs/bounded_int.rs
@@ -844,6 +844,11 @@ mod test {
     #[test_case("bi_m100x0_times_bi_0x100", -100, 100, -10000)]
     #[test_case("bi_1x1_times_bi_1x1", 1, 1, 1)]
     #[test_case("bi_m5x5_times_ui_2", -3, 2, -6)]
+    // `BoundedInt` ranges with non-power-of-two exclusive upper
+    #[test_case("bi_m3x5_times_bi_m3x5", 5, 5, 25)]
+    #[test_case("bi_m3x5_times_bi_m3x5", -3, 5, -15)]
+    #[test_case("bi_m3x5_times_bi_m3x5", -3, -3, 9)]
+    #[test_case("bi_m3x5_times_bi_m3x5", 5, -3, -15)]
     fn test_mul(entry_point: &str, lhs: i32, rhs: i32, expected_result: i32) {
         let program = get_compiled_program("test_data_artifacts/programs/libfuncs/bounded_int_mul");
         let result = run_program(

--- a/src/utils/range_ext.rs
+++ b/src/utils/range_ext.rs
@@ -14,8 +14,9 @@ impl RangeExt for Range {
         // Formula for unsigned integers:
         //     x.bits()
         //
-        // Formula for signed values:
-        //   - Positive: (x.magnitude() + BigUint::one()).bits()
+        // Formula for signed values (n-bit two's complement holds
+        // [-2^(n-1), 2^(n-1) - 1]):
+        //   - Positive: x.magnitude().bits() + 1
         //   - Negative: (x.magnitude() - BigUint::one()).bits() + 1
         //   - Zero: 0
 
@@ -26,7 +27,7 @@ impl RangeExt for Range {
                 match upper.sign() {
                     Sign::Minus => (upper.magnitude() - BigUint::one()).bits() + 1,
                     Sign::NoSign => 0,
-                    Sign::Plus => (upper.magnitude() + BigUint::one()).bits(),
+                    Sign::Plus => upper.magnitude().bits() + 1,
                 }
             };
 

--- a/test_data/programs/libfuncs/bounded_int_mul.cairo
+++ b/test_data/programs/libfuncs/bounded_int_mul.cairo
@@ -88,3 +88,14 @@ fn bi_m5x5_times_ui_2(a: felt252, b: felt252) -> BoundedInt<-10, 10> {
 
     mul(a,b)
 }
+
+impl MulHelperBI_m3x5_BI_m3x5 of MulHelper<BoundedInt<-3, 5>, BoundedInt<-3, 5>> {
+    type Result = BoundedInt<-15, 25>;
+}
+
+fn bi_m3x5_times_bi_m3x5(a: felt252, b: felt252) -> BoundedInt<-15, 25> {
+    let a: BoundedInt<-3, 5> = a.try_into().unwrap();
+    let b: BoundedInt<-3, 5> = b.try_into().unwrap();
+
+    mul(a,b)
+}


### PR DESCRIPTION
# Title

 Fix zero_based_bit_width off-by-one for signed BoundedInt ranges 

Closes #NA

<!--
The Sign::Plus arm of RangeExt::zero_based_bit_width returned (upper.magnitude() + 1).bits(), which only happens to give the correct signed two's-complement width when the exclusive upper is a power of two. For shapes like BoundedInt<-15, 25> (exclusive upper 26), the formula    
  returned 5 while the correct width is 6 — one less than the type's offset_bit_width.
                                                                                                                                                                                                                                                                                          
  The bug surfaced in bounded_int_mul, which uses compute_range.zero_based_bit_width() to type the entire computation pipeline (without the +1 safety margin that add / sub use). For destination types whose offset_bit_width exceeds the buggy value by one, the libfunc emitted the    
  result at i{N-1} while the next llvm.insertvalue expected iN, producing a hard MLIR verification error:
                                                                                                                                                                                                                                                                                          
  'llvm.insertvalue' op Type mismatch: cannot insert 'i5' into '!llvm.struct<(i6)>'
                                                                                                                                                                                                                                                                                          
  This was a compile-time refusal, not silent miscompilation: any Cairo program instantiating MulHelper with a non-power-of-two destination upper failed NativeContext::compile with MlirError(RunPass). Other libfuncs (add/sub/div_rem/cast) were unaffected — add and sub add +1 to    
  compute width, div_rem operates on non-negative ranges (unsigned formula is correct), and cast only uses compute_width to decide whether to extend.                                                                                                                                     
                                                                                                                                                                                                                                                                                          
  The fix replaces the Sign::Plus arm with upper.magnitude().bits() + 1 ("bits for the magnitude, plus a sign bit"), which gives the correct width for every shape, not just the power-of-two ones. Standard Cairo signed types (i8, i16, …) all have power-of-two exclusive upper, so the
   formula change is a no-op for them and existing tests are unaffected.
-->

## Introduces Breaking Changes?
No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1600)
<!-- Reviewable:end -->
