### PR TITLE
fix(values): un-box memory-allocated enum payload in Value::to_ptr

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -327,7 +327,17 @@ impl Value {
                         native_assert!(*tag < info.variants.len(), "Variant index out of range.");
 
                         let payload_type_id = &info.variants[*tag];
+                        let payload_ty = registry.get_type(payload_type_id)?;
                         let payload = value.to_ptr(arena, registry, payload_type_id)?;
+
+                        // Undo the wrapper pointer added when the payload is memory
+                        // allocated (e.g. a nested >=2-variant enum), so that the copy
+                        // below reads the payload data rather than the wrapper pointer.
+                        let payload = if payload_ty.is_memory_allocated(registry)? {
+                            *payload.cast::<NonNull<()>>().as_ref()
+                        } else {
+                            payload
+                        };
 
                         let (layout, tag_layout, variant_layouts) =
                             crate::types::r#enum::get_layout_for_variants(

--- a/test_data/programs/nested_enum_arg.cairo
+++ b/test_data/programs/nested_enum_arg.cairo
@@ -1,0 +1,29 @@
+// Both `Inner` and `Outer` are 2-variant enums, so both are memory-allocated.
+// Passing an `Outer` as an argument forces `to_ptr` to serialize a nested
+// memory-allocated enum. The return value depends on both discriminants and the
+// payload, so any corruption of the nested value changes the result.
+
+#[derive(Drop)]
+enum Inner {
+    A: felt252,
+    B: felt252,
+}
+
+#[derive(Drop)]
+enum Outer {
+    X: Inner,
+    Y: Inner,
+}
+
+fn run_test(x: Outer) -> felt252 {
+    match x {
+        Outer::X(inner) => match inner {
+            Inner::A(v) => v,
+            Inner::B(v) => v + 1,
+        },
+        Outer::Y(inner) => match inner {
+            Inner::A(v) => v + 2,
+            Inner::B(v) => v + 3,
+        },
+    }
+}

--- a/tests/tests/enums.rs
+++ b/tests/tests/enums.rs
@@ -50,3 +50,52 @@ fn single_variant_enum_in_array_matches_vm() {
     )
     .expect("single-variant enum in array must agree between VM and native");
 }
+
+#[test]
+fn nested_enum_argument_matches_vm() {
+    let program = &load_program_and_runner("programs/nested_enum_arg");
+
+    // (outer_tag, inner_tag). Both enums have 2 variants, so the tag equals the
+    // variant index (no selector encoding is needed).
+    for (outer_tag, inner_tag) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
+        let payload = Felt::from(0x1234);
+
+        let result_vm = run_vm_program(
+            program,
+            "run_test",
+            vec![
+                Arg::Value(Felt::from(outer_tag as u64)),
+                Arg::Value(Felt::from(inner_tag as u64)),
+                Arg::Value(payload),
+            ],
+            Some(DEFAULT_GAS as usize),
+        )
+        .unwrap();
+
+        let result_native = run_native_program(
+            program,
+            "run_test",
+            &[Value::Enum {
+                tag: outer_tag,
+                value: Box::new(Value::Enum {
+                    tag: inner_tag,
+                    value: Box::new(Value::Felt252(payload)),
+                    debug_name: None,
+                }),
+                debug_name: None,
+            }],
+            Some(DEFAULT_GAS),
+            Option::<DummySyscallHandler>::None,
+        );
+
+        compare_outputs(
+            &program.1,
+            &program.2.find_function("run_test").unwrap().id,
+            &result_vm,
+            &result_native,
+        )
+        .unwrap_or_else(|e| {
+            panic!("nested enum (outer={outer_tag}, inner={inner_tag}) mismatch: {e:?}")
+        });
+    }
+}


### PR DESCRIPTION
## What

The `Enum` arm of `Value::to_ptr` (`src/values.rs`) copied the payload straight from the pointer returned by the payload's own `to_ptr`. When the payload is a **memory-allocated** type — e.g. a nested `>=2`-variant enum, which `is_memory_allocated` marks true — that pointer is a *wrapper* (a pointer to the data pointer). The copy therefore read the 8-byte wrapper pointer plus adjacent bump-arena garbage into the parent variant slot, instead of the actual payload data.

Because a 2-variant enum accepts any tag bit pattern, the corrupted value never trips an "invalid tag" assert: execution completes and returns a wrong result with **no crash and no signal** — a silent correctness bug.

The sibling `Struct` arm a few lines above already handles this by un-boxing memory-allocated members; this change makes the `Enum` arm do the same.

## Fix

```rust
let payload_type_id = &info.variants[*tag];
let payload_ty = registry.get_type(payload_type_id)?;
let payload = value.to_ptr(arena, registry, payload_type_id)?;
// Undo the wrapper pointer added when the payload is memory
// allocated (e.g. a nested >=2-variant enum).
let payload = if payload_ty.is_memory_allocated(registry)? {
    *payload.cast::<NonNull<()>>().as_ref()
} else {
    payload
};
```

## Reachability / scope

Only reachable through the generic `JitNativeExecutor::invoke_dynamic(&[Value], …)` API (used by `cairo-native-run` / `cairo-native-test` and library consumers passing structured `Value` arguments). The Starknet **contract** path (`executor/contract.rs`) marshals arguments and results as raw felts and never calls `Value::to_ptr` / `Value::from_ptr`, so sequencer/contract execution is unaffected.

## Test

Adds `nested_enum_argument_matches_vm` (`tests/tests/enums.rs`) with a nested 2-variant-enum program (`test_data/programs/nested_enum_arg.cairo`), comparing native vs VM across all four `(outer_tag, inner_tag)` combinations.

- **Before the fix:** fails — for `Outer::X(Inner::A(0x1234))` the VM returns `4660` while native returns garbage (`859618275080168…`).
- **After the fix:** passes; full enum/result suite green (29/29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo_native/1650)
<!-- Reviewable:end -->
