### PR TITLE
fixed bugs in tests for large enums

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -787,12 +787,9 @@ impl Value {
                     native_panic!("todo: implement uninit from_ptr or ignore the return value")
                 }
                 CoreTypeConcrete::Enum(info) => {
-                    let tag_layout = crate::utils::get_integer_layout(match info.variants.len() {
-                        0 | 1 => 0,
-                        num_variants => (num_variants.next_power_of_two().next_multiple_of(8) >> 3)
-                            .try_into()
-                            .map_err(|_| Error::IntegerConversion)?,
-                    });
+                    let (_, tag_layout, variant_layouts) =
+                        crate::types::r#enum::get_layout_for_variants(registry, &info.variants)?;
+
                     let tag_value = match info.variants.len() {
                         0 => {
                             // An enum without variants is basically the `!` (never) type in Rust.
@@ -808,17 +805,14 @@ impl Value {
                         },
                     };
 
-                    // Filter out bits that are not part of the enum's tag.
-                    let tag_value = tag_value
-                        & 1usize
-                            .wrapping_shl(info.variants.len().next_power_of_two().trailing_zeros())
-                            .wrapping_sub(1);
-
-                    let payload_ty = registry.get_type(&info.variants[tag_value])?;
-                    let payload_layout = payload_ty.layout(registry)?;
+                    // The tag occupies `ceil(log2(variants.len()))` bits but is stored in a
+                    // power-of-two-byte slot (u8/u16/u32/u64). Whenever those don't match,
+                    // the high bits of the slot are not part of the tag — mask them off.
+                    let tag_value = tag_value & (info.variants.len().next_power_of_two() - 1);
 
                     let payload_ptr = NonNull::new(
-                        ptr.as_ptr().byte_add(tag_layout.extend(payload_layout)?.1),
+                        ptr.as_ptr()
+                            .byte_add(tag_layout.extend(variant_layouts[tag_value])?.1),
                     )
                     .to_native_assert_error("tried to make a non-null ptr out of a null one")?;
                     let payload = Self::from_ptr(

--- a/test_data/programs/cases/enums/enum_large_variants.cairo
+++ b/test_data/programs/cases/enums/enum_large_variants.cairo
@@ -1,0 +1,18 @@
+// Tests an enum with a large number of variants (> 16).
+
+#[derive(Drop)]
+enum LargeEnum {
+    V0: u8, V1: u8, V2: u8, V3: u8, V4: u8, V5: u8, V6: u8, V7: u8,
+    V8: u8, V9: u8, V10: u8, V11: u8, V12: u8, V13: u8, V14: u8, V15: u8,
+    V16: u8, V17: u8, V18: u8, V19: u8, V20: u8, V21: u8, V22: u8, V23: u8,
+    V24: u8, V25: u8, V26: u8, V27: u8, V28: u8, V29: u8, V30: u8, V31: u8,
+    V32: u8, V33: u8, V34: u8, V35: u8, V36: u8, V37: u8, V38: u8, V39: u8,
+    V40: u8, V41: u8, V42: u8, V43: u8, V44: u8, V45: u8, V46: u8, V47: u8,
+    V48: u8, V49: u8, V50: u8, V51: u8, V52: u8, V53: u8, V54: u8, V55: u8,
+    V56: u8, V57: u8, V58: u8, V59: u8, V60: u8, V61: u8, V62: u8, V63: u8,
+    V64: u8,
+}
+
+fn main() -> (LargeEnum, u8) {
+    (LargeEnum::V3(1), 2)
+}

--- a/tests/tests/cases.rs
+++ b/tests/tests/cases.rs
@@ -39,6 +39,7 @@ use test_case::test_case;
 #[test_case("test_data_artifacts/programs/cases/enums/enum_match")]
 #[test_case("test_data_artifacts/programs/cases/enums/enum_snapshot_match_a")]
 #[test_case("test_data_artifacts/programs/cases/enums/enum_snapshot_match_b")]
+#[test_case("test_data_artifacts/programs/cases/enums/enum_large_variants")]
 // returns
 #[test_case("test_data_artifacts/programs/cases/returns/enums")]
 #[test_case("test_data_artifacts/programs/cases/returns/simple")]


### PR DESCRIPTION
# Fix `Value::from_ptr` tag layout for enums with > 16 variants

Closes #NA

`from_ptr` open-coded the tag layout with a formula that fed a *byte*
count to `get_integer_layout` (which expects *bits*), so > 16-variant
enums nested inside another type came back with a corrupted payload.
Replaced with the canonical `get_layout_for_variants` helper already
used by `to_ptr` and the MLIR builder. Adds a regression test.

## Introduces Breaking Changes?

No.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1603)
<!-- Reviewable:end -->
