### PR TITLE
Fixed top level type of i64 and i128 values.

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -554,11 +554,11 @@ fn parse_result(
             None => Ok(Value::Sint32(ret_registers[0] as i32)),
         },
         CoreTypeConcrete::Sint64(_) => match return_ptr {
-            Some(return_ptr) => Ok(Value::Uint64(unsafe { *return_ptr.cast().as_ref() })),
+            Some(return_ptr) => Ok(Value::Sint64(unsafe { *return_ptr.cast().as_ref() })),
             None => Ok(Value::Sint64(ret_registers[0] as i64)),
         },
         CoreTypeConcrete::Sint128(_) => match return_ptr {
-            Some(return_ptr) => Ok(Value::Uint128(unsafe { *return_ptr.cast().as_ref() })),
+            Some(return_ptr) => Ok(Value::Sint128(unsafe { *return_ptr.cast().as_ref() })),
             None => Ok(Value::Sint128(
                 ((ret_registers[1] as i128) << 64) | ret_registers[0] as i128,
             )),


### PR DESCRIPTION
# Title

Fix top level returning functions serialization.

## Introduces Breaking Changes?

No. The main used API is just serialization of Span and Array of felt252.

## Checklist

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1602)
<!-- Reviewable:end -->
