### PR TITLE
fixed a bug where blake call count was wrong when a contract invokes …

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -142,15 +142,15 @@ fn invoke_dynamic(
     let mut syscall_handler = syscall_handler
         .as_mut()
         .map(|syscall_handler| StarknetSyscallHandlerCallbacks::new(syscall_handler));
-    // We only care for the previous syscall handler if we actually modify it
-    #[cfg(feature = "with-cheatcode")]
-    let syscall_handler_guard = syscall_handler
-        .as_mut()
-        .map(|syscall_handler| SyscallHandlerGuard::install(syscall_handler as *mut _));
 
-    // We may be inside a recursive contract, save the possible saved builtin costs to restore it after our call.
+    // We may be inside a recursive contract, save the possibly saved thread-local state to
+    // restore it after our call.
     let builtin_costs = BuiltinCosts::default();
-    let builtin_costs_guard = BuiltinCostsGuard::install(builtin_costs);
+    let invocation_guard = InvocationGuard::install(
+        builtin_costs,
+        #[cfg(feature = "with-cheatcode")]
+        syscall_handler.as_mut().map(|h| h as *mut _ as *mut ()),
+    );
 
     // Generate argument list.
     let mut iter = args.iter();
@@ -231,11 +231,6 @@ fn invoke_dynamic(
     crate::utils::safe_runner::run_safely(run_trampoline).map_err(Error::SafeRunner)?;
     #[cfg(not(feature = "with-segfault-catcher"))]
     run_trampoline();
-
-    // Restore the previous syscall handler and builtin costs.
-    #[cfg(feature = "with-cheatcode")]
-    drop(syscall_handler_guard);
-    drop(builtin_costs_guard);
 
     // Parse final gas.
     unsafe fn read_value<T>(ptr: &mut NonNull<()>) -> &T {
@@ -350,7 +345,8 @@ fn invoke_dynamic(
 
     // Get the blake call count from the global counter (blake doesn't have a buffer-based counter
     // like other builtins, so it's tracked globally via the blake libfuncs)
-    builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.replace(0)) as usize;
+    builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.get()) as usize;
+    drop(invocation_guard);
 
     #[cfg(feature = "with-mem-tracing")]
     crate::utils::mem_tracing::report_stats();
@@ -362,42 +358,45 @@ fn invoke_dynamic(
     })
 }
 
-#[cfg(feature = "with-cheatcode")]
+/// Saves and restores the thread-local state shared between the host and compiled code
+/// for the duration of a single invocation. On drop, all installed values are reverted to
+/// their previous state, which is required to support recursive (contract-in-contract) calls.
 #[derive(Debug)]
-struct SyscallHandlerGuard(*mut ());
+pub(crate) struct InvocationGuard {
+    builtin_costs: BuiltinCosts,
+    blake_call_count: u64,
+    #[cfg(feature = "with-cheatcode")]
+    syscall_handler: Option<*mut ()>,
+}
 
-#[cfg(feature = "with-cheatcode")]
-impl SyscallHandlerGuard {
-    // NOTE: It is the caller's responsibility to ensure that the syscall handler is alive until the
-    //   guard is dropped.
-    pub fn install<T>(value: *mut T) -> Self {
-        let previous_value = crate::starknet::SYSCALL_HANDLER_VTABLE.get();
-        let syscall_handler_ptr = value as *mut ();
-        crate::starknet::SYSCALL_HANDLER_VTABLE.set(syscall_handler_ptr);
-
-        Self(previous_value)
+impl InvocationGuard {
+    // NOTE: When `syscall_handler` is `Some`, it is the caller's responsibility to ensure that
+    //   the syscall handler is alive until the guard is dropped.
+    pub fn install(
+        builtin_costs: BuiltinCosts,
+        #[cfg(feature = "with-cheatcode")] syscall_handler: Option<*mut ()>,
+    ) -> Self {
+        Self {
+            builtin_costs: BUILTIN_COSTS.replace(builtin_costs),
+            blake_call_count: BLAKE_CALL_COUNT.with(|c| c.replace(0)),
+            #[cfg(feature = "with-cheatcode")]
+            syscall_handler: syscall_handler.map(|ptr| {
+                let previous_value = crate::starknet::SYSCALL_HANDLER_VTABLE.get();
+                crate::starknet::SYSCALL_HANDLER_VTABLE.set(ptr);
+                previous_value
+            }),
+        }
     }
 }
 
-#[cfg(feature = "with-cheatcode")]
-impl Drop for SyscallHandlerGuard {
+impl Drop for InvocationGuard {
     fn drop(&mut self) {
-        crate::starknet::SYSCALL_HANDLER_VTABLE.set(self.0);
-    }
-}
-
-#[derive(Debug)]
-struct BuiltinCostsGuard(BuiltinCosts);
-
-impl BuiltinCostsGuard {
-    pub fn install(value: BuiltinCosts) -> Self {
-        Self(BUILTIN_COSTS.replace(value))
-    }
-}
-
-impl Drop for BuiltinCostsGuard {
-    fn drop(&mut self) {
-        BUILTIN_COSTS.set(self.0);
+        BUILTIN_COSTS.set(self.builtin_costs);
+        BLAKE_CALL_COUNT.with(|c| c.set(self.blake_call_count));
+        #[cfg(feature = "with-cheatcode")]
+        if let Some(previous_value) = self.syscall_handler {
+            crate::starknet::SYSCALL_HANDLER_VTABLE.set(previous_value);
+        }
     }
 }
 

--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -43,7 +43,7 @@ use crate::{
         POSEIDON_BUILTIN_SIZE, RANGE_CHECK96_BUILTIN_SIZE, RANGE_CHECK_BUILTIN_SIZE,
         SEGMENT_ARENA_BUILTIN_SIZE,
     },
-    executor::{invoke_trampoline, BuiltinCostsGuard},
+    executor::{invoke_trampoline, InvocationGuard},
     metadata::runtime_bindings::setup_runtime,
     module::NativeModule,
     native_assert, native_panic,
@@ -444,10 +444,15 @@ impl AotContractExecutor {
         let function_ptr = self.find_function_ptr(&function_id, true)?;
 
         // Initialize syscall handler and builtin costs.
-        // We may be inside a recursive contract, save the possible saved builtin costs to restore it after our call.
+        // We may be inside a recursive contract, save the possibly saved thread-local state to
+        // restore it after our call.
         let mut syscall_handler = StarknetSyscallHandlerCallbacks::new(&mut syscall_handler);
         let builtin_costs = builtin_costs.unwrap_or_default();
-        let builtin_costs_guard = BuiltinCostsGuard::install(builtin_costs);
+        let invocation_guard = InvocationGuard::install(
+            builtin_costs,
+            #[cfg(feature = "with-cheatcode")]
+            None,
+        );
 
         //  it can vary from contract to contract thats why we need to store/ load it.
         let builtins_size: usize = self.contract_info.entry_points[&selector]
@@ -699,12 +704,10 @@ impl AotContractExecutor {
             }
         };
 
-        // Restore the original builtin costs pointer.
-        drop(builtin_costs_guard);
-
         // Get the blake call count from the global counter (blake doesn't have a buffer-based counter
         // like other builtins, so it's tracked globally via the blake libfuncs on each invocation)
-        builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.replace(0)) as usize;
+        builtin_stats.blake = BLAKE_CALL_COUNT.with(|c| c.get()) as usize;
+        drop(invocation_guard);
 
         #[cfg(feature = "with-mem-tracing")]
         crate::utils::mem_tracing::report_stats();


### PR DESCRIPTION
…another contract

# Title

fix(blake): preserve blake call count across nested contract calls

Closes #NA
<!--
BLAKE_CALL_COUNT` is a process-wide thread-local counter that the blake libfuncs increment on every call Both `invoke_dynamic` and `AotContractExecutor::run` consumed it via `BLAKE_CALL_COUNT.with(|c| c.replace(0))` at the end of the invocation.

When contract A made `N` blake calls and then invoked contract B via syscall, B's recursive `run` reset the shared counter on exit. The result:

- B reported `N + M` blake calls (it incorrectly absorbed A's tally).
- A reported only the calls it made *after* the syscall, missing the original `N`.
- The grand total still matched the true number of blake calls, so the bug was invisible to anyone summing across contracts but produced wrong per-invocation numbers in `BuiltinStats`.

This PR introduces `BlakeCallCountGuard`, modeled on the existing `BuiltinCostsGuard`. On install it saves the current count and zeroes the cell; on drop it restores the saved value. It is installed at the start of `invoke_dynamic` (`src/executor.rs`) and `AotContractExecutor::run` (`src/executor/contract.rs`), and the terminal read switches from `replace(0)` to `get()` since the guard's `Drop` is now the canonical restorer.

-->

## Introduces Breaking Changes?

No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1601)
<!-- Reviewable:end -->
