### PR TITLE
arena for sha256 and circuits

### DIFF
--- a/src/libfuncs/circuit.rs
+++ b/src/libfuncs/circuit.rs
@@ -9,7 +9,6 @@ use crate::{
     libfuncs::r#struct::build_struct_value,
     metadata::{
         drop_overrides::DropOverridesMeta,
-        realloc_bindings::ReallocBindingsMeta,
         runtime_bindings::{CircuitArithOperationType, RuntimeBindingsMeta},
         MetadataStorage,
     },
@@ -102,8 +101,6 @@ fn build_init_circuit_data<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureAndTypeConcreteLibfunc,
 ) -> Result<()> {
-    metadata.get_or_insert_with(|| ReallocBindingsMeta::new(context, helper));
-
     let circuit_info = match registry.get_type(&info.ty)? {
         CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(info)) => &info.circuit_info,
         _ => return Err(SierraAssertError::BadTypeInfo.into()),
@@ -119,22 +116,21 @@ fn build_init_circuit_data<'ctx, 'this>(
 
     // Calculate full capacity for array.
     let capacity = circuit_info.n_inputs;
-    let u384_layout = get_integer_layout(384);
-    let capacity_bytes = layout_repeat(&u384_layout, capacity)?
-        .0
-        .pad_to_align()
-        .size();
-    let capacity_bytes_value = entry.const_int(context, location, capacity_bytes, 64)?;
+    let inputs_layout = layout_repeat(&get_integer_layout(384), capacity)?.0;
+    let capacity_bytes_value =
+        entry.const_int(context, location, inputs_layout.pad_to_align().size(), 64)?;
 
-    // Alloc memory for array.
-    let ptr_ty = llvm::r#type::pointer(context, 0);
-    let ptr = entry.append_op_result(llvm::zero(ptr_ty, location))?;
-    let ptr = entry.append_op_result(ReallocBindingsMeta::realloc(
+    // Alloc memory for array from the arena.
+    let align_value = entry.const_int(context, location, inputs_layout.align(), 64)?;
+    let rtb = metadata.get_or_insert_with(RuntimeBindingsMeta::default);
+    let ptr = rtb.arena_alloc(
         context,
-        ptr,
-        capacity_bytes_value,
+        helper.module,
+        entry,
         location,
-    )?)?;
+        capacity_bytes_value,
+        align_value,
+    )?;
 
     // Create accumulator struct.
     let k0 = entry.const_int(context, location, 0, 64)?;
@@ -309,8 +305,6 @@ fn build_eval<'ctx, 'this>(
     metadata: &mut MetadataStorage,
     info: &SignatureAndTypeConcreteLibfunc,
 ) -> Result<()> {
-    metadata.get_or_insert_with(|| ReallocBindingsMeta::new(context, helper));
-
     let circuit_info = match registry.get_type(&info.ty)? {
         CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(info)) => &info.circuit_info,
         _ => return Err(SierraAssertError::BadTypeInfo.into()),
@@ -373,21 +367,22 @@ fn build_eval<'ctx, 'this>(
 
         // Calculate capacity for array.
         let outputs_capacity = circuit_info.values.len();
-        let u384_integer_layout = get_integer_layout(384);
-        let outputs_layout = layout_repeat(&u384_integer_layout, outputs_capacity)?.0;
-        let outputs_capacity_bytes = outputs_layout.pad_to_align().size();
+        let outputs_layout = layout_repeat(&get_integer_layout(384), outputs_capacity)?.0;
         let outputs_capacity_bytes_value =
-            ok_block.const_int(context, location, outputs_capacity_bytes, 64)?;
+            ok_block.const_int(context, location, outputs_layout.pad_to_align().size(), 64)?;
 
-        // Alloc memory for array.
-        let ptr_ty = llvm::r#type::pointer(context, 0);
-        let outputs_ptr = ok_block.append_op_result(llvm::zero(ptr_ty, location))?;
-        let outputs_ptr = ok_block.append_op_result(ReallocBindingsMeta::realloc(
+        // Alloc memory for array from the arena.
+        let outputs_align_value =
+            ok_block.const_int(context, location, outputs_layout.align(), 64)?;
+        let rtb = metadata.get_or_insert_with(RuntimeBindingsMeta::default);
+        let outputs_ptr = rtb.arena_alloc(
             context,
-            outputs_ptr,
-            outputs_capacity_bytes_value,
+            helper.module,
+            ok_block,
             location,
-        )?)?;
+            outputs_capacity_bytes_value,
+            outputs_align_value,
+        )?;
 
         // Insert evaluated gates into the array.
         for (i, gate) in gates.into_iter().enumerate() {

--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -1863,14 +1863,24 @@ pub(crate) mod handler {
             state: *mut [u32; 8],
             block: &[u32; 16],
         ) {
-            let state_ref = unsafe { state.as_mut().unwrap() };
+            // Sha256StateHandle is Copy in corelib, so the input pointer may be
+            // aliased by other live copies. Mutate a fresh arena slot rather than
+            // the input buffer to keep aliased copies observing the prior state.
+            let new_state = unsafe {
+                crate::runtime::cairo_native__arena_alloc(
+                    std::mem::size_of::<[u32; 8]>() as u64,
+                    std::mem::align_of::<[u32; 8]>() as u64,
+                ) as *mut [u32; 8]
+            };
+            unsafe { std::ptr::copy_nonoverlapping(state, new_state, 1) };
+            let state_ref = unsafe { new_state.as_mut().unwrap() };
             let result = ptr.sha256_process_block(state_ref, block, gas);
 
             *result_ptr = match result {
-                Ok(x) => SyscallResultAbi {
+                Ok(_) => SyscallResultAbi {
                     ok: ManuallyDrop::new(SyscallResultAbiOk {
                         tag: 0u8,
-                        payload: ManuallyDrop::new(state),
+                        payload: ManuallyDrop::new(new_state),
                     }),
                 },
                 Err(e) => Self::wrap_error(&e),

--- a/src/types/circuit.rs
+++ b/src/types/circuit.rs
@@ -5,25 +5,19 @@ use std::alloc::Layout;
 use super::WithSelf;
 use crate::{
     error::{Result, SierraAssertError},
-    metadata::{
-        drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
-        realloc_bindings::ReallocBindingsMeta, MetadataStorage,
-    },
-    utils::{get_integer_layout, layout_repeat, ProgramRegistryExt},
+    metadata::MetadataStorage,
+    utils::{get_integer_layout, layout_repeat},
 };
 use cairo_lang_sierra::{
     extensions::{
         circuit::{CircuitTypeConcrete, ConcreteU96LimbsLessThanGuarantee},
-        core::{CoreLibfunc, CoreType, CoreTypeConcrete},
-        types::InfoOnlyConcreteType,
+        core::{CoreLibfunc, CoreType},
     },
-    program::GenericArg,
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::{func, llvm},
-    helpers::{ArithBlockExt, BuiltinBlockExt, LlvmBlockExt},
-    ir::{r#type::IntegerType, Block, BlockLike, Location, Module, Region, Type, Value},
+    dialect::llvm,
+    ir::{r#type::IntegerType, Module, Type},
     Context,
 };
 
@@ -40,27 +34,25 @@ pub fn build<'ctx>(
     match &*selector {
         CircuitTypeConcrete::CircuitModulus(_) => Ok(IntegerType::new(context, 384).into()),
         CircuitTypeConcrete::U96Guarantee(_) => Ok(IntegerType::new(context, 96).into()),
-        CircuitTypeConcrete::CircuitInputAccumulator(info) => build_circuit_accumulator(
+        CircuitTypeConcrete::CircuitInputAccumulator(_) => Ok(llvm::r#type::r#struct(
             context,
-            module,
-            registry,
-            metadata,
-            WithSelf::new(selector.self_ty(), info),
-        ),
-        CircuitTypeConcrete::CircuitData(info) => build_circuit_data(
+            &[
+                IntegerType::new(context, 64).into(),
+                llvm::r#type::pointer(context, 0),
+            ],
+            false,
+        )),
+        // Arena-allocated `*u384`.
+        CircuitTypeConcrete::CircuitData(_) => Ok(llvm::r#type::pointer(context, 0)),
+        // Arena-allocated `{ *u384, u384struct }`.
+        CircuitTypeConcrete::CircuitOutputs(_) => Ok(llvm::r#type::r#struct(
             context,
-            module,
-            registry,
-            metadata,
-            WithSelf::new(selector.self_ty(), info),
-        ),
-        CircuitTypeConcrete::CircuitOutputs(info) => build_circuit_outputs(
-            context,
-            module,
-            registry,
-            metadata,
-            WithSelf::new(selector.self_ty(), info),
-        ),
+            &[
+                llvm::r#type::pointer(context, 0),
+                build_u384_struct_type(context),
+            ],
+            false,
+        )),
         CircuitTypeConcrete::U96LimbsLessThanGuarantee(info) => {
             build_u96_limbs_less_than_guarantee(
                 context,
@@ -92,307 +84,6 @@ pub fn build<'ctx>(
     }
 }
 
-/// Builds the circuit accumulator type.
-///
-/// ## Layout:
-///
-/// Holds up to N_INPUTS elements. Where each element is an u384 integer.
-///
-/// ```txt
-/// type = struct {
-///     size: u64,
-///     data: *u384,
-/// }
-/// ```
-pub fn build_circuit_accumulator<'ctx>(
-    context: &'ctx Context,
-    module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
-) -> Result<Type<'ctx>> {
-    metadata.get_or_insert_with(|| ReallocBindingsMeta::new(context, module));
-
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    DupOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let accumulator = entry.arg(0)?;
-            let inputs_ptr = entry.extract_value(
-                context,
-                location,
-                accumulator,
-                llvm::r#type::pointer(context, 0),
-                1,
-            )?;
-
-            let u384_layout = get_integer_layout(384);
-
-            let new_inputs_ptr = build_array_dup(
-                context,
-                &entry,
-                location,
-                inputs_ptr,
-                circuit.circuit_info.n_inputs,
-                u384_layout,
-            )?;
-
-            let new_accumulator =
-                entry.insert_value(context, location, accumulator, new_inputs_ptr, 1)?;
-            entry.append_operation(func::r#return(&[accumulator, new_accumulator], location));
-
-            Ok(Some(region))
-        },
-    )?;
-    DropOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let accumulator = entry.arg(0)?;
-            let inputs_ptr = entry.extract_value(
-                context,
-                location,
-                accumulator,
-                llvm::r#type::pointer(context, 0),
-                1,
-            )?;
-
-            entry.append_operation(ReallocBindingsMeta::free(context, inputs_ptr, location)?);
-            entry.append_operation(func::r#return(&[], location));
-
-            Ok(Some(region))
-        },
-    )?;
-
-    let fields = vec![
-        IntegerType::new(context, 64).into(),
-        llvm::r#type::pointer(context, 0),
-    ];
-
-    Ok(llvm::r#type::r#struct(context, &fields, false))
-}
-
-/// Builds the circuit data type.
-///
-/// ## Layout:
-///
-/// Holds N_INPUTS elements. Where each element is an u384.
-///
-/// ```txt
-/// type = *u384
-/// ```
-pub fn build_circuit_data<'ctx>(
-    context: &'ctx Context,
-    module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
-) -> Result<Type<'ctx>> {
-    metadata.get_or_insert_with(|| ReallocBindingsMeta::new(context, module));
-
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    DupOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let data_ptr = entry.arg(0)?;
-
-            let u384_layout = get_integer_layout(384);
-
-            let new_data_ptr = build_array_dup(
-                context,
-                &entry,
-                location,
-                data_ptr,
-                circuit.circuit_info.n_inputs,
-                u384_layout,
-            )?;
-
-            entry.append_operation(func::r#return(&[data_ptr, new_data_ptr], location));
-
-            Ok(Some(region))
-        },
-    )?;
-    DropOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let data_ptr = entry.arg(0)?;
-
-            entry.append_operation(ReallocBindingsMeta::free(context, data_ptr, location)?);
-            entry.append_operation(func::r#return(&[], location));
-
-            Ok(Some(region))
-        },
-    )?;
-
-    Ok(llvm::r#type::pointer(context, 0))
-}
-
-/// Builds the circuit outputs type.
-///
-/// ## Layout:
-///
-/// Holds the evaluated circuit output gates and the circuit modulus.
-/// - The data is stored as a dynamic array of u384 integers.
-/// - The modulus is stored as a u384 in struct form (multi-limb).
-///
-/// ```txt
-/// type = struct {
-///     data: *u384,
-///     modulus: u384struct,
-/// };
-///
-/// u384struct = struct {
-///     limb1: u96,
-///     limb2: u96,
-///     limb3: u96,
-///     limb4: u96,
-/// }
-/// ```
-pub fn build_circuit_outputs<'ctx>(
-    context: &'ctx Context,
-    module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
-) -> Result<Type<'ctx>> {
-    metadata.get_or_insert_with(|| ReallocBindingsMeta::new(context, module));
-
-    let Some(GenericArg::Type(circuit_type_id)) = info.info.long_id.generic_args.first() else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-    let CoreTypeConcrete::Circuit(CircuitTypeConcrete::Circuit(circuit)) =
-        registry.get_type(circuit_type_id)?
-    else {
-        return Err(SierraAssertError::BadTypeInfo.into());
-    };
-
-    DupOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let outputs = entry.arg(0)?;
-            let gates_ptr = entry.extract_value(
-                context,
-                location,
-                outputs,
-                llvm::r#type::pointer(context, 0),
-                0,
-            )?;
-
-            let u384_integer_layout = get_integer_layout(384);
-
-            let new_gates_ptr = build_array_dup(
-                context,
-                &entry,
-                location,
-                gates_ptr,
-                circuit.circuit_info.values.len(),
-                u384_integer_layout,
-            )?;
-
-            let new_outputs = entry.insert_value(context, location, outputs, new_gates_ptr, 0)?;
-            entry.append_operation(func::r#return(&[outputs, new_outputs], location));
-
-            Ok(Some(region))
-        },
-    )?;
-    DropOverridesMeta::register_with(
-        context,
-        module,
-        registry,
-        metadata,
-        info.self_ty(),
-        |metadata| {
-            let location = Location::unknown(context);
-            let region = Region::new();
-            let value_ty = registry.build_type(context, module, metadata, info.self_ty())?;
-            let entry = region.append_block(Block::new(&[(value_ty, location)]));
-
-            let outputs = entry.arg(0)?;
-            let gates_ptr = entry.extract_value(
-                context,
-                location,
-                outputs,
-                llvm::r#type::pointer(context, 0),
-                0,
-            )?;
-
-            entry.append_operation(ReallocBindingsMeta::free(context, gates_ptr, location)?);
-            entry.append_operation(func::r#return(&[], location));
-
-            Ok(Some(region))
-        },
-    )?;
-
-    Ok(llvm::r#type::r#struct(
-        context,
-        &[
-            llvm::r#type::pointer(context, 0),
-            build_u384_struct_type(context),
-        ],
-        false,
-    ))
-}
-
 pub fn build_u96_limbs_less_than_guarantee<'ctx>(
     context: &'ctx Context,
     _module: &Module<'ctx>,
@@ -410,33 +101,6 @@ pub fn build_u96_limbs_less_than_guarantee<'ctx>(
         &[limb_struct_type, limb_struct_type],
         false,
     ))
-}
-
-pub fn build_array_dup<'ctx, 'this>(
-    context: &'ctx Context,
-    block: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    ptr: Value<'ctx, 'this>,
-    capacity: usize,
-    layout: Layout,
-) -> Result<Value<'ctx, 'this>> {
-    let capacity_bytes = layout_repeat(&layout, capacity)?.0.pad_to_align().size();
-    let capacity_bytes_value = block.const_int(context, location, capacity_bytes, 64)?;
-
-    let new_inputs_ptr = {
-        let ptr_ty = llvm::r#type::pointer(context, 0);
-        let new_inputs_ptr = block.append_op_result(llvm::zero(ptr_ty, location))?;
-        block.append_op_result(ReallocBindingsMeta::realloc(
-            context,
-            new_inputs_ptr,
-            capacity_bytes_value,
-            location,
-        )?)?
-    };
-
-    block.memcpy(context, location, ptr, new_inputs_ptr, capacity_bytes_value);
-
-    Ok(new_inputs_ptr)
 }
 
 pub const fn is_complex(info: &CircuitTypeConcrete) -> bool {

--- a/src/types/starknet.rs
+++ b/src/types/starknet.rs
@@ -22,13 +22,7 @@
 // TODO: Maybe the types used here can be i251 instead of i252. See https://github.com/starkware-libs/cairo_native/issues/1226
 
 use super::WithSelf;
-use crate::{
-    error::Result,
-    metadata::{
-        drop_overrides::DropOverridesMeta, dup_overrides::DupOverridesMeta,
-        realloc_bindings::ReallocBindingsMeta, MetadataStorage,
-    },
-};
+use crate::{error::Result, metadata::MetadataStorage};
 use cairo_lang_sierra::{
     extensions::{
         core::{CoreLibfunc, CoreType},
@@ -38,12 +32,8 @@ use cairo_lang_sierra::{
     program_registry::ProgramRegistry,
 };
 use melior::{
-    dialect::{func, llvm, ods},
-    helpers::{ArithBlockExt, BuiltinBlockExt},
-    ir::{
-        attribute::IntegerAttribute, r#type::IntegerType, Block, BlockLike, Location, Module,
-        Region, Type,
-    },
+    dialect::llvm,
+    ir::{r#type::IntegerType, Module, Type},
     Context,
 };
 
@@ -198,54 +188,12 @@ pub fn build_secp256_point<'ctx>(
 
 pub fn build_sha256_state_handle<'ctx>(
     context: &'ctx Context,
-    module: &Module<'ctx>,
-    registry: &ProgramRegistry<CoreType, CoreLibfunc>,
-    metadata: &mut MetadataStorage,
-    info: WithSelf<InfoOnlyConcreteType>,
+    _module: &Module<'ctx>,
+    _registry: &ProgramRegistry<CoreType, CoreLibfunc>,
+    _metadata: &mut MetadataStorage,
+    _info: WithSelf<InfoOnlyConcreteType>,
 ) -> Result<Type<'ctx>> {
-    let location = Location::unknown(context);
-    if metadata.get::<ReallocBindingsMeta>().is_none() {
-        metadata.insert(ReallocBindingsMeta::new(context, module));
-    }
-
-    DupOverridesMeta::register_with(context, module, registry, metadata, info.self_ty(), |_| {
-        let region = Region::new();
-        let block =
-            region.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
-
-        let null_ptr =
-            block.append_op_result(llvm::zero(llvm::r#type::pointer(context, 0), location))?;
-        let k32 = block.const_int(context, location, 32, 64)?;
-        let new_ptr = block.append_op_result(ReallocBindingsMeta::realloc(
-            context, null_ptr, k32, location,
-        )?)?;
-
-        block.append_operation(
-            ods::llvm::intr_memcpy_inline(
-                context,
-                new_ptr,
-                block.arg(0)?,
-                IntegerAttribute::new(IntegerType::new(context, 64).into(), 32),
-                IntegerAttribute::new(IntegerType::new(context, 1).into(), 0),
-                location,
-            )
-            .into(),
-        );
-
-        block.append_operation(func::r#return(&[block.arg(0)?, new_ptr], location));
-        Ok(Some(region))
-    })?;
-    DropOverridesMeta::register_with(context, module, registry, metadata, info.self_ty(), |_| {
-        let region = Region::new();
-        let block =
-            region.append_block(Block::new(&[(llvm::r#type::pointer(context, 0), location)]));
-
-        block.append_operation(ReallocBindingsMeta::free(context, block.arg(0)?, location)?);
-
-        block.append_operation(func::r#return(&[], location));
-        Ok(Some(region))
-    })?;
-
-    // A ptr to a heap (realloc) allocated [u32; 8]
+    // Arena-allocated [u32; 8]. No dup/drop overrides needed — bitwise
+    // copy of the pointer is safe and drop is a noop (arena owns memory).
     Ok(llvm::r#type::pointer(context, 0))
 }


### PR DESCRIPTION
# Move arrays, sha256 state, and circuit buffers to the per-invocation arena

  Closes #NA

  Extends the arena-allocation strategy introduced for boxes/nullables in #1593 to the remaining heap-allocated runtime types:

  - **Arrays** (`src/types/array.rs`, `src/libfuncs/array.rs`): data buffer and metadata are now allocated from the per-invocation arena. Dup is bitwise-copy of the pointer/length, drop is a noop — the previous dup/drop overrides that called `realloc`/`free` are deleted
  (~500 lines gone from `libfuncs/array.rs`). The `cairo_native__alloc_dict` / array realloc paths in `runtime.rs` are replaced with `cairo_native__arena_alloc`.
  - **Sha256StateHandle** (`src/types/starknet.rs`, `src/starknet.rs`): backing `[u32; 8]` moved to the arena; dup/drop overrides removed. The `wrap_sha256_process_block` syscall wrapper now copies the input state into a fresh arena slot before mutation — `Sha256StateHandle`
   is `Copy` in corelib, so the input pointer may be aliased by other live copies and mutating in place would corrupt them.
  - **Circuit types** — `CircuitInputAccumulator`, `CircuitData`, `CircuitOutputs` (`src/types/circuit.rs`, `src/libfuncs/circuit.rs`): u384 buffers moved to the arena, dup/drop overrides and the `build_array_dup` helper removed. `build_init_circuit_data` and `build_eval`
  allocate via `RuntimeBindingsMeta::arena_alloc` instead of `ReallocBindingsMeta::realloc`.
  - New regression test: `tests/cases/programs/types/array_dup_double_free.cairo`.

  ## Introduces Breaking Changes?

  No.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1615)
<!-- Reviewable:end -->
