### PR TITLE
add EmuContractExecutor (sierra-emu backend, interchangeable with AotContractExecutor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,10 @@ with-debug-utils = []
 with-mem-tracing = []
 with-libfunc-profiling = []
 with-segfault-catcher = []
-with-trace-dump = ["dep:sierra-emu"]
+with-trace-dump = ["sierra-emu"]
+# Enables the `ContractExecutor::Emu` variant for dispatching contract execution
+# through the sierra-emu interpreter.
+sierra-emu = ["dep:sierra-emu"]
 testing = ["dep:cairo-lang-compiler", "dep:cairo-lang-filesystem"]
 
 [dependencies]

--- a/debug_utils/sierra-emu/src/vm.rs
+++ b/debug_utils/sierra-emu/src/vm.rs
@@ -449,6 +449,32 @@ impl VirtualMachine {
 
         ContractExecutionResult::from_state(&last?)
     }
+
+    /// One-shot convenience over [`VirtualMachine::new_starknet`],
+    /// [`VirtualMachine::call_contract`] and [`VirtualMachine::run`]: build a
+    /// Starknet VM for `program`, call the entry point identified by `selector`
+    /// and run it to completion.
+    ///
+    /// Returns `None` when execution never produced a final state.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_contract<I>(
+        program: Arc<Program>,
+        entry_points: &ContractEntryPoints,
+        sierra_version: VersionId,
+        selector: Felt,
+        initial_gas: u64,
+        calldata: I,
+        builtin_costs: Option<BuiltinCosts>,
+        syscall_handler: &mut impl StarknetSyscallHandler,
+    ) -> Option<ContractExecutionResult>
+    where
+        I: IntoIterator<Item = Felt>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut vm = Self::new_starknet(program, entry_points, sierra_version);
+        vm.call_contract(selector, initial_gas, calldata, builtin_costs);
+        vm.run(syscall_handler)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,6 +3,8 @@
 //! This module provides methods to execute the programs, either via JIT or compiled ahead
 //! of time. It also provides a cache to avoid recompiling previously compiled programs.
 
+#[cfg(feature = "sierra-emu")]
+pub use self::emu_contract_executor::EmuContractExecutor;
 pub use self::{aot::AotNativeExecutor, contract::AotContractExecutor, jit::JitNativeExecutor};
 use crate::{
     arch::{AbiArgument, ValueWithInfoWrapper},
@@ -39,6 +41,8 @@ use std::{alloc::Layout, arch::global_asm, ptr::NonNull};
 
 mod aot;
 mod contract;
+#[cfg(feature = "sierra-emu")]
+mod emu_contract_executor;
 mod jit;
 
 #[cfg(target_arch = "aarch64")]

--- a/src/executor/emu_contract_executor.rs
+++ b/src/executor/emu_contract_executor.rs
@@ -1,0 +1,82 @@
+//! A sierra-emu-backed contract executor exposing the same `run` shape as
+//! [`AotContractExecutor::run`](crate::executor::AotContractExecutor::run), so a caller
+//! can swap the two behind a feature flag without changing call-site code.
+//!
+//! Both executors share the same `H: StarknetSyscallHandler` -- sierra-emu and
+//! cairo-native re-export the trait from `cairo-native-syscalls`, so no adapter is
+//! needed.
+
+use cairo_lang_sierra::program::Program;
+use cairo_lang_starknet_classes::compiler_version::VersionId;
+use cairo_lang_starknet_classes::contract_class::ContractEntryPoints;
+use starknet_types_core::felt::Felt;
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+use crate::execution_result::ContractExecutionResult;
+use crate::starknet::StarknetSyscallHandler;
+use crate::utils::BuiltinCosts;
+
+/// Runs contract entry points through the sierra-emu interpreter.
+///
+/// Holds the program + entry points + sierra version triple that
+/// `sierra_emu::VirtualMachine::run_contract` requires; the `Arc<Program>` is shared
+/// across invocations rather than cloned per call.
+#[derive(Debug, Clone)]
+pub struct EmuContractExecutor {
+    pub program: Arc<Program>,
+    pub entry_points: ContractEntryPoints,
+    pub sierra_version: VersionId,
+}
+
+impl EmuContractExecutor {
+    /// Run the contract entry point identified by `selector`.
+    ///
+    /// Mirrors [`AotContractExecutor::run`](crate::executor::AotContractExecutor::run) so
+    /// the two executor types are interchangeable at the call site.
+    pub fn run(
+        &self,
+        selector: Felt,
+        args: &[Felt],
+        gas: u64,
+        builtin_costs: Option<BuiltinCosts>,
+        mut syscall_handler: impl StarknetSyscallHandler,
+    ) -> Result<ContractExecutionResult> {
+        // `run_contract` returns `None` when the VM never produced a final state --
+        // propagate as an error rather than aborting the host.
+        let result = sierra_emu::VirtualMachine::run_contract(
+            Arc::clone(&self.program),
+            &self.entry_points,
+            self.sierra_version,
+            selector,
+            gas,
+            args.to_vec(),
+            builtin_costs.map(convert_builtin_costs),
+            &mut syscall_handler,
+        )
+        .ok_or_else(|| {
+            Error::UnexpectedValue("sierra-emu VM produced no final state".to_string())
+        })?;
+
+        Ok(ContractExecutionResult {
+            remaining_gas: result.remaining_gas,
+            failure_flag: result.failure_flag,
+            return_values: result.return_values,
+            error_msg: result.error_msg,
+            builtin_stats: Default::default(),
+        })
+    }
+}
+
+fn convert_builtin_costs(builtin_costs: BuiltinCosts) -> sierra_emu::BuiltinCosts {
+    sierra_emu::BuiltinCosts {
+        r#const: builtin_costs.r#const,
+        pedersen: builtin_costs.pedersen,
+        bitwise: builtin_costs.bitwise,
+        ecop: builtin_costs.ecop,
+        poseidon: builtin_costs.poseidon,
+        add_mod: builtin_costs.add_mod,
+        mul_mod: builtin_costs.mul_mod,
+        blake: builtin_costs.blake,
+    }
+}


### PR DESCRIPTION
## Summary

Makes the sierra-emu interpreter usable as a drop-in alternative to `AotContractExecutor` at contract call sites — without a dispatch enum. No consumer selects a backend at runtime (the choice is always made per build by feature flags), so consumers pick an executor *type* per build instead of wrapping every executor in an enum on the production path.

An earlier revision of this PR introduced a `ContractExecutor` dispatch enum (`Aot` + `Emu`); per review it's gone — no consumer, in-tree or out, ever picked a variant at runtime, so the enum's `match` was ceremony around a decision the build's feature flags had already made.

## Changes

- **`debug_utils/sierra-emu`**: new `VirtualMachine::run_contract(...)` — one-shot convenience over `new_starknet` + `call_contract` + `run`. Returns `None` when the VM never produced a final state.
- **`src/executor/emu_contract_executor.rs`** (new, gated on the new `sierra-emu` cargo feature): `EmuContractExecutor { program, entry_points, sierra_version }` with an inherent `run()` that mirrors `AotContractExecutor::run` — same parameter shape, same `StarknetSyscallHandler` trait (shared via `cairo-native-syscalls`, so the handler flows through unchanged). Converts `BuiltinCosts` and the emu result into cairo-native's `ContractExecutionResult` (with default `builtin_stats`).
- **`Cargo.toml`**: new `sierra-emu = ["dep:sierra-emu"]` feature; `with-trace-dump` now depends on the feature rather than the optional dep directly.

## Stack

1. #1610 — trait alignment
2. #1611 — extract shared crate
3. **this PR** — sierra-emu contract executor
4. #1613 — `run_with_libfunc_profile` + `AotWithProgram`

## Test plan

- [x] `cargo check` (default features) clean
- [x] `cargo check --features sierra-emu` clean
- [x] `cargo check --workspace --all-features` clean (on stack tip)
- [ ] CI green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1612)
<!-- Reviewable:end -->
