### PR TITLE
fix: size dict elements buffer to HashMap capacity, not len

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -370,17 +370,6 @@ impl Value {
                         let elem_ty = registry.get_type(&info.ty)?;
                         let elem_layout = elem_ty.layout(registry)?;
 
-                        // Arena-allocate the elements buffer.
-                        let elements = if map.is_empty() {
-                            null_mut()
-                        } else {
-                            crate::runtime::cairo_native__arena_alloc(
-                                (elem_layout.pad_to_align().size() * map.len()) as u64,
-                                elem_layout.align() as u64,
-                            )
-                            .cast()
-                        };
-
                         // Arena-allocate the FeltDict struct and register it.
                         let dict_ptr = crate::runtime::cairo_native__dict_new(
                             elem_layout.size() as u64,
@@ -388,6 +377,19 @@ impl Value {
                         );
                         let dict = &mut *dict_ptr;
                         dict.mappings.reserve(map.len());
+
+                        // Arena-allocate the elements buffer. It must be sized to the
+                        // HashMap's capacity (read *after* `reserve`).
+                        let capacity = dict.mappings.capacity();
+                        let elements = if map.is_empty() {
+                            null_mut()
+                        } else {
+                            crate::runtime::cairo_native__arena_alloc(
+                                (elem_layout.pad_to_align().size() * capacity) as u64,
+                                elem_layout.align() as u64,
+                            )
+                            .cast()
+                        };
                         dict.elements = elements;
 
                         for (key, value) in map.iter() {


### PR DESCRIPTION
## Summary

When materializing a `Felt252Dict` value (`Value::Felt252Dict` → native), the elements buffer was arena-allocated with room for `map.len()` slots. The runtime's `dict_get` only grows the elements buffer once the backing `HashMap` is full, so a runtime insert of a new key could write one slot past the end of the buffer and corrupt the arena.

This reorders the allocation so the `FeltDict` struct is created and `reserve`d first, then sizes the elements buffer to the HashMap's actual `capacity()` (which `reserve` usually over-allocates). That guarantees there is always room for the runtime to fill every slot the HashMap can hold.

## Changes

- `src/values.rs`: allocate/register the `FeltDict` before the elements buffer, and size the buffer to `dict.mappings.capacity()` instead of `map.len()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1646)
<!-- Reviewable:end -->
