### PR TITLE
refactor: store array data pointer inline, drop ArrayMetadata.

### DIFF
--- a/src/executor/contract.rs
+++ b/src/executor/contract.rs
@@ -50,7 +50,7 @@ use crate::{
     runtime::BLAKE_CALL_COUNT,
     starknet::{handler::StarknetSyscallHandlerCallbacks, StarknetSyscallHandler},
     statistics::{SierraDeclaredTypeStats, SierraFuncStats, Statistics},
-    types::{array::ArrayMetadata, TypeBuilder},
+    types::TypeBuilder,
     utils::{
         decode_error_message, generate_function_name, get_integer_layout, get_types_total_size,
         BuiltinCosts,
@@ -89,7 +89,7 @@ use std::{
     fs::{self, File},
     io,
     path::{Path, PathBuf},
-    ptr::{self, NonNull},
+    ptr::NonNull,
     sync::Arc,
     time::Instant,
 };
@@ -516,25 +516,7 @@ impl AotContractExecutor {
             };
         }
 
-        // Allocate metadata struct: { max_len: u32, data_ptr: *mut () }
-        let metadata_ptr = if data_ptr.is_null() {
-            ptr::null_mut()
-        } else {
-            unsafe {
-                let metadata = crate::runtime::cairo_native__arena_alloc(
-                    size_of::<ArrayMetadata>() as u64,
-                    align_of::<ArrayMetadata>() as u64,
-                )
-                .cast::<ArrayMetadata>();
-                metadata.write(ArrayMetadata {
-                    max_len: len_u32,
-                    data_ptr,
-                });
-                metadata.cast::<()>()
-            }
-        };
-
-        metadata_ptr.to_bytes(&mut invoke_data)?;
+        data_ptr.to_bytes(&mut invoke_data)?;
         if cfg!(target_arch = "aarch64") {
             0u32.to_bytes(&mut invoke_data)?; // start
             len_u32.to_bytes(&mut invoke_data)?; // end
@@ -666,16 +648,13 @@ impl AotContractExecutor {
         let value_layout = unsafe { Layout::from_size_align_unchecked(24, 8) };
         let mut value_ptr = unsafe { enum_ptr.byte_add(tag_layout.extend(value_layout)?.1).cast() };
 
-        let metadata_ptr = unsafe { *read_value::<*mut NonNull<()>>(&mut value_ptr) };
+        let data_ptr = unsafe { *read_value::<*mut u8>(&mut value_ptr) };
         let array_start = unsafe { *read_value::<u32>(&mut value_ptr) };
         let array_end = unsafe { *read_value::<u32>(&mut value_ptr) };
         let _array_capacity = unsafe { *read_value::<u32>(&mut value_ptr) };
 
         let mut array_value = Vec::with_capacity((array_end - array_start) as usize);
-        if !metadata_ptr.is_null() {
-            let metadata = unsafe { metadata_ptr.cast::<ArrayMetadata>().read() };
-            let data_ptr = metadata.data_ptr;
-
+        if !data_ptr.is_null() {
             let elem_stride = felt_layout.pad_to_align().size();
             for i in array_start..array_end {
                 let cur_elem_ptr = unsafe { data_ptr.byte_add(elem_stride * i as usize) };

--- a/src/libfuncs/array.rs
+++ b/src/libfuncs/array.rs
@@ -5,9 +5,6 @@ use crate::{
     error::{Error, Result, SierraAssertError},
     metadata::{runtime_bindings::RuntimeBindingsMeta, MetadataStorage},
     native_assert,
-    types::array::{
-        calc_metadata_align, calc_metadata_size, load_data_ptr, store_data_ptr, store_max_len,
-    },
     utils::ProgramRegistryExt,
 };
 use cairo_lang_sierra::{
@@ -189,25 +186,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
     // data_ptr aliases the input box: both are arena-backed.
     let data_ptr: Value = entry.argument(0)?.into();
 
-    // Allocate metadata struct from the arena.
-    let metadata_size = entry.const_int(context, location, calc_metadata_size(), 64)?;
-    let metadata_align_val = entry.const_int(context, location, calc_metadata_align(), 64)?;
-    let metadata_ptr = {
-        let rtb = metadata.get_or_insert_with(RuntimeBindingsMeta::default);
-        rtb.arena_alloc(
-            context,
-            helper.module,
-            entry,
-            location,
-            metadata_size,
-            metadata_align_val,
-        )?
-    };
-
-    store_max_len(context, entry, location, metadata_ptr, array_len)?;
-    store_data_ptr(context, entry, location, metadata_ptr, data_ptr)?;
-
-    // Build the array representation (4 fields: metadata_ptr, start, end, capacity)
+    // Build the array representation (4 fields: data_ptr, start, end, capacity)
     let value = entry.append_op_result(llvm::undef(
         llvm::r#type::r#struct(context, &[ptr_ty, len_ty, len_ty, len_ty], false),
         location,
@@ -216,7 +195,7 @@ pub fn build_span_from_tuple<'ctx, 'this>(
         context,
         location,
         value,
-        &[metadata_ptr, k0, array_len, array_len],
+        &[data_ptr, k0, array_len, array_len],
     )?;
 
     helper.br(entry, 0, &[value], location)
@@ -265,8 +244,7 @@ pub fn build_tuple_from_span<'ctx, 'this>(
     let len_ty = IntegerType::new(context, 32).into();
     let (_, elem_layout) = registry.build_type_with_layout(context, helper, metadata, elem_id)?;
 
-    let metadata_ptr =
-        entry.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
+    let data_ptr = entry.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
     let array_start =
         entry.extract_value(context, location, entry.argument(0)?.into(), len_ty, 1)?;
     let array_end = entry.extract_value(context, location, entry.argument(0)?.into(), len_ty, 2)?;
@@ -305,8 +283,6 @@ pub fn build_tuple_from_span<'ctx, 'this>(
             valid_block.const_int(context, location, elem_layout.pad_to_align().size(), 64)?,
             location,
         ))?;
-
-        let data_ptr = load_data_ptr(context, valid_block, location, metadata_ptr)?;
 
         let array_data_start_ptr = valid_block.gep(
             context,
@@ -376,21 +352,19 @@ pub fn build_append<'ctx, 'this>(
         Result::Ok((realloc_len, realloc_size))
     }
 
-    let metadata_ptr =
-        entry.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
+    let data_ptr = entry.extract_value(context, location, entry.argument(0)?.into(), ptr_ty, 0)?;
     let null_ptr = entry.append_op_result(llvm::zero(ptr_ty, location))?;
     let is_empty = entry.append_op_result(
         ods::llvm::icmp(
             context,
             IntegerType::new(context, 1).into(),
-            metadata_ptr,
+            data_ptr,
             null_ptr,
             IntegerAttribute::new(IntegerType::new(context, 64).into(), 0).into(),
             location,
         )
         .into(),
     )?;
-    let k0 = entry.const_int_from_type(context, location, 0, len_ty)?;
     let array_obj = entry.append_op_result(scf::r#if(
         is_empty,
         &[self_ty],
@@ -416,28 +390,8 @@ pub fn build_append<'ctx, 'this>(
                 )?
             };
 
-            // Allocate metadata struct from the arena.
-            let metadata_size = block.const_int(context, location, calc_metadata_size(), 64)?;
-            let metadata_align_val =
-                block.const_int(context, location, calc_metadata_align(), 64)?;
-            let metadata_ptr = {
-                let rtb = metadata.get_or_insert_with(RuntimeBindingsMeta::default);
-                rtb.arena_alloc(
-                    context,
-                    helper.module,
-                    &block,
-                    location,
-                    metadata_size,
-                    metadata_align_val,
-                )?
-            };
-
-            store_max_len(context, &block, location, metadata_ptr, k0)?;
-            store_data_ptr(context, &block, location, metadata_ptr, data_ptr)?;
-
-            // Build 4-field struct with capacity
             let array_obj = entry.argument(0)?.into();
-            let array_obj = block.insert_value(context, location, array_obj, metadata_ptr, 0)?;
+            let array_obj = block.insert_value(context, location, array_obj, data_ptr, 0)?;
             let array_obj = block.insert_value(context, location, array_obj, array_capacity, 3)?;
             block.append_operation(scf::r#yield(&[array_obj], location));
             region
@@ -480,15 +434,6 @@ pub fn build_append<'ctx, 'this>(
                         array_capacity,
                     )?;
 
-                    let metadata_ptr = block.extract_value(
-                        context,
-                        location,
-                        entry.argument(0)?.into(),
-                        ptr_ty,
-                        0,
-                    )?;
-                    let data_ptr = load_data_ptr(context, &block, location, metadata_ptr)?;
-
                     // Only [0, array_end) holds live data; the tail up to capacity is unused.
                     let array_end_64 =
                         block.extui(array_end, IntegerType::new(context, 64).into(), location)?;
@@ -496,6 +441,8 @@ pub fn build_append<'ctx, 'this>(
                     let data_align = block.const_int(context, location, elem_align, 64)?;
 
                     // Arena-realloc the data (old buffer is abandoned in the arena).
+                    // Pre-existing snapshots keep pointing at the old buffer, which remains
+                    // alive in the arena; the memcpy preserves their visible prefix.
                     let new_data_ptr = {
                         let rtb = metadata.get_or_insert_with(RuntimeBindingsMeta::default);
                         rtb.arena_alloc(
@@ -509,11 +456,9 @@ pub fn build_append<'ctx, 'this>(
                     };
                     block.memcpy(context, location, data_ptr, new_data_ptr, copy_size);
 
-                    // Update data_ptr in metadata
-                    store_data_ptr(context, &block, location, metadata_ptr, new_data_ptr)?;
-
-                    // Update capacity in struct field 3
                     let array_obj = entry.argument(0)?.into();
+                    let array_obj =
+                        block.insert_value(context, location, array_obj, new_data_ptr, 0)?;
                     let array_obj =
                         block.insert_value(context, location, array_obj, new_capacity, 3)?;
                     block.append_operation(scf::r#yield(&[array_obj], location));
@@ -528,8 +473,7 @@ pub fn build_append<'ctx, 'this>(
         location,
     ))?;
 
-    let metadata_ptr = entry.extract_value(context, location, array_obj, ptr_ty, 0)?;
-    let data_ptr = load_data_ptr(context, entry, location, metadata_ptr)?;
+    let data_ptr = entry.extract_value(context, location, array_obj, ptr_ty, 0)?;
 
     // Insert the value.
     let target_offset = entry.extract_value(context, location, array_obj, len_ty, 2)?;
@@ -554,8 +498,6 @@ pub fn build_append<'ctx, 'this>(
     let array_end = entry.extract_value(context, location, array_obj, len_ty, 2)?;
     let array_end = entry.addi(array_end, k1, location)?;
     let array_obj = entry.insert_value(context, location, array_obj, array_end, 2)?;
-
-    store_max_len(context, entry, location, metadata_ptr, array_end)?;
 
     helper.br(entry, 0, &[array_obj], location)
 }
@@ -656,9 +598,7 @@ fn build_pop<'ctx, 'this, const CONSUME: bool, const REVERSE: bool>(
     {
         let mut branch_values = branch_values.clone();
 
-        let metadata_ptr = valid_block.extract_value(context, location, array_obj, ptr_ty, 0)?;
-
-        let data_ptr = load_data_ptr(context, valid_block, location, metadata_ptr)?;
+        let data_ptr = valid_block.extract_value(context, location, array_obj, ptr_ty, 0)?;
 
         let elem_stride =
             valid_block.const_int(context, location, elem_layout.pad_to_align().size(), 64)?;
@@ -790,9 +730,8 @@ pub fn build_get<'ctx, 'this>(
         )?;
         let source_offset = valid_block.muli(source_offset, elem_stride, location)?;
 
-        let metadata_ptr =
+        let data_ptr =
             valid_block.extract_value(context, location, entry.argument(1)?.into(), ptr_ty, 0)?;
-        let data_ptr = load_data_ptr(context, valid_block, location, metadata_ptr)?;
 
         let source_ptr = valid_block.gep(
             context,

--- a/src/metadata/trace_dump.rs
+++ b/src/metadata/trace_dump.rs
@@ -407,14 +407,12 @@ pub mod trace_dump_runtime {
                 let mut data = Vec::with_capacity((array.until - array.since) as usize);
 
                 if !array.ptr.is_null() {
-                    let data_ptr = array.ptr.read();
                     for index in (array.since)..array.until {
                         let index = index as usize;
-
                         data.push(value_from_ptr(
                             registry,
                             &info.ty,
-                            NonNull::new(data_ptr.byte_add(layout.size() * index)).unwrap(),
+                            NonNull::new(array.ptr.byte_add(layout.size() * index)).unwrap(),
                         ));
                     }
                 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     starknet::{ArrayAbi, Felt252Abi},
-    types::array::ArrayMetadata,
     utils::{blake_utils, BuiltinCosts},
 };
 use bumpalo::Bump;
@@ -335,18 +334,8 @@ unsafe fn create_dict_entries_array(dict: &mut FeltDict) -> ArrayAbi<c_void> {
         final_value_ptr.copy_from_nonoverlapping(value, element_size);
     }
 
-    // Allocate and initialize ArrayMetadata struct from the arena
-    let metadata_ptr = cairo_native__arena_alloc(
-        size_of::<ArrayMetadata>() as u64,
-        align_of::<ArrayMetadata>() as u64,
-    ) as *mut ArrayMetadata;
-    metadata_ptr.write(ArrayMetadata {
-        max_len: len as u32,
-        data_ptr: data_ptr.cast::<u8>(),
-    });
-
     ArrayAbi {
-        ptr: metadata_ptr.cast(),
+        ptr: data_ptr.cast(),
         since: 0,
         until: len as u32,
         capacity: len as u32,

--- a/src/starknet.rs
+++ b/src/starknet.rs
@@ -1,6 +1,5 @@
 //! Starknet related code for `cairo_native`
 
-use crate::types::array::ArrayMetadata;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
@@ -9,7 +8,7 @@ pub type SyscallResult<T> = std::result::Result<T, Vec<Felt>>;
 #[repr(C)]
 #[derive(Debug)]
 pub struct ArrayAbi<T> {
-    pub ptr: *mut *mut T,
+    pub ptr: *mut T,
     pub since: u32,
     pub until: u32,
     pub capacity: u32,
@@ -24,12 +23,7 @@ impl From<&ArrayAbi<Felt252Abi>> for Vec<Felt> {
             let len = until_offset - since_offset;
             match len {
                 0 => &[],
-                _ => {
-                    // Access data through ArrayMetadata.data_ptr
-                    let metadata = &*value.ptr.cast::<ArrayMetadata>();
-                    let data_ptr = metadata.data_ptr.cast::<Felt252Abi>();
-                    std::slice::from_raw_parts(data_ptr.add(since_offset), len)
-                }
+                _ => std::slice::from_raw_parts(value.ptr.add(since_offset), len),
             }
         }
         .iter()
@@ -642,7 +636,7 @@ impl StarknetSyscallHandler for DummySyscallHandler {
 // TODO: Move to the correct place or remove if unused. See: https://github.com/starkware-libs/cairo_native/issues/1222
 pub(crate) mod handler {
     use super::*;
-    use crate::{types::array::ArrayMetadata, utils::libc_malloc};
+    use crate::utils::libc_malloc;
     use std::{
         alloc::Layout,
         fmt::Debug,
@@ -1060,7 +1054,7 @@ pub(crate) mod handler {
                 _ => {
                     let len: u32 = data.len().try_into().unwrap();
 
-                    // Allocate data from the arena (no prefix).
+                    // Allocate data from the arena.
                     let data_layout = Layout::array::<E>(data.len()).unwrap();
                     let data_ptr = crate::runtime::cairo_native__arena_alloc(
                         data_layout.size() as u64,
@@ -1071,18 +1065,8 @@ pub(crate) mod handler {
                         data_ptr.add(i).write(val.clone());
                     }
 
-                    let metadata_layout = Layout::new::<ArrayMetadata>();
-                    let metadata_ptr = crate::runtime::cairo_native__arena_alloc(
-                        metadata_layout.size() as u64,
-                        metadata_layout.align() as u64,
-                    ) as *mut ArrayMetadata;
-                    metadata_ptr.write(ArrayMetadata {
-                        max_len: len,
-                        data_ptr: data_ptr.cast::<u8>(),
-                    });
-
                     ArrayAbi {
-                        ptr: metadata_ptr.cast(),
+                        ptr: data_ptr,
                         since: 0,
                         until: len,
                         capacity: len,
@@ -1605,12 +1589,7 @@ pub(crate) mod handler {
                 let len = until_offset - since_offset;
                 match len {
                     0 => &[],
-                    _ => {
-                        // Access data through ArrayMetadata.data_ptr
-                        let metadata = &*input.ptr.cast::<ArrayMetadata>();
-                        let data_ptr = metadata.data_ptr.cast::<u64>();
-                        std::slice::from_raw_parts(data_ptr.add(since_offset), len)
-                    }
+                    _ => std::slice::from_raw_parts(input.ptr.add(since_offset), len),
                 }
             };
 

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -4,21 +4,14 @@
 //!
 //! ## Layout
 //!
-//! Being dynamically allocated, we just need to keep the pointer to the metadata, its length and
-//! its capacity:
+//! | Index | Type        | Description                              |
+//! | ----- | ----------- | ---------------------------------------- |
+//! |   0   | `!llvm.ptr` | Pointer to the element data buffer[^1].  |
+//! |   1   | `i32`       | Array start offset[^2].                  |
+//! |   2   | `i32`       | Array end offset[^2].                    |
+//! |   3   | `i32`       | Allocated capacity[^2].                  |
 //!
-//! | Index | Type        | Description                   |
-//! | ----- | ----------- | ----------------------------- |
-//! |   0   | `!llvm.ptr` | Pointer to ArrayMetadata[^1]. |
-//! |   1   | `i32`       | Array start offset[^2].       |
-//! |   2   | `i32`       | Array end offset[^2].         |
-//! |   3   | `i32`       | Allocated capacity[^2].       |
-//!
-//! The ArrayMetadata struct contains:
-//!   1. Array max length (`u32`).
-//!   2. Pointer to array data (`*mut u8`).
-//!
-//! [^1]: This pointer is null when the array has not yet been allocated (i.e., initially).
+//! [^1]: This pointer is null when no buffer has been allocated yet (i.e. for a fresh empty array).
 //! [^2]: Those numbers are number of items, **not bytes**.
 
 use super::WithSelf;
@@ -32,8 +25,7 @@ use cairo_lang_sierra::{
 };
 use melior::{
     dialect::llvm,
-    helpers::{GepIndex, LlvmBlockExt},
-    ir::{r#type::IntegerType, Block, Location, Module, Type, Value},
+    ir::{r#type::IntegerType, Module, Type},
     Context,
 };
 
@@ -58,122 +50,6 @@ pub fn build<'ctx>(
         &[ptr_ty, len_ty, len_ty, len_ty],
         false,
     ))
-}
-
-/// Metadata struct definition for arrays (maxlen, data_ptr).
-#[repr(C)]
-pub struct ArrayMetadata {
-    pub max_len: u32,
-    pub data_ptr: *mut u8,
-}
-
-/// Returns the metadata struct layout size.
-pub fn calc_metadata_size() -> usize {
-    std::mem::size_of::<ArrayMetadata>()
-}
-
-/// Returns the metadata struct alignment.
-pub fn calc_metadata_align() -> usize {
-    std::mem::align_of::<ArrayMetadata>()
-}
-
-/// Get the LLVM struct type for ArrayMetadata: { max_len: i32, data_ptr: ptr }
-///
-/// Field indices:
-/// - 0: max_len (u32)
-/// - 1: data_ptr (*mut u8)
-pub fn get_metadata_llvm_type(context: &Context) -> Type<'_> {
-    llvm::r#type::r#struct(
-        context,
-        &[
-            IntegerType::new(context, 32).into(), // max_len: u32
-            llvm::r#type::pointer(context, 0),    // data_ptr: *mut u8
-        ],
-        false,
-    )
-}
-
-#[repr(i32)]
-enum MetadataField {
-    MaxLen = 0,
-    DataPtr = 1,
-}
-
-/// Returns a pointer to the given `field` in the ArrayMetadata struct.
-fn metadata_field_ptr<'ctx, 'this>(
-    context: &'ctx Context,
-    block: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    metadata_ptr: Value<'ctx, 'this>,
-    field: MetadataField,
-) -> Result<Value<'ctx, 'this>> {
-    Ok(block.gep(
-        context,
-        location,
-        metadata_ptr,
-        &[GepIndex::Const(0), GepIndex::Const(field as i32)],
-        get_metadata_llvm_type(context),
-    )?)
-}
-
-/// Load `data_ptr` from the ArrayMetadata struct.
-pub fn load_data_ptr<'ctx, 'this>(
-    context: &'ctx Context,
-    block: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    metadata_ptr: Value<'ctx, 'this>,
-) -> Result<Value<'ctx, 'this>> {
-    let field_ptr = metadata_field_ptr(
-        context,
-        block,
-        location,
-        metadata_ptr,
-        MetadataField::DataPtr,
-    )?;
-    Ok(block.load(
-        context,
-        location,
-        field_ptr,
-        llvm::r#type::pointer(context, 0),
-    )?)
-}
-
-/// Store `max_len` (i32) into the ArrayMetadata struct.
-pub fn store_max_len<'ctx, 'this>(
-    context: &'ctx Context,
-    block: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    metadata_ptr: Value<'ctx, 'this>,
-    max_len: Value<'ctx, 'this>,
-) -> Result<()> {
-    let field_ptr = metadata_field_ptr(
-        context,
-        block,
-        location,
-        metadata_ptr,
-        MetadataField::MaxLen,
-    )?;
-    block.store(context, location, field_ptr, max_len)?;
-    Ok(())
-}
-
-/// Store `data_ptr` into the ArrayMetadata struct.
-pub fn store_data_ptr<'ctx, 'this>(
-    context: &'ctx Context,
-    block: &'this Block<'ctx>,
-    location: Location<'ctx>,
-    metadata_ptr: Value<'ctx, 'this>,
-    data_ptr: Value<'ctx, 'this>,
-) -> Result<()> {
-    let field_ptr = metadata_field_ptr(
-        context,
-        block,
-        location,
-        metadata_ptr,
-        MetadataField::DataPtr,
-    )?;
-    block.store(context, location, field_ptr, data_ptr)?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/values.rs
+++ b/src/values.rs
@@ -6,8 +6,8 @@ use crate::{
     error::{panic::ToNativeAssertError, CompilerError, Error},
     native_assert, native_panic,
     runtime::FeltDict,
-    starknet::{Secp256k1Point, Secp256r1Point},
-    types::{array::ArrayMetadata, TypeBuilder},
+    starknet::{ArrayAbi, Secp256k1Point, Secp256r1Point},
+    types::TypeBuilder,
     utils::{felt252_bigint, get_integer_layout, layout_repeat, RangeExt, PRIME},
 };
 use bumpalo::Bump;
@@ -245,45 +245,14 @@ impl Value {
                             );
                         }
 
-                        // Allocate metadata struct: { max_len: u32, data_ptr: *mut () }
-                        let metadata_ptr: *mut () = if data_ptr.is_null() {
-                            null_mut()
-                        } else {
-                            let metadata: *mut ArrayMetadata = arena
-                                .alloc_layout(Layout::new::<ArrayMetadata>())
-                                .cast()
-                                .as_ptr();
-                            metadata.write(ArrayMetadata {
-                                max_len: len,
-                                data_ptr,
-                            });
-                            metadata.cast()
+                        let target = arena.alloc_layout(Layout::new::<ArrayAbi<u8>>()).as_ptr();
+
+                        *target.cast::<ArrayAbi<u8>>() = ArrayAbi {
+                            ptr: data_ptr,
+                            since: 0,
+                            until: len,
+                            capacity: len,
                         };
-
-                        let target = arena
-                            .alloc_layout(
-                                Layout::new::<*mut ()>() // metadata_ptr
-                                    .extend(Layout::new::<u32>())? // start
-                                    .0
-                                    .extend(Layout::new::<u32>())? // end
-                                    .0
-                                    .extend(Layout::new::<u32>())? // capacity
-                                    .0
-                                    .pad_to_align(),
-                            )
-                            .as_ptr();
-
-                        *target.cast::<*mut ()>() = metadata_ptr.cast();
-
-                        let (layout, offset) =
-                            Layout::new::<*mut NonNull<()>>().extend(Layout::new::<u32>())?;
-                        *target.byte_add(offset).cast::<u32>() = 0; // start
-
-                        let (layout, offset) = layout.extend(Layout::new::<u32>())?;
-                        *target.byte_add(offset).cast::<u32>() = len; // end
-
-                        let (_, offset) = layout.extend(Layout::new::<u32>())?;
-                        *target.byte_add(offset).cast::<u32>() = len; // capacity
 
                         NonNull::new_unchecked(target).cast()
                     } else {
@@ -602,24 +571,18 @@ impl Value {
                         .as_ref();
                     let (_ptr_layout, _offset) = ptr_layout.extend(len_layout)?; // capacity (unused here)
 
-                    // This pointer can be null if the array is empty.
-                    let metadata_ptr = *ptr.cast::<*mut *mut ()>().as_ref();
+                    // This pointer is null when no buffer has been allocated for the array.
+                    let data_ptr = *ptr.cast::<*mut u8>().as_ref();
 
-                    let array_value = if metadata_ptr.is_null() {
+                    let array_value = if data_ptr.is_null() {
                         Vec::new()
                     } else {
-                        let metadata = metadata_ptr
-                            .cast::<ArrayMetadata>()
-                            .as_ref()
-                            .to_native_assert_error("metadata pointer should not be null")?;
-
                         native_assert!(
                             end_offset_value >= start_offset_value,
                             "can't have an array with negative length"
                         );
                         let num_elems = (end_offset_value - start_offset_value) as usize;
 
-                        let data_ptr = metadata.data_ptr;
                         let mut array_value = Vec::with_capacity(num_elems);
                         for i in start_offset_value..end_offset_value {
                             let cur_elem_ptr =


### PR DESCRIPTION
# Refactor: store array data pointer inline, drop ArrayMetadata

  Closes #NA

  Removes the ArrayMetadata { max_len, data_ptr } indirection. The array struct still has shape {ptr, start, end, capacity}, but ptr now points directly to the element buffer instead of to a heap-allocated metadata struct. max_len was only ever written, never read.

  Net effect per array op: one fewer arena allocation and one fewer load.

  Introduces Breaking Changes?

  Yes.

  ArrayAbi.ptr changes from *mut *mut T to *mut T. Any external consumer reading ArrayAbi (notably starknet-replay and the sequencer fork) must follow.

  - Created PR in sequencer
  - Created PR in starknet-replay
  - Updated the starknet-blocks.yml workflow to use these PRs.

  These PRs should be merged after this one right away, in that order.

  Checklist

  - Linked to Github Issue.
  - Unit tests added. (existing array/snapshot/dict-array tests cover the new layout)
  - Integration tests added.
  - This change requires new documentation.
    - Documentation has been added/updated. (layout table in src/types/array.rs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1619)
<!-- Reviewable:end -->
