### PR TITLE
Fix manifest_path for binary uploads in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cairo-native-compile
+          manifest_path: binaries/cairo-native-compile/Cargo.toml
           target: ${{ matrix.target }}
           tar: unix
           zip: windows
@@ -53,6 +54,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cairo-native-dump
+          manifest_path: binaries/cairo-native-dump/Cargo.toml
           target: ${{ matrix.target }}
           tar: unix
           zip: windows
@@ -61,6 +63,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cairo-native-run
+          manifest_path: binaries/cairo-native-run/Cargo.toml
           target: ${{ matrix.target }}
           tar: unix
           zip: windows
@@ -78,6 +81,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cairo-native-test
+          manifest_path: binaries/cairo-native-test/Cargo.toml
           target: ${{ matrix.target }}
           tar: unix
           zip: windows
@@ -86,6 +90,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: starknet-native-compile
+          manifest_path: binaries/starknet-native-compile/Cargo.toml
           target: ${{ matrix.target }}
           tar: unix
           zip: windows


### PR DESCRIPTION
## Summary
- Adds `manifest_path` to the 5 `taiki-e/upload-rust-binary-action@v1` steps that were missing it in `.github/workflows/release.yml`.
- Without `manifest_path`, the action runs `cargo build --bin <name>` from the repo root. Since the root `Cargo.toml` declares `[package]` (cairo-native), cargo treats it as the default-run package and only searches it — failing with `error: no bin target named X in default-run packages`.
- The bins live in workspace member packages under `binaries/`, so each step needs `manifest_path` pointing at the member's `Cargo.toml`. `cairo-native-stress` already had this, which is why it was the only binary uploaded successfully in past releases.

## Background
The "GitHub Release" workflow has been failing on every release since at least v0.9.0-rc.5. crates.io publishing was unaffected — only the binary asset uploads to the GitHub release have been broken.

## Test plan
- [ ] On the next tag push (e.g. v0.9.0-rc.8), confirm the GitHub Release contains tarballs for all six binaries on both `x86_64-unknown-linux-gnu` and `x86_64-apple-darwin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1622)
<!-- Reviewable:end -->
