### PR TITLE
Disallow warnings when compiling test data

### DIFF
--- a/test_data/programs/array_slice_overflow.cairo
+++ b/test_data/programs/array_slice_overflow.cairo
@@ -1,4 +1,4 @@
 fn run_test(user_len: u32) {
     let arr: Array<u64> = array![10_u64, 20_u64];
-    let slice = arr.span().slice(1, user_len);
+    let _slice = arr.span().slice(1, user_len);
 }

--- a/test_data/programs/libfuncs/array_snapshot_pop_back_clone_offset.cairo
+++ b/test_data/programs/libfuncs/array_snapshot_pop_back_clone_offset.cairo
@@ -3,7 +3,7 @@ fn run_test() -> Span<felt252> {
     let mut data = data.span();
 
     assert(*data.pop_front().unwrap() == 7, 0);
-    let data2 = data.clone();
+    let _data2 = data.clone();
 
     assert(*data.pop_back().unwrap() == 193827, 1);
 

--- a/test_data/programs/libfuncs/array_snapshot_pop_front_clone_offset.cairo
+++ b/test_data/programs/libfuncs/array_snapshot_pop_front_clone_offset.cairo
@@ -3,7 +3,7 @@ fn run_test() -> Span<felt252> {
     let mut data = data.span();
 
     assert(*data.pop_front().unwrap() == 7, 0);
-    let data2 = data.clone();
+    let _data2 = data.clone();
 
     assert(*data.pop_front().unwrap() == 3, 1);
 

--- a/test_utils/src/bin/compile-cairo-project.rs
+++ b/test_utils/src/bin/compile-cairo-project.rs
@@ -35,9 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         dbb.build()?
     };
     let crate_inputs = setup_project(&mut db, &args.cairo_path)?;
-    let diagnostics_reporter = DiagnosticsReporter::stderr()
-        .with_crates(&crate_inputs)
-        .allow_warnings();
+    let diagnostics_reporter = DiagnosticsReporter::stderr().with_crates(&crate_inputs);
     let crate_ids = CrateInput::into_crate_ids(&db, crate_inputs);
 
     let program = compile_prepared_db_program_artifact(

--- a/test_utils/src/bin/compile-cairo-tests.rs
+++ b/test_utils/src/bin/compile-cairo-tests.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let compiler = TestCompiler::try_new(
         &args.cairo_path,
-        true,
+        false,
         true,
         TestsCompilationConfig {
             starknet: args.starknet,


### PR DESCRIPTION
## Summary
- `compile-cairo-project` and `compile-cairo-tests` previously accepted warnings (the former explicitly called `.allow_warnings()`, the latter passed `allow_warnings=true` to `TestCompiler::try_new`). `make compile-test-data` now fails fast on warnings instead.
- Fixed the three Cairo files that had unused-variable warnings by prefixing the bindings with `_`.

## Test plan
- [x] `make compile-test-data` runs to completion with no warnings.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1623)
<!-- Reviewable:end -->
