### PR TITLE
fix: drop bogus i64 return from cairo_native__dict_squash MLIR call

### DIFF
--- a/src/metadata/runtime_bindings.rs
+++ b/src/metadata/runtime_bindings.rs
@@ -830,11 +830,9 @@ impl RuntimeBindingsMeta {
         Ok((is_present, value_ptr))
     }
 
-    /// Register if necessary, then invoke the `dict_gas_refund()` function.
+    /// Register if necessary, then invoke the `dict_squash()` function.
     ///
-    /// Compute the total gas refund for the dictionary.
-    ///
-    /// Returns a u64 of the result.
+    /// Squash the dictionary in place, updating the range check and gas pointers.
     #[allow(clippy::too_many_arguments)]
     pub fn dict_squash<'c, 'a>(
         &mut self,
@@ -856,7 +854,6 @@ impl RuntimeBindingsMeta {
             OperationBuilder::new("llvm.call", location)
                 .add_operands(&[function])
                 .add_operands(&[dict_ptr, range_check_ptr, gas_ptr])
-                .add_results(&[IntegerType::new(context, 64).into()])
                 .build()?,
         ))
     }


### PR DESCRIPTION
## Summary

The MLIR `llvm.call` binding to `cairo_native__dict_squash` (in `src/metadata/runtime_bindings.rs`) declared an `i64` return value via `.add_results(...)`, but the actual C function in `src/runtime.rs` returns `void`.

The declared result was never consumed — the sole caller (`src/libfuncs/felt252_dict.rs`) discards the operation result. It was only harmless because dead-value elimination removed the unused value, but it is a genuine ABI mismatch that could surface as `OptLevel` increases.

## Changes

- Remove `.add_results(&[IntegerType::new(context, 64).into()])` from the `dict_squash` call, matching the pattern used by other void calls like `dict_into_entries`.
- Fix the doc comment, which was copy-pasted from `dict_gas_refund` and incorrectly claimed a u64 return.

## Testing

- `cargo build --lib` passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1638)
<!-- Reviewable:end -->
