### PR TITLE
fixed a bug where coupons type is not calculated correctly at return …

### DIFF
--- a/src/libfuncs/function_call.rs
+++ b/src/libfuncs/function_call.rs
@@ -248,6 +248,7 @@ pub fn build<'ctx, 'this>(
                 // Complex return type. Just extract the values from the struct, since LLVM will
                 // handle the rest.
 
+                let mut count = 0;
                 for (idx, type_id) in info.function.signature.ret_types.iter().enumerate() {
                     let type_info = registry.get_type(type_id)?;
 
@@ -258,9 +259,10 @@ pub fn build<'ctx, 'this>(
                             context,
                             location,
                             function_call_result,
-                            result_types[idx],
-                            idx,
+                            result_types[count],
+                            count,
                         )?;
+                        count += 1;
 
                         results.push(val);
                     }

--- a/test_data/programs/coupons_function_param/cairo_project.toml
+++ b/test_data/programs/coupons_function_param/cairo_project.toml
@@ -1,0 +1,10 @@
+[crate_roots]
+coupons_function_param = "."
+
+[config.global]
+edition = "2023_01"
+
+[config.global.experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = true

--- a/test_data/programs/coupons_function_param/coupons_function_param.cairo
+++ b/test_data/programs/coupons_function_param/coupons_function_param.cairo
@@ -1,0 +1,15 @@
+extern fn coupon_buy<T>() -> T nopanic;
+fn run_test(mut x: felt252) {
+
+    let mut y = x + 4;
+    let mut c = coupon_buy();
+    bar(ref x, ref c, ref y);
+    foo(__coupon__: c);
+}
+#[inline(never)]
+fn foo() {
+
+}
+#[inline(never)]
+fn bar(ref x: felt252, ref c: foo::Coupon, ref y: felt252) {
+}

--- a/test_data/programs/coupons_function_param/lib.cairo
+++ b/test_data/programs/coupons_function_param/lib.cairo
@@ -1,0 +1,1 @@
+mod coupons_function_param;

--- a/tests/tests/coupon.rs
+++ b/tests/tests/coupon.rs
@@ -1,0 +1,35 @@
+use crate::common::{compare_outputs, run_native_program, run_vm_program, DEFAULT_GAS};
+use cairo_lang_runner::Arg;
+use cairo_native::starknet::DummySyscallHandler;
+use cairo_native::utils::testing::load_program_and_runner;
+use cairo_native::Value;
+use starknet_types_core::felt::Felt;
+
+#[test]
+fn return_coupon() {
+    let program = &load_program_and_runner("programs/coupons_function_param");
+    let x = 5;
+
+    let result_vm = run_vm_program(
+        program,
+        "run_test",
+        vec![Arg::Value(Felt::from(x))],
+        Some(DEFAULT_GAS as usize),
+    )
+    .unwrap();
+    let result_native = run_native_program(
+        program,
+        "run_test",
+        &[Value::Felt252(Felt::from(x))],
+        Some(DEFAULT_GAS),
+        Option::<DummySyscallHandler>::None,
+    );
+
+    compare_outputs(
+        &program.1,
+        &program.2.find_function("run_test").unwrap().id,
+        &result_vm,
+        &result_native,
+    )
+    .expect("coupon function call diverges between VM and native");
+}

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -4,6 +4,7 @@ pub mod boolean;
 pub mod cases;
 pub mod circuit;
 pub mod compile_library;
+pub mod coupon;
 pub mod dict;
 pub mod e2e_libfuncs;
 pub mod ec;


### PR DESCRIPTION
  #Fix incorrect type index for coupon (ZST) types in complex return values

  Closes #NA

  When a function has a "complex" return type, the lowering loop iterated over info.function.signature.ret_types and used the enumeration index idx to index into result_types. However, result_types
  only contains the non-ZST returned values — builtin zero-sized types (such as Coupon) are skipped. When a ZST type appeared before other return values, every subsequent value was extracted at the
  wrong offset, producing incorrect results.

  The fix introduces a separate count that only advances for actually-materialized (non-ZST) values, so extract_value always reads from the correct slot in result_types.

  Introduces Breaking Changes?

  No.

  Checklist

  - [ ] Linked to Github Issue.
  - [x] Unit tests added.
  - [x] Integration tests added.
  - [ ] This change requires new documentation.
    - [ ] Documentation has been added/updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1630)
<!-- Reviewable:end -->
